### PR TITLE
Database read throttle

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -10,7 +10,7 @@
             "replication_factor":1,
             "table_prefix":"",
             "max_write_requests_outstanding":25000,
-            "max_read_requests_outstanding":1000,
+            "max_read_requests_outstanding":30000,
             "threads":8
         }
     },

--- a/example-config.json
+++ b/example-config.json
@@ -9,7 +9,8 @@
             "keyspace":"clio",
             "replication_factor":1,
             "table_prefix":"",
-            "max_requests_outstanding":25000,
+            "max_write_requests_outstanding":25000,
+            "max_read_requests_outstanding":1000,
             "threads":8
         }
     },

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -13,10 +13,6 @@ namespace Backend {
 class DatabaseTimeout : public std::exception
 {
 public:
-    DatabaseTimeout()
-    {
-    }
-
     const char*
     what() const throw() override
     {

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -57,13 +57,13 @@ retryOnTimeout(F func, size_t waitMs = 500)
         {
             BOOST_LOG_TRIVIAL(error)
                 << __func__
-                << " function timed out. Sleeping and retrying ... ";
+                << " Database request timed out. Sleeping and retrying ... ";
             std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
         }
         catch (DatabaseRequestThrottled& t)
         {
             BOOST_LOG_TRIVIAL(error)
-                << __func__ << " Request throttled. Retrying";
+                << __func__ << " Database request throttled. Retrying";
         }
     }
 }

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -7,6 +7,7 @@
 #include <backend/Types.h>
 #include <thread>
 #include <type_traits>
+
 namespace Backend {
 
 class DatabaseTimeout : public std::exception
@@ -20,20 +21,6 @@ public:
     what() const throw() override
     {
         return "Database read timed out. Please retry the request";
-    }
-};
-
-class DatabaseRequestThrottled : public std::exception
-{
-public:
-    DatabaseRequestThrottled()
-    {
-    }
-
-    const char*
-    what() const throw() override
-    {
-        return "Max outstanding database requests exceeded";
     }
 };
 
@@ -53,11 +40,6 @@ retryOnTimeout(F func, size_t waitMs = 500)
                 << __func__
                 << " Database request timed out. Sleeping and retrying ... ";
             std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
-        }
-        catch (DatabaseRequestThrottled& t)
-        {
-            BOOST_LOG_TRIVIAL(error)
-                << __func__ << " Database request throttled. Retrying";
         }
     }
 }
@@ -366,6 +348,9 @@ public:
     // Close the database, releasing any resources
     virtual void
     close(){};
