### PR TITLE
return null when successor not in object table

### DIFF
--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -143,7 +143,6 @@ BackendInterface::fetchSuccessorObject(
         if (!obj)
             return {{*succ, {}}};
 
-
         return {{*succ, *obj}};
     }
     return {};

--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -140,7 +140,10 @@ BackendInterface::fetchSuccessorObject(
     if (succ)
     {
         auto obj = fetchLedgerObject(*succ, ledgerSequence, yield);
-        assert(obj);
+        if (!obj)
+            return {{*succ, {}}};
+
+
         return {{*succ, *obj}};
     }
     return {};

--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -178,7 +178,7 @@ BackendInterface::fetchBookOffers(
         auto mid2 = std::chrono::system_clock::now();
         numSucc++;
         succMillis += getMillis(mid2 - mid1);
-        if (!offerDir || offerDir->key > bookEnd)
+        if (!offerDir || offerDir->key >= bookEnd)
         {
             BOOST_LOG_TRIVIAL(debug) << __func__ << " - offerDir.has_value() "
                                      << offerDir.has_value() << " breaking";


### PR DESCRIPTION
This is a valid case if a book no longer has any offers. 

We check that this object is > `bookEnd`, but we never actually reach that branch because we de-reference a `std::nullopt` optional. (which segfaults).

This fixes that behavior.