### PR TITLE
report transactions as validated in account_tx

### DIFF
--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 
 namespace RPC {
 

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -192,6 +192,7 @@ doAccountTx(Context const& context)
             obj[JS(ledger_index)] = txnPlusMeta.ledgerSequence;
             obj[JS(date)] = txnPlusMeta.date;
         }
+        obj[JS(validated)] = true;
 
         txns.push_back(obj);
         if (!minReturnedIndex || txnPlusMeta.ledgerSequence < *minReturnedIndex)


### PR DESCRIPTION
All transactions Clio extracts are validated, so when handling account_tx we can report them all as `validated: true`.

Fixes #164 