### PR TITLE
return entryNotFound instead of ledgerNotFound

### DIFF
--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -349,7 +349,7 @@ doLedgerEntry(Context const& context)
     auto end = std::chrono::system_clock::now();
 
     if (!dbResponse or dbResponse->size() == 0)
-        return Status{Error::rpcLGR_NOT_FOUND};
+        return Status{Error::rpcOBJECT_NOT_FOUND, "entryNotFound"};
 
     response["index"] = ripple::strHex(key);
     response["ledger_hash"] = ripple::strHex(lgrInfo.hash);


### PR DESCRIPTION
Return the correct error code when ledger entry is not found in `doLedgerEntry()`