### PR TITLE
Added a cache for TransactionAndMetadata objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(clio PRIVATE
   src/backend/Pg.cpp
   src/backend/PostgresBackend.cpp
   src/backend/SimpleCache.cpp
+  src/backend/TxCache.cpp
   ## ETL
   src/etl/ETLSource.cpp
   src/etl/NFTHelpers.cpp

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -416,12 +416,12 @@ CassandraBackend::hardFetchLedgerRange(boost::asio::yield_context& yield) const
 }
 
 std::vector<TransactionAndMetadata>
-CassandraBackend::fetchAllTransactionsInLedger(
+CassandraBackend::doFetchAllTransactionsInLedger(
     std::uint32_t const ledgerSequence,
     boost::asio::yield_context& yield) const
 {
-    auto hashes = fetchAllTransactionHashesInLedger(ledgerSequence, yield);
-    return fetchTransactions(hashes, yield);
+    auto hashes = doFetchAllTransactionHashesInLedger(ledgerSequence, yield);
+    return doFetchTransactions(hashes, yield);
 }
 
 template <class Result>
@@ -480,7 +480,7 @@ processAsyncRead(CassFuture* fut, void* cbData)
 }
 
 std::vector<TransactionAndMetadata>
-CassandraBackend::fetchTransactions(
+CassandraBackend::doFetchTransactions(
     std::vector<ripple::uint256> const& hashes,
     boost::asio::yield_context& yield) const
 {
@@ -535,7 +535,7 @@ CassandraBackend::fetchTransactions(
 }
 
 std::vector<ripple::uint256>
-CassandraBackend::fetchAllTransactionHashesInLedger(
+CassandraBackend::doFetchAllTransactionHashesInLedger(
     std::uint32_t const ledgerSequence,
     boost::asio::yield_context& yield) const
 {

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -876,12 +876,12 @@ public:
     hardFetchLedgerRange(boost::asio::yield_context& yield) const override;
 
     std::vector<TransactionAndMetadata>
-    fetchAllTransactionsInLedger(
+    doFetchAllTransactionsInLedger(
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
 
     std::vector<ripple::uint256>
-    fetchAllTransactionHashesInLedger(
+    doFetchAllTransactionHashesInLedger(
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
 
@@ -929,7 +929,7 @@ public:
     }
 
     std::optional<TransactionAndMetadata>
-    fetchTransaction(
+    doFetchTransaction(
         ripple::uint256 const& hash,
         boost::asio::yield_context& yield) const override
     {
@@ -957,7 +957,7 @@ public:
         boost::asio::yield_context& yield) const override;
 
     std::vector<TransactionAndMetadata>
-    fetchTransactions(
+    doFetchTransactions(
         std::vector<ripple::uint256> const& hashes,
         boost::asio::yield_context& yield) const override;
 

--- a/src/backend/PostgresBackend.cpp
+++ b/src/backend/PostgresBackend.cpp
@@ -354,7 +354,7 @@ PostgresBackend::doFetchLedgerObject(
 
 // returns a transaction, metadata pair
 std::optional<TransactionAndMetadata>
-PostgresBackend::fetchTransaction(
+PostgresBackend::doFetchTransaction(
     ripple::uint256 const& hash,
     boost::asio::yield_context& yield) const
 {
@@ -378,7 +378,7 @@ PostgresBackend::fetchTransaction(
     return {};
 }
 std::vector<TransactionAndMetadata>
-PostgresBackend::fetchAllTransactionsInLedger(
+PostgresBackend::doFetchAllTransactionsInLedger(
     std::uint32_t const ledgerSequence,
     boost::asio::yield_context& yield) const
 {
@@ -407,7 +407,7 @@ PostgresBackend::fetchAllTransactionsInLedger(
     return {};
 }
 std::vector<ripple::uint256>
-PostgresBackend::fetchAllTransactionHashesInLedger(
+PostgresBackend::doFetchAllTransactionHashesInLedger(
     std::uint32_t const ledgerSequence,
     boost::asio::yield_context& yield) const
 {
@@ -468,7 +468,7 @@ PostgresBackend::doFetchSuccessorKey(
 }
 
 std::vector<TransactionAndMetadata>
-PostgresBackend::fetchTransactions(
+PostgresBackend::doFetchTransactions(
     std::vector<ripple::uint256> const& hashes,
     boost::asio::yield_context& yield) const
 {

--- a/src/backend/PostgresBackend.h
+++ b/src/backend/PostgresBackend.h
@@ -48,17 +48,17 @@ public:
 
     // returns a transaction, metadata pair
     std::optional<TransactionAndMetadata>
-    fetchTransaction(
+    doFetchTransaction(
         ripple::uint256 const& hash,
         boost::asio::yield_context& yield) const override;
 
     std::vector<TransactionAndMetadata>
-    fetchAllTransactionsInLedger(
+    doFetchAllTransactionsInLedger(
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
 
     std::vector<ripple::uint256>
-    fetchAllTransactionHashesInLedger(
+    doFetchAllTransactionHashesInLedger(
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
 
@@ -91,7 +91,7 @@ public:
         boost::asio::yield_context& yield) const override;
 
     std::vector<TransactionAndMetadata>
-    fetchTransactions(
+    doFetchTransactions(
         std::vector<ripple::uint256> const& hashes,
         boost::asio::yield_context& yield) const override;
 

--- a/src/backend/TxCache.cpp
+++ b/src/backend/TxCache.cpp
@@ -1,0 +1,105 @@
+#include <backend/TxCache.h>
+namespace Backend {
+
+uint32_t
+TxCache::latestLedgerSequence() const
+{
+    std::shared_lock lck{mtx_};
+    return latestSeq_;
+}
+
+// adds an entire ledger's worth of transactions to the cache. Evicts oldest
+// ledger.
+void
+TxCache::update(
+    std::vector<ripple::uint256> const& hashes,
+    std::vector<TransactionAndMetadata> const& transactions,
+    uint32_t seq)
+{
+    std::unique_lock lck{mtx_};
+    cache_[tail_].clear();
+
+    assert(seq == latestSeq_ + 1 || latestSeq_ == 0);
+    latestSeq_ = seq;
+    for (std::size_t i = 0; i < hashes.size(); i++)
+    {
+        cache_[tail_][hashes[i]] = transactions[i];
+    }
+    tail_ = (tail_ + 1) % NUM_LEDGERS_CACHED;
+}
+
+std::optional<TransactionAndMetadata>
+TxCache::get(ripple::uint256 const& key) const
+{
+    std::shared_lock lck{mtx_};
+    txReqCounter_++;
+
+    for (auto& map : cache_)
+    {
+        auto e = map.find(key);
+        if (e != map.end())
+        {
+            txHitCounter_++;
+            return {e->second};
+        }
+    }
+    return {};
+}
+
+float
+TxCache::getHitRate() const
+{
+    if (!txReqCounter_)
+        return 0;
+    return ((float)txHitCounter_ / txReqCounter_);
+}
+
+std::optional<std::vector<TransactionAndMetadata>>
+TxCache::getLedgerTransactions(std::uint32_t const ledgerSequence) const
+{
+    std::shared_lock lck{mtx_};
+    txReqCounter_++;
+    auto diff = latestSeq_ - ledgerSequence;
+    if (diff < NUM_LEDGERS_CACHED)
+    {
+        auto head = (tail_ - 1) % NUM_LEDGERS_CACHED;
+        auto ledgerCache = cache_[(head - diff) % NUM_LEDGERS_CACHED];
+        std::vector<TransactionAndMetadata> result;
+        for (auto const& tx : ledgerCache)
+        {
+            result.push_back(tx.second);
+        }
+        if (result.size() > 0)
+        {
+            txHitCounter_++;
+            return {result};
+        }
+    }
+    return {};
+}
+
+std::optional<std::vector<ripple::uint256>>
+TxCache::getLedgerTransactionHashes(std::uint32_t const ledgerSequence) const
+{
+    std::shared_lock lck{mtx_};
+    txReqCounter_++;
+    auto diff = latestSeq_ - ledgerSequence;
+    if (diff < NUM_LEDGERS_CACHED)
+    {
+        auto head = (tail_ - 1) % NUM_LEDGERS_CACHED;
+        auto ledgerCache = cache_[(head - diff) % NUM_LEDGERS_CACHED];
+        std::vector<ripple::uint256> result;
+        for (auto const& tx : ledgerCache)
+        {
+            result.push_back(tx.first);
+        }
+        if (result.size() > 0)
+        {
+            txHitCounter_++;
+            return {result};
+        }
+    }
+    return {};
+}
+
+}  // namespace Backend

--- a/src/backend/TxCache.h
+++ b/src/backend/TxCache.h
@@ -1,0 +1,56 @@
+#ifndef CLIO_TXCACHE_H_INCLUDED
+#define CLIO_TXCACHE_H_INCLUDED
+
+#include <ripple/basics/base_uint.h>
+#include <ripple/basics/hardened_hash.h>
+#include <backend/Types.h>
+#include <map>
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+#define NUM_LEDGERS_CACHED 10
+
+namespace Backend {
+class TxCache
+{
+    // basically a ring buffer
+    // array of maps of transaction hashes -> TransactionAndMetadata objects
+    // replace the oldest ledger in cache when inserting a new ledger
+    std::array<
+        std::map<ripple::uint256, TransactionAndMetadata>,
+        NUM_LEDGERS_CACHED>
+        cache_;
+    mutable std::shared_mutex mtx_;
+    uint32_t latestSeq_ = 0;
+    std::atomic_int tail_;
+    mutable std::atomic_int txReqCounter_;
+    mutable std::atomic_int txHitCounter_;
+
+public:
+    // Update the cache with new ledger objects
+    void
+    update(
+        std::vector<ripple::uint256> const& hashes,
+        std::vector<TransactionAndMetadata> const& transactions,
+        uint32_t seq);
+
+    std::optional<TransactionAndMetadata>
+    get(ripple::uint256 const& key) const;
+
+    std::optional<std::vector<TransactionAndMetadata>>
+    getLedgerTransactions(std::uint32_t const ledgerSequence) const;
+
+    std::optional<std::vector<ripple::uint256>>
+    getLedgerTransactionHashes(std::uint32_t const ledgerSequence) const;
+
+    uint32_t
+    latestLedgerSequence() const;
+
+    float
+    getHitRate() const;
+};
+
+}  // namespace Backend
+#endif

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -191,11 +191,10 @@ ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
                 return backend_->fetchFees(lgrInfo.seq, yield);
             });
 
-        hashes =
-            Backend::synchronousAndRetryOnTimeout([&](auto yield) {
-                return backend_->doFetchAllTransactionHashesInLedger(
-                    lgrInfo.seq, yield);
-            });
+        hashes = Backend::synchronousAndRetryOnTimeout([&](auto yield) {
+            return backend_->doFetchAllTransactionHashesInLedger(
+                lgrInfo.seq, yield);
+        });
 
         transactions = Backend::synchronousAndRetryOnTimeout([&](auto yield) {
             return backend_->doFetchTransactions(hashes, yield);

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -187,13 +187,13 @@ ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
 
         std::vector<ripple::uint256> hashes =
             Backend::synchronousAndRetryOnTimeout([&](auto yield) {
-                return backend_->fetchAllTransactionHashesInLedger(
+                return backend_->doFetchAllTransactionHashesInLedger(
                     lgrInfo.seq, yield);
             });
 
         std::vector<Backend::TransactionAndMetadata> transactions =
             Backend::synchronousAndRetryOnTimeout([&](auto yield) {
-                return backend_->fetchTransactions(hashes, yield);
+                return backend_->doFetchTransactions(hashes, yield);
             });
 
         // hashes map to transactions

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -71,13 +71,17 @@ ReportingETL::insertTransactions(
             ledger.closeTime.time_since_epoch().count(),
             std::move(*raw),
             std::move(*txn.mutable_metadata_blob()));
-        
+
         Backend::Blob txBlob;
         std::copy(raw->begin(), raw->end(), std::back_inserter(txBlob));
         Backend::Blob mdBlob;
         auto mdStr = txn.mutable_metadata_blob();
         std::copy(mdStr->begin(), mdStr->end(), std::back_inserter(mdBlob));
-        transactions.push_back({txBlob, mdBlob, ledger.seq, ledger.closeTime.time_since_epoch().count()});
+        transactions.push_back(
+            {txBlob,
+             mdBlob,
+             ledger.seq,
+             ledger.closeTime.time_since_epoch().count()});
     }
     backend_->txCache().update(hashes, transactions, ledger.seq);
 
@@ -193,10 +197,9 @@ ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
                     lgrInfo.seq, yield);
             });
 
-        transactions =
-            Backend::synchronousAndRetryOnTimeout([&](auto yield) {
-                return backend_->doFetchTransactions(hashes, yield);
-            });
+        transactions = Backend::synchronousAndRetryOnTimeout([&](auto yield) {
+            return backend_->doFetchTransactions(hashes, yield);
+        });
 
         auto ledgerRange = backend_->fetchLedgerRange();
         assert(ledgerRange);

--- a/src/rpc/handlers/ServerInfo.cpp
+++ b/src/rpc/handlers/ServerInfo.cpp
@@ -85,6 +85,7 @@ doServerInfo(Context const& context)
     cache["is_full"] = context.backend->cache().isFull();
     cache["latest_ledger_seq"] =
         context.backend->cache().latestLedgerSequence();
+    cache["tx_cache_hit_rate"] = context.backend->txCache().getHitRate();
 
     response["etl"] = context.etl->getInfo();
 


### PR DESCRIPTION
This PR adds a cache for TransactionAndMetadata objects. The backend of clio maintains a cache of the `NUM_CACHED_LEDGERS` most recently published ledgers' transactions. I am posting this now mainly for visibility. 