### PR TITLE
Use ledger close times for stale data warning

### DIFF
--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -147,11 +147,9 @@ ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
         backend_->cache().update(diff, lgrInfo.seq);
         backend_->updateRange(lgrInfo.seq);
     }
-    auto now = std::chrono::duration_cast<std::chrono::seconds>(
-                   std::chrono::system_clock::now().time_since_epoch())
-                   .count();
-    auto closeTime = lgrInfo.closeTime.time_since_epoch().count();
-    auto age = now - (rippleEpochStart + closeTime);
+
+    setLastClose(lgrInfo.closeTime);
+    auto age = lastCloseAgeSeconds();
     // if the ledger closed over 10 minutes ago, assume we are still
     // catching up and don't publish
     if (age < 600)

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -422,8 +422,8 @@ handle_request(
             "This is a clio server. clio only serves validated data. If you "
             "want to talk to rippled, include 'ledger_index':'current' in your "
             "request");
-        auto lastPublishAge = context->etl->lastPublishAgeSeconds();
-        if (lastPublishAge >= 60)
+        auto lastCloseAge = context->etl->lastCloseAgeSeconds();
+        if (lastCloseAge >= 60)
             warnings.emplace_back("This server may be out of date");
         result["warnings"] = warnings;
         responseStr = boost::json::serialize(response);

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -351,10 +351,9 @@ public:
             "want to talk to rippled, include 'ledger_index':'current' in your "
             "request");
 
-        auto lastPublishAge = etl_->lastPublishAgeSeconds();
-        if (lastPublishAge >= 60)
+        auto lastCloseAge = etl_->lastCloseAgeSeconds();
+        if (lastCloseAge >= 60)
             warnings.emplace_back("This server may be out of date");
-
         response["warnings"] = warnings;
         std::string responseStr = boost::json::serialize(response);
         if (!dosGuard_.add(*ip, responseStr.size()))


### PR DESCRIPTION
Small change to correct the stale data warning feature. Now, request handlers look at close time of last published ledger instead of time the last ledger was published.

I used the same testing strategy as (#175)