### PR TITLE
Add cache for JSON deserialization

### DIFF
--- a/src/backend/SimpleCache.cpp
+++ b/src/backend/SimpleCache.cpp
@@ -45,7 +45,7 @@ SimpleCache::update(
         }
     }
     bool updateJsonCache =
-        isBackground ? jsonCaching_ == FULL : jsonCaching_ == DIFFS;
+        isBackground ? jsonCaching_ == FULL : jsonCaching_ != NONE;
     if (updateJsonCache)
     {
         for (auto const& obj : objs)

--- a/src/backend/SimpleCache.cpp
+++ b/src/backend/SimpleCache.cpp
@@ -43,6 +43,17 @@ SimpleCache::update(
             }
         }
     }
+    for(auto const& obj : objs)
+    {
+        if(obj.blob.size())
+        {
+            ripple::STLedgerEntry sle{
+                ripple::SerialIter{obj.blob.data(), obj.blob.size()}, obj.key};
+            boost::json::value json = boost::json::parse(
+                    sle.getJson(ripple::JsonOptions::none).toStyledString());
+            updateJson(obj.key,seq,std::move(json.as_object()));
+        }
+    }
 }
 std::optional<LedgerObject>
 SimpleCache::getSuccessor(ripple::uint256 const& key, uint32_t seq) const

--- a/src/backend/SimpleCache.h
+++ b/src/backend/SimpleCache.h
@@ -3,6 +3,7 @@
 
 #include <ripple/basics/base_uint.h>
 #include <ripple/basics/hardened_hash.h>
+#include <boost/json.hpp>
 #include <backend/Types.h>
 #include <map>
 #include <mutex>
@@ -16,11 +17,26 @@ class SimpleCache
     {
         uint32_t seq = 0;
         Blob blob;
+        std::atomic_bool hasJson = false;
+        std::atomic_bool updatingJson = false;
+        std::optional<boost::json::object> json;
+
+        CacheEntry&
+        operator=(CacheEntry&& other)
+        {
+            seq = other.seq;
+            blob = std::move(other.blob);
+            updatingJson = other.updatingJson.load();
+            json = std::move(other.json);
+            return *this;
+        }
     };
+    using CacheIter = std::map<ripple::uint256, CacheEntry>::iterator;
     std::map<ripple::uint256, CacheEntry> map_;
     mutable std::shared_mutex mtx_;
     uint32_t latestSeq_ = 0;
     std::atomic_bool full_ = false;
+    std::atomic_bool cacheJson_ = false;
     // temporary set to prevent background thread from writing already deleted
     // data. not used when cache is full
     std::unordered_set<ripple::uint256, ripple::hardened_hash<>> deletes_;
@@ -34,8 +50,17 @@ public:
         uint32_t seq,
         bool isBackground = false);
 
+    void
+    updateJson(
+        ripple::uint256 const& key,
+        uint32_t seq,
+        boost::json::object&& json) const;
+
     std::optional<Blob>
     get(ripple::uint256 const& key, uint32_t seq) const;
+
+    std::optional<boost::json::object>
+    getJson(ripple::uint256 const& key, uint32_t seq) const;
 
     // always returns empty optional if isFull() is false
     std::optional<LedgerObject>
@@ -47,6 +72,9 @@ public:
 
     void
     setFull();
+
+    void
+    enableJsonCaching();
 
     uint32_t
     latestLedgerSequence() const;

--- a/src/backend/SimpleCache.h
+++ b/src/backend/SimpleCache.h
@@ -36,7 +36,8 @@ class SimpleCache
     mutable std::shared_mutex mtx_;
     uint32_t latestSeq_ = 0;
     std::atomic_bool full_ = false;
-    std::atomic_bool cacheJson_ = false;
+    enum JsonCaching { NONE, DIFFS, FULL };
+    JsonCaching jsonCaching_ = NONE;
     // temporary set to prevent background thread from writing already deleted
     // data. not used when cache is full
     std::unordered_set<ripple::uint256, ripple::hardened_hash<>> deletes_;
@@ -74,7 +75,7 @@ public:
     setFull();
 
     void
-    enableJsonCaching();
+    enableJsonCaching(bool full);
 
     uint32_t
     latestLedgerSequence() const;

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -1108,9 +1108,12 @@ ReportingETL::ReportingETL(
             if (entry == "none" || entry == "no")
                 cacheLoadStyle_ = CacheLoadStyle::NOT_AT_ALL;
         }
-        if (cache.contains("num_diffs") && cache.at("num_diffs").as_int64())
+        if (cache.contains("num_diffs") && cache.at("num_diffs").is_int64())
         {
             numDiffs_ = cache.at("num_diffs").as_int64();
         }