+
+    virtual bool
+    isTooBusy() const = 0;
 
     // *** private helper methods
 private:

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -11,26 +11,20 @@ namespace Backend {
 
 class DatabaseTimeout : public std::exception
 {
-    std::string msg;
-
 public:
-    DatabaseTimeout(std::string const& msg) : msg(msg)
+    DatabaseTimeout()
     {
     }
-    DatabaseTimeout() : msg("Database read timed out. Please retry the request")
-    {
-    }
+
     const char*
     what() const throw() override
     {
-        return msg.c_str();
+        return "Database read timed out. Please retry the request";
     }
 };
 
 class DatabaseRequestThrottled : public std::exception
 {
-    std::string msg;
-
 public:
     DatabaseRequestThrottled()
     {

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -486,9 +486,6 @@ CassandraBackend::fetchTransactions(
 {
     if (hashes.size() == 0)
         return {};
-    if (numReadRequestsOutstanding_ + hashes.size() >=
-        maxReadRequestsOutstanding)
-        throw DatabaseRequestThrottled();
     numReadRequestsOutstanding_ += hashes.size();
 
     handler_type handler(std::forward<decltype(yield)>(yield));
@@ -816,8 +813,6 @@ CassandraBackend::doFetchLedgerObjects(
 {
     if (keys.size() == 0)
         return {};
-    if (numReadRequestsOutstanding_ + keys.size() >= maxReadRequestsOutstanding)
-        throw DatabaseRequestThrottled();
 
     numReadRequestsOutstanding_ += keys.size();
 
@@ -973,6 +968,12 @@ CassandraBackend::doOnlineDelete(
     executeSyncWrite(statement);
     // update ledger_range
     return true;
+}
+
+bool
+CassandraBackend::isTooBusy() const
+{
+    return numReadRequestsOutstanding_ >= maxReadRequestsOutstanding;
 }
 
 void

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -652,7 +652,7 @@ private:
 
     // maximum number of concurrent in flight read requests. isTooBusy() will
     // return true if the number of in flight read requests exceeds this limit
-    std::uint32_t maxReadRequestsOutstanding = 10000;
+    std::uint32_t maxReadRequestsOutstanding = 100000;
     mutable std::atomic_uint32_t numReadRequestsOutstanding_ = 0;
 
     // mutex and condition_variable to limit the number of concurrent in flight

--- a/src/backend/PostgresBackend.h
+++ b/src/backend/PostgresBackend.h
@@ -157,6 +157,12 @@ public:
     doFinishWrites() override;
 
     bool
+    isTooBusy() const override
+    {
+        return false;
+    }
+
+    bool
     doOnlineDelete(
         std::uint32_t const numLedgersToKeep,
         boost::asio::yield_context& yield) const override;

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -344,6 +344,8 @@ buildResponse(Context const& ctx)
 
     if (ctx.backend->isTooBusy())
     {
+        BOOST_LOG_TRIVIAL(error)
+            << __func__ << " Database is too busy. Rejecting request";
         return Status{Error::rpcTOO_BUSY};
     }
 

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -342,6 +342,11 @@ buildResponse(Context const& ctx)
     if (ctx.method == "ping")
         return boost::json::object{};
 
+    if (ctx.backend->isTooBusy())
+    {
+        return Status{Error::rpcTOO_BUSY};
+    }
+
     auto method = handlerTable.getHandler(ctx.method);
 
     if (!method)
@@ -367,11 +372,6 @@ buildResponse(Context const& ctx)
     catch (Backend::DatabaseTimeout const& t)
     {
         BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
-        return Status{Error::rpcTOO_BUSY};
-    }
-    catch (Backend::DatabaseRequestThrottled const& t)
-    {
-        BOOST_LOG_TRIVIAL(error) << __func__ << " Database request throttled";
         return Status{Error::rpcTOO_BUSY};
     }
     catch (std::exception const& err)

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -364,6 +364,16 @@ buildResponse(Context const& ctx)
     {
         return Status{Error::rpcACT_NOT_FOUND, err.what()};
     }
+    catch (Backend::DatabaseTimeout const& t)
+    {
+        BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
+        return Status{Error::rpcTOO_BUSY};
+    }
+    catch (Backend::DatabaseRequestThrottled const& t)
+    {
+        BOOST_LOG_TRIVIAL(error) << __func__ << " Database request throttled";
+        return Status{Error::rpcTOO_BUSY};
+    }
     catch (std::exception const& err)
     {
         BOOST_LOG_TRIVIAL(error)

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -434,6 +434,22 @@ handle_request(
         return send(
             httpResponse(http::status::ok, "application/json", responseStr));
     }
+    catch (Backend::DatabaseTimeout const& t)
+    {
+        BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
+        return send(httpResponse(
+            http::status::ok,
+            "application/json",
+            boost::json::serialize(RPC::make_error(RPC::Error::rpcTOO_BUSY))));
+    }
+    catch (Backend::DatabaseRequestThrottled const& t)
+    {
+        BOOST_LOG_TRIVIAL(error) << __func__ << " Database request throttled";
+        return send(httpResponse(
+            http::status::ok,
+            "application/json",
+            boost::json::serialize(RPC::make_error(RPC::Error::rpcTOO_BUSY))));
+    }
     catch (std::exception const& e)
     {
         BOOST_LOG_TRIVIAL(error)

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -434,22 +434,6 @@ handle_request(
         return send(
             httpResponse(http::status::ok, "application/json", responseStr));
     }
-    catch (Backend::DatabaseTimeout const& t)
-    {
-        BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
-        return send(httpResponse(
-            http::status::ok,
-            "application/json",
-            boost::json::serialize(RPC::make_error(RPC::Error::rpcTOO_BUSY))));
-    }
-    catch (Backend::DatabaseRequestThrottled const& t)
-    {
-        BOOST_LOG_TRIVIAL(error) << __func__ << " Database request throttled";
-        return send(httpResponse(
-            http::status::ok,
-            "application/json",
-            boost::json::serialize(RPC::make_error(RPC::Error::rpcTOO_BUSY))));
-    }
     catch (std::exception const& e)
     {
         BOOST_LOG_TRIVIAL(error)

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -318,7 +318,13 @@ public:
             catch (Backend::DatabaseTimeout const& t)
             {
                 BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
-                return sendError(RPC::Error::rpcNOT_READY);
+                return sendError(RPC::Error::rpcTOO_BUSY);
+            }
+            catch (Backend::DatabaseRequestThrottled const& t)
+            {
+                BOOST_LOG_TRIVIAL(error)
+                    << __func__ << " Database request throttled";
+                return sendError(RPC::Error::rpcTOO_BUSY);
             }
         }
         catch (std::exception const& e)

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -266,65 +266,51 @@ public:
         try
         {
             BOOST_LOG_TRIVIAL(debug) << " received request : " << request;
-            try
+            auto range = backend_->fetchLedgerRange();
+            if (!range)
+                return sendError(RPC::Error::rpcNOT_READY);
+
+            std::optional<RPC::Context> context = RPC::make_WsContext(
+                yield,
+                request,
+                backend_,
+                subscriptions_.lock(),
+                balancer_,
+                etl_,
+                shared_from_this(),
+                *range,
+                counters_,
+                *ip);
+
+            if (!context)
+                return sendError(RPC::Error::rpcBAD_SYNTAX);
+
+            response = getDefaultWsResponse(id);
+
+            auto start = std::chrono::system_clock::now();
+            auto v = RPC::buildResponse(*context);
+            auto end = std::chrono::system_clock::now();
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                end - start);
+            logDuration(*context, us);
+
+            if (auto status = std::get_if<RPC::Status>(&v))
             {
-                auto range = backend_->fetchLedgerRange();
-                if (!range)
-                    return sendError(RPC::Error::rpcNOT_READY);
+                counters_.rpcErrored(context->method);
 
-                std::optional<RPC::Context> context = RPC::make_WsContext(
-                    yield,
-                    request,
-                    backend_,
-                    subscriptions_.lock(),
-                    balancer_,
-                    etl_,
-                    shared_from_this(),
-                    *range,
-                    counters_,
-                    *ip);
+                auto error = RPC::make_error(*status);
 
-                if (!context)
-                    return sendError(RPC::Error::rpcBAD_SYNTAX);
+                if (!id.is_null())
+                    error["id"] = id;
 
-                response = getDefaultWsResponse(id);
-
-                auto start = std::chrono::system_clock::now();
-                auto v = RPC::buildResponse(*context);
-                auto end = std::chrono::system_clock::now();
-                auto us = std::chrono::duration_cast<std::chrono::microseconds>(
-                    end - start);
-                logDuration(*context, us);
-
-                if (auto status = std::get_if<RPC::Status>(&v))
-                {
-                    counters_.rpcErrored(context->method);
-
-                    auto error = RPC::make_error(*status);
-
-                    if (!id.is_null())
-                        error["id"] = id;
-
-                    error["request"] = request;
-                    response = error;
-                }
-                else
-                {
-                    counters_.rpcComplete(context->method, us);
-
-                    response["result"] = std::get<boost::json::object>(v);
-                }
+                error["request"] = request;
+                response = error;
             }
-            catch (Backend::DatabaseTimeout const& t)
+            else
             {
-                BOOST_LOG_TRIVIAL(error) << __func__ << " Database timeout";
-                return sendError(RPC::Error::rpcTOO_BUSY);
-            }
-            catch (Backend::DatabaseRequestThrottled const& t)
-            {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " Database request throttled";
-                return sendError(RPC::Error::rpcTOO_BUSY);
+                counters_.rpcComplete(context->method, us);
+
+                response["result"] = std::get<boost::json::object>(v);
             }
         }
         catch (std::exception const& e)


### PR DESCRIPTION
Add a way for the server to throttle the number of outstanding read requests. Needs a bit more testing, but wanted to get some eyes on this now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/242)
<!-- Reviewable:end -->
