### PR TITLE
Fix header and function call

### DIFF
--- a/src/backend/DBHelpers.h
+++ b/src/backend/DBHelpers.h
@@ -22,7 +22,7 @@ struct AccountTransactionsData
         ripple::TxMeta& meta,
         ripple::uint256 const& txHash,
         beast::Journal& j)
-        : accounts(meta.getAffectedAccounts(j))
+        : accounts(meta.getAffectedAccounts())
         , ledgerSequence(meta.getLgrSeq())
         , transactionIndex(meta.getIndex())
         , txHash(txHash)

--- a/src/rpc/handlers/AccountLines.cpp
+++ b/src/rpc/handlers/AccountLines.cpp
@@ -1,5 +1,5 @@
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/app/paths/RippleState.h>
+#include <ripple/app/paths/TrustLine.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Indexes.h>

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -1,5 +1,5 @@
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/app/paths/RippleState.h>
+#include <ripple/app/paths/TrustLine.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Indexes.h>

--- a/src/rpc/handlers/AccountOffers.cpp
+++ b/src/rpc/handlers/AccountOffers.cpp
@@ -1,5 +1,5 @@
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/app/paths/RippleState.h>
+#include <ripple/app/paths/TrustLine.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Indexes.h>

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -254,7 +254,7 @@ SubscriptionManager::pubTransaction(
     txSubscribers_.publish(pubMsg);
 
     auto journal = ripple::debugLog();
-    auto accounts = meta->getAffectedAccounts(journal);
+    auto accounts = meta->getAffectedAccounts();
 
     for (auto const& account : accounts)
         accountSubscribers_.publish(pubMsg, account);

--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -317,7 +317,7 @@ TEST(BackendTest, Basic)
                     EXPECT_TRUE(hash256.parseHex(hashHex));
                     ripple::TxMeta txMeta{hash256, lgrInfoNext.seq, metaBlob};
                     auto journal = ripple::debugLog();
-                    auto accountsSet = txMeta.getAffectedAccounts(journal);
+                    auto accountsSet = txMeta.getAffectedAccounts();
                     for (auto& a : accountsSet)
                     {
                         affectedAccounts.push_back(a);


### PR DESCRIPTION
rippled's `RippledState.h` has been changed to `TrustLine.h`

`getAffectedAccounts()` must have changed