+        if (cache.contains("json") && cache.at("json").is_bool() &&
+            cache.at("json").as_bool())
+            backend_->cache().enableJsonCaching();
     }
 }

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -1099,7 +1099,7 @@ ReportingETL::ReportingETL(
         auto cache = config.at("cache").as_object();
         if (cache.contains("load") && cache.at("load").is_string())
         {
-            auto entry = config.at("cache").as_object().at("load").as_string();
+            auto entry = cache.at("load").as_string();
             boost::algorithm::to_lower(entry);
             if (entry == "sync")
                 cacheLoadStyle_ = CacheLoadStyle::SYNC;
@@ -1112,8 +1112,20 @@ ReportingETL::ReportingETL(
         {
             numDiffs_ = cache.at("num_diffs").as_int64();
         }
-        if (cache.contains("json") && cache.at("json").is_bool() &&
-            cache.at("json").as_bool())
-            backend_->cache().enableJsonCaching();
+        if (cache.contains("json") && cache.at("json").is_string())
+        {
+            auto entry = cache.at("json").as_string();
+            boost::algorithm::to_lower(entry);
+            bool full = false;
+            bool cacheJson = true;
+            if (entry == "full" || entry == "all")
+                full = true;
+            if (entry == "diff" || entry == "diffs")
+                full = false;
+            if (entry == "none" || entry == "no")
+                cacheJson = false;
+            if (cacheJson)
+                backend_->cache().enableJsonCaching(full);
+        }
     }
 }

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -420,14 +420,6 @@ toJson(ripple::SLE const& sle, BackendInterface const& backend, uint32_t seq)
         << std::chrono::duration_cast<std::chrono::microseconds>(end2 - end)
                .count()
         << " microseconds";
-    backend.cache().updateJson(
-        sle.key(), seq, boost::json::object{value.as_object()});
-    auto end3 = std::chrono::system_clock::now();
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " json cache insert took "
-        << std::chrono::duration_cast<std::chrono::microseconds>(end3 - end2)
-               .count()
-        << " microseconds";
     return value.as_object();
 }
 

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -49,7 +49,9 @@ deserializeTxPlusMeta(
     std::uint32_t seq);
 
 std::pair<boost::json::object, boost::json::object>
-toExpandedJson(Backend::TransactionAndMetadata const& blobs);
+toExpandedJson(
+    Backend::TransactionAndMetadata const& blobs,
+    BackendInterface const& backend);
 
 bool
 insertDeliveredAmount(
@@ -58,11 +60,13 @@ insertDeliveredAmount(
     std::shared_ptr<ripple::TxMeta const> const& meta);
 
 boost::json::object
-toJson(ripple::STBase const& obj);
+toJson(
+    ripple::STBase const& obj,
+    BackendInterface const& backend,
+    uint32_t seq);
 
 boost::json::object
-toJson(ripple::SLE const& sle);
-
+toJson(ripple::SLE const& sle, BackendInterface const& backend, uint32_t seq);
 boost::json::object
 toJson(ripple::LedgerInfo const& info);
 

--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -76,7 +76,7 @@ doAccountInfo(Context const& context)
     //     response["account_data"] = ripple::strHex(*dbResponse);
     // response["db_time"] = time;
 
-    response["account_data"] = toJson(sle);
+    response["account_data"] = toJson(sle, *context.backend, lgrInfo.seq);
     response["ledger_hash"] = ripple::strHex(lgrInfo.hash);
     response["ledger_index"] = lgrInfo.seq;
 
@@ -101,7 +101,8 @@ doAccountInfo(Context const& context)
             if (!signersKey.check(sleSigners))
                 return Status{Error::rpcDB_DESERIALIZATION};
 
-            signerList.push_back(toJson(sleSigners));
+            signerList.push_back(
+                toJson(sleSigners, *context.backend, lgrInfo.seq));
         }
 
         response["account_data"].as_object()["signer_lists"] =

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -89,7 +89,7 @@ doAccountObjects(Context const& context)
     auto const addToResponse = [&](ripple::SLE const& sle) {
         if (!objectType || objectType == sle.getType())
         {
-            jsonObjects.push_back(toJson(sle));
+            jsonObjects.push_back(toJson(sle, *context.backend, lgrInfo.seq));
         }
     };
 

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -205,7 +205,7 @@ doAccountTx(Context const& context)
 
         if (!binary)
         {
-            auto [txn, meta] = toExpandedJson(txnPlusMeta);
+            auto [txn, meta] = toExpandedJson(txnPlusMeta, *context.backend);
             obj["meta"] = meta;
             obj["tx"] = txn;
             obj["tx"].as_object()["ledger_index"] = txnPlusMeta.ledgerSequence;

--- a/src/rpc/handlers/Ledger.cpp
+++ b/src/rpc/handlers/Ledger.cpp
@@ -92,11 +92,12 @@ doLedger(Context const& context)
                 std::move_iterator(txns.begin()),
                 std::move_iterator(txns.end()),
                 std::back_inserter(jsonTxs),
-                [binary](auto obj) {
+                [binary, &context](auto obj) {
                     boost::json::object entry;
                     if (!binary)
                     {
-                        auto [txn, meta] = toExpandedJson(obj);
+                        auto [txn, meta] =
+                            toExpandedJson(obj, *context.backend);
                         entry = txn;
                         entry["metaData"] = meta;
                     }
@@ -141,7 +142,7 @@ doLedger(Context const& context)
                 ripple::STLedgerEntry sle{
                     ripple::SerialIter{obj.blob.data(), obj.blob.size()},
                     obj.key};
-                entry["object"] = toJson(sle);
+                entry["object"] = toJson(sle, *context.backend, lgrInfo.seq);
             }
             else
                 entry["object"] = "";

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -180,7 +180,7 @@ doLedgerData(Context const& context)
             objects.push_back(std::move(entry));
         }
         else
-            objects.push_back(toJson(sle));
+            objects.push_back(toJson(sle, *context.backend, lgrInfo.seq));
     }
     response["state"] = std::move(objects);
     auto end2 = std::chrono::system_clock::now();

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -363,7 +363,7 @@ doLedgerEntry(Context const& context)
     {
         ripple::STLedgerEntry sle{
             ripple::SerialIter{dbResponse->data(), dbResponse->size()}, key};
-        response["node"] = toJson(sle);
+        response["node"] = toJson(sle, *context.backend, lgrInfo.seq);
     }
 
     return response;

