### PR TITLE
use 64 bit counters

### DIFF
--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -253,8 +253,9 @@ BackendInterface::fetchLedgerPage(
     bool reachedEnd = false;
     while (keys.size() < limit && !reachedEnd)
     {
-        ripple::uint256 const& curCursor =
-            keys.size() ? keys.back() : cursor ? *cursor : firstKey;
+        ripple::uint256 const& curCursor = keys.size() ? keys.back()
+            : cursor                                   ? *cursor
+                                                       : firstKey;
         uint32_t seq = outOfOrder ? range->maxSequence : ledgerSequence;
         auto succ = fetchSuccessorKey(curCursor, seq, yield);
         if (!succ)

--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -16,11 +16,11 @@ private:
     {
         MethodInfo() = default;
 
-        std::atomic_uint started{0};
-        std::atomic_uint finished{0};
-        std::atomic_uint errored{0};
-        std::atomic_uint forwarded{0};
-        std::atomic_uint duration{0};
+        std::atomic_uint64_t started{0};
+        std::atomic_uint64_t finished{0};
+        std::atomic_uint64_t errored{0};
+        std::atomic_uint64_t forwarded{0};
+        std::atomic_uint64_t duration{0};
     };
 
     void


### PR DESCRIPTION
the 32 bit counters would wrap back around to zero after hitting a couple hundred seconds. 

64 bit counters give us 580,000 years worth of RPC time, which should be sufficient. 