### PR TITLE
ensure lgrInfo is in context.range

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -569,7 +569,7 @@ ledgerInfoFromRequest(Context const& ctx)
 
         auto lgrInfo = ctx.backend->fetchLedgerByHash(ledgerHash, ctx.yield);
 
-        if (!lgrInfo)
+        if (!lgrInfo || lgrInfo->seq > ctx.range.maxSequence)
             return Status{Error::rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
         return *lgrInfo;
@@ -604,7 +604,7 @@ ledgerInfoFromRequest(Context const& ctx)
     auto lgrInfo =
         ctx.backend->fetchLedgerBySequence(*ledgerSequence, ctx.yield);
 
-    if (!lgrInfo)
+    if (!lgrInfo || lgrInfo->seq > ctx.range.maxSequence)
         return Status{Error::rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
     return *lgrInfo;


### PR DESCRIPTION
This fixes a data race where we write the ledger `n`, but the `range.maxSequence` is still `n-1`. In this case we should treat this the same as not finding the ledger to prevent a data race.