--- a/src/rpc/handlers/TransactionEntry.cpp
+++ b/src/rpc/handlers/TransactionEntry.cpp
@@ -32,7 +32,7 @@ doTransactionEntry(Context const& context)
             "transactionNotFound",
             "Transaction not found."};
 
-    auto [txn, meta] = toExpandedJson(*dbResponse);
+    auto [txn, meta] = toExpandedJson(*dbResponse, *context.backend);
     response["tx_json"] = std::move(txn);
     response["metadata"] = std::move(meta);
     response["ledger_index"] = lgrInfo.seq;

--- a/src/rpc/handlers/Tx.cpp
+++ b/src/rpc/handlers/Tx.cpp
@@ -43,7 +43,7 @@ doTx(Context const& context)
 
     if (!binary)
     {
-        auto [txn, meta] = toExpandedJson(*dbResponse);
+        auto [txn, meta] = toExpandedJson(*dbResponse, *context.backend);
         response = txn;
         response["meta"] = meta;
     }

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -211,7 +211,7 @@ SubscriptionManager::pubTransaction(
 {
     auto [tx, meta] = RPC::deserializeTxPlusMeta(blobs, lgrInfo.seq);
     boost::json::object pubObj;
-    pubObj["transaction"] = RPC::toJson(*tx);
+    pubObj["transaction"] = RPC::toJson(*tx, *backend_, lgrInfo.seq);
     pubObj["meta"] = RPC::toJson(*meta);
     RPC::insertDeliveredAmount(pubObj["meta"].as_object(), tx, meta);
     pubObj["type"] = "transaction";

--- a/test.py
+++ b/test.py
@@ -498,7 +498,7 @@ async def ledger_data_full(ip, port, ledger, binary, limit, typ=None, count=-1, 
             while True:
                 res = {}
                 if marker is None:
-                    await ws.send(json.dumps({"command":"ledger_data","ledger_index":int(ledger),"binary":binary, "limit":int(limit)}))
+                    await ws.send(json.dumps({"command":"ledger_data","ledger_index":int(ledger),"binary":binary, "limit":int(limit),"out_of_order":True}))
                     res = json.loads(await ws.recv())
                     
                 else:


### PR DESCRIPTION
* SimpleCache entries now have an optional JSON representation of the
object. By default, this object is an empty optional, and is written to
when that object is deserialized to JSON by a handler. The JSON objects
are only removed when the cache entry is updated as part of handling
newly validated ledgers. The cache in the worst case can grow to the
size of the full ledger, which is about 30GB at the time of writing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/155)
<!-- Reviewable:end -->
