### PR TITLE
Add a flag to defer cache reads while the cache is being updated

### DIFF
--- a/src/backend/SimpleCache.h
+++ b/src/backend/SimpleCache.h
@@ -19,6 +19,9 @@ class SimpleCache
     };
     std::map<ripple::uint256, CacheEntry> map_;
     mutable std::shared_mutex mtx_;
+    // flag set in update to prevent reads from starving the update, and to
+    // prevent reads from piling up behind the update
+    std::atomic_bool deferReads_ = false;
     uint32_t latestSeq_ = 0;
     std::atomic_bool full_ = false;
     // temporary set to prevent background thread from writing already deleted


### PR DESCRIPTION
The cache is updated atomically every ledger. The size of this update depends on the size of the ledger. I think reads should just hit the database while the cache is updating.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cjcobb23/clio/97)
<!-- Reviewable:end -->
