### PR TITLE
Timeout tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,4 +101,5 @@ jobs:
           name: clio_tests
 
       - name: Run tests
+        timeout-minutes: 10
         uses: XRPLF/clio-gha/test@main


### PR DESCRIPTION
Kill the job if the tests are hanging more than 10 minutes