### PR TITLE
handle string ledger_index values in doAccountTx

### DIFF
--- a/src/clio/rpc/RPCHelpers.cpp
+++ b/src/clio/rpc/RPCHelpers.cpp
@@ -1,6 +1,6 @@
 #include <boost/algorithm/string.hpp>
-#include <backend/BackendInterface.h>
-#include <rpc/RPCHelpers.h>
+#include <clio/backend/BackendInterface.h>
+#include <clio/rpc/RPCHelpers.h>
 namespace RPC {
 
 std::optional<bool>
@@ -557,12 +557,7 @@ ledgerInfoFromRequest(Context const& ctx)
         if (!ledgerHash.parseHex(hashValue.as_string().c_str()))
             return Status{Error::rpcINVALID_PARAMS, "ledgerHashMalformed"};
 
-        auto lgrInfo = ctx.backend->fetchLedgerByHash(ledgerHash, ctx.yield);
-
-        if (!lgrInfo)
-            return Status{Error::rpcLGR_NOT_FOUND, "ledgerNotFound"};
-
-        return *lgrInfo;
+        return ctx.app.backend().fetchLedgerByHash(ledgerHash, ctx.yield);
     }
 
     auto indexValue = ctx.params.contains("ledger_index")
@@ -592,7 +587,7 @@ ledgerInfoFromRequest(Context const& ctx)
         return Status{Error::rpcLGR_NOT_FOUND, "ledgerIndexMalformed"};
 
     auto lgrInfo =
-        ctx.backend->fetchLedgerBySequence(*ledgerSequence, ctx.yield);
+        ctx.app.backend().fetchLedgerBySequence(*ledgerSequence, ctx.yield);
 
     if (!lgrInfo)
         return Status{Error::rpcLGR_NOT_FOUND, "ledgerNotFound"};
@@ -823,7 +818,7 @@ read(
     ripple::LedgerInfo const& lgrInfo,
     Context const& context)
 {
-    if (auto const blob = context.backend->fetchLedgerObject(
+    if (auto const blob = context.app.backend().fetchLedgerObject(
             keylet.key, lgrInfo.seq, context.yield);
         blob)
     {

--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 
 namespace RPC {
 


### PR DESCRIPTION
Previously, we were just directly parsing ledger_index and ledger_hash in doAccountTx. This meant that ledger_index values like `closed` and `validated` were treated as incorrect. 

Instead, we call `ledgerInfoFromRequest()` which should treat these values correctly, and reuses the code that handles `ledger_index` and `ledger_hash` values.

I'll need to grab an AWS box to test this, since I'm on my Macbook.