### PR TITLE
insert delivered_amount based on close time

### DIFF
--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -62,7 +62,8 @@ bool
 insertDeliveredAmount(
     boost::json::object& metaJson,
     std::shared_ptr<ripple::STTx const> const& txn,
-    std::shared_ptr<ripple::TxMeta const> const& meta);
+    std::shared_ptr<ripple::TxMeta const> const& meta,
+    uint32_t date);
 
 boost::json::object
 toJson(ripple::STBase const& obj);

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -257,7 +257,8 @@ SubscriptionManager::pubTransaction(
     boost::json::object pubObj;
     pubObj["transaction"] = RPC::toJson(*tx);
     pubObj["meta"] = RPC::toJson(*meta);
-    RPC::insertDeliveredAmount(pubObj["meta"].as_object(), tx, meta);
+    RPC::insertDeliveredAmount(
+        pubObj["meta"].as_object(), tx, meta, blobs.date);
     pubObj["type"] = "transaction";
     pubObj["validated"] = true;
     pubObj["status"] = "closed";


### PR DESCRIPTION
Previously, we were only checking the ledger sequence to determine if we should insert delivered amount. This works on mainnet, but could fail on other networks that are newer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/252)
<!-- Reviewable:end -->
