### PR TITLE
bugfix/account_tx-returns-marker

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1646,8 +1646,13 @@ traverseTransactions(
 
     for (auto const& txnPlusMeta : blobs)
     {
-        if (txnPlusMeta.ledgerSequence < minIndex ||
-            txnPlusMeta.ledgerSequence > maxIndex)
+        if ((txnPlusMeta.ledgerSequence < minIndex && !forward) ||
+            (txnPlusMeta.ledgerSequence > maxIndex && forward))
+        {
+            response.erase(JS(marker));
+            break;
+        }
+        else if (txnPlusMeta.ledgerSequence > maxIndex && !forward)
         {
             BOOST_LOG_TRIVIAL(debug)
                 << __func__
@@ -1674,13 +1679,11 @@ traverseTransactions(
             obj[JS(date)] = txnPlusMeta.date;
         }
         obj[JS(validated)] = true;
-
         txns.push_back(obj);
     }
 
     response[JS(ledger_index_min)] = minIndex;
     response[JS(ledger_index_max)] = maxIndex;
-
     response[JS(transactions)] = txns;
 
     BOOST_LOG_TRIVIAL(info)


### PR DESCRIPTION
**Issue** (#195): account_tx API method returns marker with "0" when paging has been exhausted
**Fix**: After AccountTx.cpp functionality was moved to RPCHelpers.cpp from develop, core logic on paging, skipping transactions, and ingress/egress paging direction based on window of transactions was modified to exit when remaining transactions < limit