### PR TITLE
allow user to specify no peer in doAccountLines

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -222,6 +222,32 @@ getAccount(
 }
 
 Status
+getOptionalAccount(
+    boost::json::object const& request,
+    std::optional<ripple::AccountID>& account,
+    boost::string_view const& field)
+{
+    if (!request.contains(field))
+    {
+        account = {};
+        return {};
+    }
+
+    if (!request.at(field).is_string())
+        return Status{
+            Error::rpcINVALID_PARAMS, field.to_string() + "NotString"};
+
+    if (auto a = accountFromStringStrict(request.at(field).as_string().c_str());
+        a)
+    {
+        account = a.value();
+        return {};
+    }
+
+    return Status{Error::rpcINVALID_PARAMS, field.to_string() + "Malformed"};
+}
+
+Status
 getAccount(boost::json::object const& request, ripple::AccountID& accountId)
 {
     return getAccount(request, accountId, JS(account), true);

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -239,6 +239,12 @@ getAccount(
     boost::string_view const& field);
 
 Status
+getOptionalAccount(
+    boost::json::object const& request,
+    std::optional<ripple::AccountID>& account,
+    boost::string_view const& field);
+
+Status
 getTaker(boost::json::object const& request, ripple::AccountID& takerID);
 
 Status

--- a/src/rpc/handlers/AccountLines.cpp
+++ b/src/rpc/handlers/AccountLines.cpp
@@ -39,7 +39,7 @@ addLine(
     auto lineQualityIn = viewLowest ? lowQualityIn : highQualityIn;
     auto lineQualityOut = viewLowest ? lowQualityOut : highQualityOut;
 
-    if (peerAccount and peerAccount != lineAccountIDPeer)
+    if (peerAccount && peerAccount != lineAccountIDPeer)
         return;
 
     if (!viewLowest)
@@ -109,8 +109,9 @@ doAccountLines(Context const& context)
     if (!rawAcct)
         return Status{Error::rpcACT_NOT_FOUND, "accountNotFound"};
 
-    ripple::AccountID peerAccount;
-    if (auto const status = getAccount(request, peerAccount, JS(peer)); status)
+    std::optional<ripple::AccountID> peerAccount;
+    if (auto const status = getOptionalAccount(request, peerAccount, JS(peer));
+        status)
         return status;
 
     std::uint32_t limit;


### PR DESCRIPTION
the account_lines handler was misbehaving when no peer was specified, due to reuse of the `getAccount` helper. 

When `peer` was empty, `traverseOwnedNodes` would attempt to look for lines w/ only the default constructed account ID, filtering out every peer account.

I added a `getOptionalAccount` helper, which assigns `account` to a `std::nullopt` if `!object.contains(peer)`, and otherwise errors if `peer` is not string.