### PR TITLE
return no offers when an owner directory is not found

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -764,7 +764,7 @@ traverseOwnedNodes(
                 backend.fetchLedgerObject(currentIndex.key, sequence, yield);
 
             if (!ownerDir)
-                return Status(ripple::rpcACT_NOT_FOUND);
+                break;
 
             ripple::SerialIter it{ownerDir->data(), ownerDir->size()};
             ripple::SLE sle{it, currentIndex.key};

--- a/src/rpc/handlers/AccountChannels.cpp
+++ b/src/rpc/handlers/AccountChannels.cpp
@@ -58,6 +58,12 @@ doAccountChannels(Context const& context)
     if (auto const status = getAccount(request, accountID); status)
         return status;
 
+    auto rawAcct = context.backend->fetchLedgerObject(
+        ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield);
+
+    if (!rawAcct)
+        return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
+
     ripple::AccountID destAccount;
     if (auto const status =
             getAccount(request, destAccount, JS(destination_account));

--- a/src/rpc/handlers/AccountCurrencies.cpp
+++ b/src/rpc/handlers/AccountCurrencies.cpp
@@ -28,6 +28,12 @@ doAccountCurrencies(Context const& context)
     if (auto const status = getAccount(request, accountID); status)
         return status;
 
+    auto rawAcct = context.backend->fetchLedgerObject(
+        ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield);
+
+    if (!rawAcct)
+        return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
+
     std::set<std::string> send, receive;
     auto const addToResponse = [&](ripple::SLE const& sle) {
         if (sle.getType() == ripple::ltRIPPLE_STATE)

--- a/src/rpc/handlers/AccountLines.cpp
+++ b/src/rpc/handlers/AccountLines.cpp
@@ -103,6 +103,12 @@ doAccountLines(Context const& context)
     if (auto const status = getAccount(request, accountID); status)
         return status;
 
+    auto rawAcct = context.backend->fetchLedgerObject(
+        ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield);
+
+    if (!rawAcct)
+        return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
+
     ripple::AccountID peerAccount;
     if (auto const status = getAccount(request, peerAccount, JS(peer)); status)
         return status;

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -47,9 +47,10 @@ doAccountNFTs(Context const& context)
     if (!accountID)
         return Status{Error::rpcINVALID_PARAMS, "malformedAccount"};
 
-    // TODO: just check for existence without pulling
-    if (!context.backend->fetchLedgerObject(
-            ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield))
+    auto rawAcct = context.backend->fetchLedgerObject(
+        ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield);
+
+    if (!rawAcct)
         return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
 
     std::uint32_t limit = 200;

--- a/src/rpc/handlers/AccountOffers.cpp
+++ b/src/rpc/handlers/AccountOffers.cpp
@@ -80,6 +80,12 @@ doAccountOffers(Context const& context)
     if (auto const status = getAccount(request, accountID); status)
         return status;
 
+    auto rawAcct = context.backend->fetchLedgerObject(
+        ripple::keylet::account(accountID).key, lgrInfo.seq, context.yield);
+
+    if (!rawAcct)
+        return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
+
     std::uint32_t limit = 200;
     if (auto const status = getLimit(request, limit); status)
         return status;


### PR DESCRIPTION
We're returning `rpcACT_NOT_FOUND` when we don't find the owner directory. This is incorrect. An account can exist without a directory. We should just return a list w/ no offers if this is the case. 

This change adds a check to test for an account not existing, and just breaks when the owner directory is not found.