### PR TITLE
Fix bug causing some ledgers to not be published

### DIFF
--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -382,6 +382,8 @@ public:
                        std::chrono::system_clock::now().time_since_epoch())
                        .count();
         auto closeTime = lastCloseTime_.time_since_epoch().count();
+        if (now < (rippleEpochStart + closeTime))
+            return 0;
         return now - (rippleEpochStart + closeTime);
     }
 };


### PR DESCRIPTION
close time in the ledger header is not accurate to the second. Sometimes, the close time is a second or two in the future, and so the age was being calculated as negative, which converts to a very large unsigned integer. This caused us to skip publishing ledgers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/281)
<!-- Reviewable:end -->
