### PR TITLE
cleanup subscriptions when session errors or is closed

### DIFF
--- a/src/backend/SimpleCache.cpp
+++ b/src/backend/SimpleCache.cpp
@@ -30,6 +30,7 @@ SimpleCache::update(
             {
                 if (isBackground && deletes_.count(obj.key))
                     continue;
+
                 auto& e = map_[obj.key];
                 if (seq > e.seq)
                 {
@@ -45,6 +46,7 @@ SimpleCache::update(
         }
     }
 }
+
 std::optional<LedgerObject>
 SimpleCache::getSuccessor(ripple::uint256 const& key, uint32_t seq) const
 {
@@ -58,6 +60,7 @@ SimpleCache::getSuccessor(ripple::uint256 const& key, uint32_t seq) const
         return {};
     return {{e->first, e->second.blob}};
 }
+
 std::optional<LedgerObject>
 SimpleCache::getPredecessor(ripple::uint256 const& key, uint32_t seq) const
 {

--- a/src/backend/SimpleCache.h
+++ b/src/backend/SimpleCache.h
@@ -17,6 +17,7 @@ class SimpleCache
         uint32_t seq = 0;
         Blob blob;
     };
+
     std::map<ripple::uint256, CacheEntry> map_;
     mutable std::shared_mutex mtx_;
     uint32_t latestSeq_ = 0;

--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 
 namespace RPC {
 

--- a/src/rpc/handlers/ServerInfo.cpp
+++ b/src/rpc/handlers/ServerInfo.cpp
@@ -44,6 +44,8 @@ doServerInfo(Context const& context)
 
     info[JS(counters)] = boost::json::object{};
     info[JS(counters)].as_object()[JS(rpc)] = context.counters.report();
+    info[JS(counters)].as_object()["subscriptions"] =
+        context.subscriptions->report();
 
     auto serverInfoRippled = context.balancer->forwardToRippled(
         {{"counters", "server_info"}}, context.clientIp, context.yield);

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -228,6 +228,7 @@ public:
                     std::move(req_),
                     lambda_,
                     backend_,
+                    subscriptions_,
                     balancer_,
                     etl_,
                     dosGuard_,
@@ -275,6 +276,7 @@ handle_request(
         request<Body, boost::beast::http::basic_fields<Allocator>>&& req,
     Send&& send,
     std::shared_ptr<BackendInterface const> backend,
+    std::shared_ptr<SubscriptionManager> subscriptions,
     std::shared_ptr<ETLLoadBalancer> balancer,
     std::shared_ptr<ReportingETL const> etl,
     DOSGuard& dosGuard,
@@ -349,7 +351,15 @@ handle_request(
                     RPC::make_error(RPC::Error::rpcNOT_READY))));
 
         std::optional<RPC::Context> context = RPC::make_HttpContext(
-            yc, request, backend, nullptr, balancer, etl, *range, counters, ip);
+            yc,
+            request,
+            backend,
+            subscriptions,
+            balancer,
+            etl,
+            *range,
+            counters,
+            ip);
 
         if (!context)
             return send(httpResponse(

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -99,6 +99,9 @@ class WsSession : public WsBase,
             BOOST_LOG_TRIVIAL(info)
                 << "wsFail: " << what << ": " << ec.message();
             boost::beast::get_lowest_layer(derived().ws()).socket().close(ec);
+
+            if (auto manager = subscriptions_.lock(); manager)
+                manager->cleanup(derived().shared_from_this());
         }
     }
 


### PR DESCRIPTION
Subscription manager keeps track of how to clean up sessions. It does this by capturing `unsub` function for Books and Accounts in lambdas, and calling those functions when a session goes out of scope.

This is by default threadsafe, because we're just calling Subscription::unsubBook, which posts work to an underlying strand.

This also adds counters for the subscriptions manager, and unsubscribe w/ `book`