### PR TITLE
Allow server to download cache from another clio server

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -21,6 +21,7 @@
             "grpc_port":"50051"
         }
     ],
+    "clio_peers": [],
     "dos_guard":
     {
         "whitelist":["127.0.0.1"]

--- a/example-config.json
+++ b/example-config.json
@@ -21,7 +21,7 @@
             "grpc_port":"50051"
         }
     ],
-    "clio_peers": [],
+    "peers": [],
     "dos_guard":
     {
         "whitelist":["127.0.0.1"]

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -1004,12 +1004,12 @@ ReportingETL::loadCacheFromClioPeer(
             BOOST_LOG_TRIVIAL(trace)
                 << __func__ << " Successfully parsed response " << parsed;
 
-            auto& response = parsed.as_object();
-            if (response.contains("error"))
+            if (auto const& response = parsed.as_object();
+                response.contains("error"))
             {
                 BOOST_LOG_TRIVIAL(error)
                     << __func__ << " Response contains error: " << response;
-                auto const& err = response["error"];
+                auto const& err = response.at("error");
                 if (err.is_string() && err.as_string() == "lgrNotFound")
                 {
                     BOOST_LOG_TRIVIAL(warning)
@@ -1020,7 +1020,8 @@ ReportingETL::loadCacheFromClioPeer(
                 }
                 return false;
             }
-            response = response["result"].as_object();
+            auto const& response = parsed.as_object()["result"].as_object();
+
             if (!response.contains("cache_full") ||
                 !response.at("cache_full").as_bool())
             {
@@ -1033,7 +1034,7 @@ ReportingETL::loadCacheFromClioPeer(
             else
                 marker = {};
 
-            auto const& state = response["state"].as_array();
+            auto const& state = response.at("state").as_array();
 
             std::vector<Backend::LedgerObject> objects;
             objects.reserve(state.size());

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -943,13 +943,13 @@ ReportingETL::loadCacheFromClioPeer(
         // Make the connection on the IP address we get from a lookup
         ws->next_layer().async_connect(results, yield[ec]);
         if (ec)
-            return {};
+            return false;
 
         BOOST_LOG_TRIVIAL(trace) << "Performing websocket handshake";
         // Perform the websocket handshake
         ws->async_handshake(ip, "/", yield[ec]);
         if (ec)
-            return {};
+            return false;
 
         std::optional<boost::json::value> marker;
 
@@ -976,7 +976,7 @@ ReportingETL::loadCacheFromClioPeer(
             if (ec)
             {
                 BOOST_LOG_TRIVIAL(error) << "error writing = " << ec.message();
-                return {};
+                return false;
             }
 
             beast::flat_buffer buffer;
@@ -984,7 +984,7 @@ ReportingETL::loadCacheFromClioPeer(
             if (ec)
             {
                 BOOST_LOG_TRIVIAL(error) << "error reading = " << ec.message();
-                return {};
+                return false;
             }
 
             auto begin = static_cast<char const*>(buffer.data().data());

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -1009,6 +1009,15 @@ ReportingETL::loadCacheFromClioPeer(
             {
                 BOOST_LOG_TRIVIAL(error)
                     << __func__ << "Response contains error: " << response;
+                auto err = response["error"];
+                if (err.is_string() && err.as_string() == "lgrNotFound")
+                {
+                    BOOST_LOG_TRIVIAL(warning)
+                        << __func__
+                        << " ledger not found. ledger = " << ledgerIndex
+                        << ". trying again";
+                    continue;
+                }
                 return false;
             }
             response = response["result"].as_object();

--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -77,6 +77,14 @@ private:
     // thread responsible for syncing the cache on startup
     std::thread cacheDownloader_;
 
+    struct ClioPeer
+    {
+        std::string ip;
+        int port;
+    };
+
+    std::vector<ClioPeer> clioPeers;
+
     std::thread worker_;
     boost::asio::io_context& ioContext_;
 
@@ -189,6 +197,16 @@ private:
     /// parameter, to populate synchronously, or not at all
     void
     loadCache(uint32_t seq);
+
+    void
+    loadCacheFromDb(uint32_t seq);
+
+    bool
+    loadCacheFromClioPeer(
+        uint32_t ledgerSequence,
+        std::string const& ip,
+        std::string const& port,
+        boost::asio::yield_context& yield);
 
     /// Run ETL. Extracts ledgers and writes them to the database, until a
     /// write conflict occurs (or the server shuts down).

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -184,6 +184,8 @@ doLedgerData(Context const& context)
             objects.push_back(toJson(sle));
     }
     response[JS(state)] = std::move(objects);
+    if (outOfOrder)
+        response["cache_full"] = context.backend->cache().isFull();
     auto end2 = std::chrono::system_clock::now();
 
     time = std::chrono::duration_cast<std::chrono::microseconds>(end2 - end)


### PR DESCRIPTION
* Config takes an array of clio peers. If any of these peers have a
  full cache, clio picks a peer at random to download the cache from.
  Otherwise, fall back to downloading cache from the database

Needs a bit more testing and some cleanup, but ready for review

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/246)
<!-- Reviewable:end -->
