### PR TITLE
send messages to subscribers w/ shared_ptr

### DIFF
--- a/src/subscriptions/Message.h
+++ b/src/subscriptions/Message.h
@@ -1,0 +1,40 @@
+#ifndef CLIO_SUBSCRIPTION_MESSAGE_H
+#define CLIO_SUBSCRIPTION_MESSAGE_H
+
+#include <string>
+
+// This class should only be constructed once, then it can
+// be read from in parallel by many websocket senders
+class Message
+{
+    std::string message_;
+
+public:
+    Message() = delete;
+    Message(std::string&& message) : message_(std::move(message))
+    {
+    }
+
+    Message(Message const&) = delete;
+    Message(Message&&) = delete;
+    Message&
+    operator=(Message const&) = delete;
+    Message&
+    operator=(Message&&) = delete;
+
+    ~Message() = default;
+
+    char*
+    data()
+    {
+        return message_.data();
+    }
+
+    std::size_t
+    size()
+    {
+        return message_.size();
+    }
+};
+
+#endif  // CLIO_SUBSCRIPTION_MESSAGE_H

--- a/src/subscriptions/SubscriptionManager.h
+++ b/src/subscriptions/SubscriptionManager.h
@@ -3,6 +3,7 @@
 
 #include <backend/BackendInterface.h>
 #include <memory>
+#include <subscriptions/Message.h>
 
 class WsBase;
 
@@ -29,7 +30,7 @@ public:
     unsubscribe(std::shared_ptr<WsBase> const& session);
 
     void
-    publish(std::string const& message);
+    publish(std::shared_ptr<Message>& message);
 };
 
 template <class Key>
@@ -58,7 +59,7 @@ public:
     unsubscribe(std::shared_ptr<WsBase> const& session, Key const& key);
 
     void
-    publish(std::string const& message, Key const& key);
+    publish(std::shared_ptr<Message>& message, Key const& key);
 };
 
 class SubscriptionManager


### PR DESCRIPTION
Defines a message type, which we create shared ptrs to. When publishing, WsSessions just hold a shared_ptr to the message, which will go out of scope once the last subscription sends the message