### PR TITLE
offer dir iteration bug fix

### DIFF
--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -182,10 +182,10 @@ BackendInterface::fetchBookOffers(
                                      << offerDir.has_value() << " breaking";
             break;
         }
+        uTipIndex = offerDir->key;
         while (keys.size() < limit)
         {
             ++numPages;
-            uTipIndex = offerDir->key;
             ripple::STLedgerEntry sle{
                 ripple::SerialIter{
                     offerDir->blob.data(), offerDir->blob.size()},


### PR DESCRIPTION
Calculate the keylet using the root directory page and next index, instead of the current directory page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/141)
<!-- Reviewable:end -->
