### PR TITLE
Probing ETL Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *clio*.log
 build/
+.vscode
 .python-version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(clio PRIVATE
   src/backend/SimpleCache.cpp
   ## ETL
   src/etl/ETLSource.cpp
+  src/etl/ProbingETLSource.cpp
   src/etl/NFTHelpers.cpp
   src/etl/ReportingETL.cpp
   ## Subscriptions

--- a/src/etl/ETLSource.cpp
+++ b/src/etl/ETLSource.cpp
@@ -8,6 +8,7 @@
 #include <boost/log/trivial.hpp>
 #include <backend/DBHelpers.h>
 #include <etl/ETLSource.h>
+#include <etl/ProbingETLSource.h>
 #include <etl/ReportingETL.h>
 #include <rpc/RPCHelpers.h>
 #include <thread>
@@ -72,66 +73,16 @@ ForwardCache::get(boost::json::object const& request) const
     return {latestForwarded_.at(*command)};
 }
 
-// Create ETL source without grpc endpoint
-// Fetch ledger and load initial ledger will fail for this source
-// Primarly used in read-only mode, to monitor when ledgers are validated
-template <class Derived>
-ETLSourceImpl<Derived>::ETLSourceImpl(
-    boost::json::object const& config,
-    boost::asio::io_context& ioContext,
-    std::shared_ptr<BackendInterface> backend,
-    std::shared_ptr<SubscriptionManager> subscriptions,
-    std::shared_ptr<NetworkValidatedLedgers> networkValidatedLedgers,
-    ETLLoadBalancer& balancer)
-    : resolver_(boost::asio::make_strand(ioContext))
-    , networkValidatedLedgers_(networkValidatedLedgers)
-    , backend_(backend)
-    , subscriptions_(subscriptions)
-    , balancer_(balancer)
-    , forwardCache_(config, ioContext, *this)
-    , ioc_(ioContext)
-    , timer_(ioContext)
-{
-    if (config.contains("ip"))
-    {
-        auto ipJs = config.at("ip").as_string();
-        ip_ = {ipJs.c_str(), ipJs.size()};
-    }
-    if (config.contains("ws_port"))
-    {
-        auto portjs = config.at("ws_port").as_string();
-        wsPort_ = {portjs.c_str(), portjs.size()};
-    }
-    if (config.contains("grpc_port"))
-    {
-        auto portjs = config.at("grpc_port").as_string();
-        grpcPort_ = {portjs.c_str(), portjs.size()};
-        try
-        {
-            boost::asio::ip::tcp::endpoint endpoint{
-                boost::asio::ip::make_address(ip_), std::stoi(grpcPort_)};
-            std::stringstream ss;
-            ss << endpoint;
-            grpc::ChannelArguments chArgs;
-            chArgs.SetMaxReceiveMessageSize(-1);
-            stub_ = org::xrpl::rpc::v1::XRPLedgerAPIService::NewStub(
-                grpc::CreateCustomChannel(
-                    ss.str(), grpc::InsecureChannelCredentials(), chArgs));
-            BOOST_LOG_TRIVIAL(debug) << "Made stub for remote = " << toString();
-        }
-        catch (std::exception const& e)
-        {
-            BOOST_LOG_TRIVIAL(debug)
-                << "Exception while creating stub = " << e.what()
-                << " . Remote = " << toString();
-        }
-    }
-}
-
 template <class Derived>
 void
 ETLSourceImpl<Derived>::reconnect(boost::beast::error_code ec)
 {
+    if (paused_)
+        return;
+
+    if (connected_)
+        hooks_.onDisconnected(ec);
+
     connected_ = false;
     // These are somewhat normal errors. operation_aborted occurs on shutdown,
     // when the timer is cancelled. connection_refused will occur repeatedly
@@ -200,11 +151,21 @@ PlainETLSource::close(bool startAgain)
                     }
                     closing_ = false;
                     if (startAgain)
+                    {
+                        ws_ = std::make_unique<boost::beast::websocket::stream<
+                            boost::beast::tcp_stream>>(
+                            boost::asio::make_strand(ioc_));
+
                         run();
+                    }
                 });
         }
         else if (startAgain)
         {
+            ws_ = std::make_unique<
+                boost::beast::websocket::stream<boost::beast::tcp_stream>>(
+                boost::asio::make_strand(ioc_));
+
             run();
         }
     });
@@ -393,6 +354,10 @@ ETLSourceImpl<Derived>::onHandshake(boost::beast::error_code ec)
 {
     BOOST_LOG_TRIVIAL(trace)
         << __func__ << " : ec = " << ec << " - " << toString();
+    if (auto action = hooks_.onConnected(ec);
+        action == ETLSourceHooks::Action::stop)
+        return;
+
     if (ec)
     {
         // start over
@@ -924,8 +889,6 @@ ETLSourceImpl<Derived>::fetchLedger(
                "correctly on the ETL source. source = "
             << toString() << " status = " << status.error_message();
     }
-    // BOOST_LOG_TRIVIAL(debug)
-    //    << __func__ << " Message size = " << response.ByteSizeLong();
     return {status, std::move(response)};
 }
 
@@ -933,34 +896,18 @@ static std::unique_ptr<ETLSource>
 make_ETLSource(
     boost::json::object const& config,
     boost::asio::io_context& ioContext,
-    std::optional<std::reference_wrapper<boost::asio::ssl::context>> sslCtx,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<SubscriptionManager> subscriptions,
     std::shared_ptr<NetworkValidatedLedgers> networkValidatedLedgers,
     ETLLoadBalancer& balancer)
 {
-    std::unique_ptr<ETLSource> src = nullptr;
-    if (sslCtx)
-    {
-        src = std::make_unique<SslETLSource>(
-            config,
-            ioContext,
-            sslCtx,
-            backend,
-            subscriptions,
-            networkValidatedLedgers,
-            balancer);
-    }
-    else
-    {
-        src = std::make_unique<PlainETLSource>(
-            config,
-            ioContext,
-            backend,
-            subscriptions,
-            networkValidatedLedgers,
-            balancer);
-    }
+    auto src = std::make_unique<ProbingETLSource>(
+        config,
+        ioContext,
+        backend,
+        subscriptions,
+        networkValidatedLedgers,
+        balancer);
 
     src->run();
 
@@ -970,7 +917,6 @@ make_ETLSource(
 ETLLoadBalancer::ETLLoadBalancer(
     boost::json::object const& config,
     boost::asio::io_context& ioContext,
-    std::optional<std::reference_wrapper<boost::asio::ssl::context>> sslCtx,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<SubscriptionManager> subscriptions,
     std::shared_ptr<NetworkValidatedLedgers> nwvl)
@@ -989,13 +935,7 @@ ETLLoadBalancer::ETLLoadBalancer(
     for (auto& entry : config.at("etl_sources").as_array())
     {
         std::unique_ptr<ETLSource> source = make_ETLSource(
-            entry.as_object(),
-            ioContext,
-            sslCtx,
-            backend,
-            subscriptions,
-            nwvl,
-            *this);
+            entry.as_object(), ioContext, backend, subscriptions, nwvl, *this);
 
         sources_.push_back(std::move(source));
         BOOST_LOG_TRIVIAL(info) << __func__ << " : added etl source - "

--- a/src/etl/ETLSource.cpp
+++ b/src/etl/ETLSource.cpp
@@ -355,7 +355,7 @@ ETLSourceImpl<Derived>::onHandshake(boost::beast::error_code ec)
     BOOST_LOG_TRIVIAL(trace)
         << __func__ << " : ec = " << ec << " - " << toString();
     if (auto action = hooks_.onConnected(ec);
-        action == ETLSourceHooks::Action::stop)
+        action == ETLSourceHooks::Action::STOP)
         return;
 
     if (ec)

--- a/src/etl/ETLSource.h
+++ b/src/etl/ETLSource.h
@@ -147,27 +147,8 @@ struct ETLSourceHooks
 {
     enum class Action { STOP, PROCEED };
 
-    std::reference_wrapper<std::mutex> mtx_;
-    std::function<Action(boost::beast::error_code)> onConnected_ = [](auto) {
-        return Action::PROCEED;  // nop
-    };
-    std::function<Action(boost::beast::error_code)> onDisconnected_ = [](auto) {
-        return Action::STOP;  // nop
-    };
-
-    Action
-    onConnected(boost::beast::error_code ec) const
-    {
-        std::lock_guard lck(mtx_.get());
-        return onConnected_(ec);
-    }
-
-    Action
-    onDisconnected(boost::beast::error_code ec) const
-    {
-        std::lock_guard lck(mtx_.get());
-        return onDisconnected_(ec);
-    }
+    std::function<Action(boost::beast::error_code)> onConnected;
+    std::function<Action(boost::beast::error_code)> onDisconnected;
 };
 
 template <class Derived>

--- a/src/etl/ETLSource.h
+++ b/src/etl/ETLSource.h
@@ -16,6 +16,7 @@
 
 class ETLLoadBalancer;
 class ETLSource;
+class ProbingETLSource;
 class SubscriptionManager;
 
 /// This class manages a connection to a single ETL source. This is almost
@@ -96,6 +97,12 @@ public:
     virtual void
     run() = 0;
 
+    virtual void
+    pause() = 0;
+
+    virtual void
+    resume() = 0;
+
     virtual std::string
     toString() const = 0;
 
@@ -126,12 +133,41 @@ public:
 
 private:
     friend ForwardCache;
+    friend ProbingETLSource;
 
     virtual std::optional<boost::json::object>
     requestFromRippled(
         boost::json::object const& request,
         std::string const& clientIp,
         boost::asio::yield_context& yield) const = 0;
+};
+
+/// Hooks are executed with respect to the mutex provided
+struct ETLSourceHooks
+{
+    enum class Action { stop, proceed };
+
+    std::reference_wrapper<std::mutex> mtx_;
+    std::function<Action(boost::beast::error_code)> onConnected_ = [](auto) {
+        return Action::proceed;  // nop
+    };
+    std::function<Action(boost::beast::error_code)> onDisconnected_ = [](auto) {
+        return Action::proceed;  // nop
+    };
+
+    Action
+    onConnected(boost::beast::error_code ec) const
+    {
+        std::lock_guard lck(mtx_.get());
+        return onConnected_(ec);
+    }
+
+    Action
+    onDisconnected(boost::beast::error_code ec) const
+    {
+        std::lock_guard lck(mtx_.get());
+        return onDisconnected_(ec);
+    }
 };
 
 template <class Derived>
@@ -199,6 +235,10 @@ protected:
 
     std::atomic_bool closing_{false};
 
+    std::atomic_bool paused_{false};
+
+    ETLSourceHooks hooks_;
+
     void
     run() override
     {
@@ -215,7 +255,7 @@ protected:
 public:
     ~ETLSourceImpl()
     {
-        close(false);
+        derived().close(false);
     }
 
     bool
@@ -247,7 +287,54 @@ public:
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<NetworkValidatedLedgers> networkValidatedLedgers,
-        ETLLoadBalancer& balancer);
+        ETLLoadBalancer& balancer,
+        ETLSourceHooks hooks)
+        : resolver_(boost::asio::make_strand(ioContext))
+        , networkValidatedLedgers_(networkValidatedLedgers)
+        , backend_(backend)
+        , subscriptions_(subscriptions)
+        , balancer_(balancer)
+        , forwardCache_(config, ioContext, *this)
+        , ioc_(ioContext)
+        , timer_(ioContext)
+        , hooks_(hooks)
+    {
+        if (config.contains("ip"))
+        {
+            auto ipJs = config.at("ip").as_string();
+            ip_ = {ipJs.c_str(), ipJs.size()};
+        }
+        if (config.contains("ws_port"))
+        {
+            auto portjs = config.at("ws_port").as_string();
+            wsPort_ = {portjs.c_str(), portjs.size()};
+        }
+        if (config.contains("grpc_port"))
+        {
+            auto portjs = config.at("grpc_port").as_string();
+            grpcPort_ = {portjs.c_str(), portjs.size()};
+            try
+            {
+                boost::asio::ip::tcp::endpoint endpoint{
+                    boost::asio::ip::make_address(ip_), std::stoi(grpcPort_)};
+                std::stringstream ss;
+                ss << endpoint;
+                grpc::ChannelArguments chArgs;
+                chArgs.SetMaxReceiveMessageSize(-1);
+                stub_ = org::xrpl::rpc::v1::XRPLedgerAPIService::NewStub(
+                    grpc::CreateCustomChannel(
+                        ss.str(), grpc::InsecureChannelCredentials(), chArgs));
+                BOOST_LOG_TRIVIAL(debug)
+                    << "Made stub for remote = " << toString();
+            }
+            catch (std::exception const& e)
+            {
+                BOOST_LOG_TRIVIAL(debug)
+                    << "Exception while creating stub = " << e.what()
+                    << " . Remote = " << toString();
+            }
+        }
+    }
 
     /// @param sequence ledger sequence to check for
     /// @return true if this source has the desired ledger
@@ -371,6 +458,22 @@ public:
     void
     reconnect(boost::beast::error_code ec);
 
+    /// Pause the source effectively stopping it from trying to reconnect
+    void
+    pause() override
+    {
+        paused_ = true;
+        derived().close(false);
+    }
+
+    /// Resume the source allowing it to reconnect again
+    void
+    resume() override
+    {
+        paused_ = false;
+        derived().close(true);
+    }
+
     /// Callback
     void
     onResolve(
@@ -420,8 +523,16 @@ public:
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<NetworkValidatedLedgers> nwvl,
-        ETLLoadBalancer& balancer)
-        : ETLSourceImpl(config, ioc, backend, subscriptions, nwvl, balancer)
+        ETLLoadBalancer& balancer,
+        ETLSourceHooks hooks)
+        : ETLSourceImpl(
+              config,
+              ioc,
+              backend,
+              subscriptions,
+              nwvl,
+              balancer,
+              std::move(hooks))
         , ws_(std::make_unique<
               boost::beast::websocket::stream<boost::beast::tcp_stream>>(
               boost::asio::make_strand(ioc)))
@@ -462,8 +573,16 @@ public:
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<NetworkValidatedLedgers> nwvl,
-        ETLLoadBalancer& balancer)
-        : ETLSourceImpl(config, ioc, backend, subscriptions, nwvl, balancer)
+        ETLLoadBalancer& balancer,
+        ETLSourceHooks hooks)
+        : ETLSourceImpl(
+              config,
+              ioc,
+              backend,
+              subscriptions,
+              nwvl,
+              balancer,
+              std::move(hooks))
         , sslCtx_(sslCtx)
         , ws_(std::make_unique<boost::beast::websocket::stream<
                   boost::beast::ssl_stream<boost::beast::tcp_stream>>>(
@@ -513,7 +632,6 @@ public:
     ETLLoadBalancer(
         boost::json::object const& config,
         boost::asio::io_context& ioContext,
-        std::optional<std::reference_wrapper<boost::asio::ssl::context>> sslCtx,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<NetworkValidatedLedgers> nwvl);
@@ -522,13 +640,12 @@ public:
     make_ETLLoadBalancer(
         boost::json::object const& config,
         boost::asio::io_context& ioc,
-        std::optional<std::reference_wrapper<boost::asio::ssl::context>> sslCtx,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<NetworkValidatedLedgers> validatedLedgers)
     {
         return std::make_shared<ETLLoadBalancer>(
-            config, ioc, sslCtx, backend, subscriptions, validatedLedgers);
+            config, ioc, backend, subscriptions, validatedLedgers);
     }
 
     ~ETLLoadBalancer()

--- a/src/etl/ETLSource.h
+++ b/src/etl/ETLSource.h
@@ -145,14 +145,14 @@ private:
 /// Hooks are executed with respect to the mutex provided
 struct ETLSourceHooks
 {
-    enum class Action { stop, proceed };
+    enum class Action { STOP, PROCEED };
 
     std::reference_wrapper<std::mutex> mtx_;
     std::function<Action(boost::beast::error_code)> onConnected_ = [](auto) {
-        return Action::proceed;  // nop
+        return Action::PROCEED;  // nop
     };
     std::function<Action(boost::beast::error_code)> onDisconnected_ = [](auto) {
-        return Action::proceed;  // nop
+        return Action::STOP;  // nop
     };
 
     Action

--- a/src/etl/ETLSource.h
+++ b/src/etl/ETLSource.h
@@ -142,7 +142,6 @@ private:
         boost::asio::yield_context& yield) const = 0;
 };
 
-/// Hooks are executed with respect to the mutex provided
 struct ETLSourceHooks
 {
     enum class Action { STOP, PROCEED };

--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -1,0 +1,187 @@
+#include <etl/ProbingETLSource.h>
+
+ProbingETLSource::ProbingETLSource(
+    boost::json::object const& config,
+    boost::asio::io_context& ioc,
+    std::shared_ptr<BackendInterface> backend,
+    std::shared_ptr<SubscriptionManager> subscriptions,
+    std::shared_ptr<NetworkValidatedLedgers> nwvl,
+    ETLLoadBalancer& balancer,
+    boost::asio::ssl::context sslCtx)
+    : ioc_{ioc}
+    , sslCtx_{std::move(sslCtx)}
+    , sslSrc_{make_shared<SslETLSource>(
+          config,
+          ioc,
+          std::reference_wrapper{sslCtx_},
+          backend,
+          subscriptions,
+          nwvl,
+          balancer,
+          make_SSLHooks(mtx_))}
+    , plainSrc_{make_shared<PlainETLSource>(
+          config,
+          ioc,
+          backend,
+          subscriptions,
+          nwvl,
+          balancer,
+          make_PlainHooks(mtx_))}
+{
+}
+
+void
+ProbingETLSource::run()
+{
+    sslSrc_->run();
+    plainSrc_->run();
+}
+
+void
+ProbingETLSource::pause()
+{
+    sslSrc_->pause();
+    plainSrc_->pause();
+}
+
+void
+ProbingETLSource::resume()
+{
+    sslSrc_->resume();
+    plainSrc_->resume();
+}
+
+bool
+ProbingETLSource::isConnected() const
+{
+    return currentSrc_ && currentSrc_->isConnected();
+}
+
+bool
+ProbingETLSource::hasLedger(uint32_t sequence) const
+{
+    if (!currentSrc_)
+        return false;
+    return currentSrc_->hasLedger(sequence);
+}
+
+boost::json::object
+ProbingETLSource::toJson() const
+{
+    if (!currentSrc_)
+        return {};
+    return currentSrc_->toJson();
+}
+
+std::string
+ProbingETLSource::toString() const
+{
+    if (!currentSrc_)
+        return "{ probing }";
+    return currentSrc_->toString();
+}
+
+bool
+ProbingETLSource::loadInitialLedger(
+    std::uint32_t ledgerSequence,
+    std::uint32_t numMarkers,
+    bool cacheOnly)
+{
+    if (!currentSrc_)
+        return false;
+    return currentSrc_->loadInitialLedger(
+        ledgerSequence, numMarkers, cacheOnly);
+}
+
+std::pair<grpc::Status, org::xrpl::rpc::v1::GetLedgerResponse>
+ProbingETLSource::fetchLedger(
+    uint32_t ledgerSequence,
+    bool getObjects,
+    bool getObjectNeighbors)
+{
+    if (!currentSrc_)
+        return {};
+    return currentSrc_->fetchLedger(
+        ledgerSequence, getObjects, getObjectNeighbors);
+}
+
+std::optional<boost::json::object>
+ProbingETLSource::forwardToRippled(
+    boost::json::object const& request,
+    std::string const& clientIp,
+    boost::asio::yield_context& yield) const
+{
+    assert(currentSrc_);  // expected to be connected
+    return currentSrc_->forwardToRippled(request, clientIp, yield);
+}
+
+std::optional<boost::json::object>
+ProbingETLSource::requestFromRippled(
+    boost::json::object const& request,
+    std::string const& clientIp,
+    boost::asio::yield_context& yield) const
+{
+    assert(currentSrc_);  // expected to be connected
+    return currentSrc_->requestFromRippled(request, clientIp, yield);
+}
+
+ETLSourceHooks
+ProbingETLSource::make_SSLHooks(std::mutex& mtx) noexcept
+{
+    return {
+        std::ref(mtx),
+        // onConnected
+        [this](auto ec) {
+            if (currentSrc_)
+                return ETLSourceHooks::Action::stop;
+
+            if (!ec)
+            {
+                plainSrc_->pause();
+                currentSrc_ = sslSrc_;
+                BOOST_LOG_TRIVIAL(info) << "Selected WSS as the main source: "
+                                        << currentSrc_->toString();
+            }
+            return ETLSourceHooks::Action::proceed;
+        },
+        // onDisconnected
+        [this](auto ec) {
+            if (currentSrc_)
+            {
+                currentSrc_ = nullptr;
+                plainSrc_->resume();
+            }
+            return ETLSourceHooks::Action::stop;
+        }};
+}
+
+ETLSourceHooks
+ProbingETLSource::make_PlainHooks(std::mutex& mtx) noexcept
+{
+    return {
+        std::ref(mtx),
+        // onConnected
+        [this](auto ec) {
+            if (currentSrc_)
+                return ETLSourceHooks::Action::stop;
+
+            if (!ec)
+            {
+                sslSrc_->pause();
+                currentSrc_ = plainSrc_;
+                BOOST_LOG_TRIVIAL(info)
+                    << "Selected Plain WS as the main source: "
+                    << currentSrc_->toString();
+            }
+            return ETLSourceHooks::Action::proceed;
+        },
+        // onDisconnected
+        [this](auto ec) {
+            if (currentSrc_)
+            {
+                currentSrc_ = nullptr;
+                sslSrc_->resume();
+            }
+            return ETLSourceHooks::Action::stop;
+        }};
+}

--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -18,7 +18,7 @@ ProbingETLSource::ProbingETLSource(
           subscriptions,
           nwvl,
           balancer,
-          make_SSLHooks(mtx_))}
+          make_SSLHooks())}
     , plainSrc_{make_shared<PlainETLSource>(
           config,
           ioc,
@@ -26,7 +26,7 @@ ProbingETLSource::ProbingETLSource(
           subscriptions,
           nwvl,
           balancer,
-          make_PlainHooks(mtx_))}
+          make_PlainHooks())}
 {
 }
 
@@ -126,10 +126,10 @@ ProbingETLSource::requestFromRippled(
 }
 
 ETLSourceHooks
-ProbingETLSource::make_SSLHooks(std::mutex& mtx) noexcept
+ProbingETLSource::make_SSLHooks() noexcept
 {
     return {
-        std::ref(mtx),
+        std::ref(mtx_),
         // onConnected
         [this](auto ec) {
             if (currentSrc_)
@@ -156,10 +156,10 @@ ProbingETLSource::make_SSLHooks(std::mutex& mtx) noexcept
 }
 
 ETLSourceHooks
-ProbingETLSource::make_PlainHooks(std::mutex& mtx) noexcept
+ProbingETLSource::make_PlainHooks() noexcept
 {
     return {
-        std::ref(mtx),
+        std::ref(mtx_),
         // onConnected
         [this](auto ec) {
             if (currentSrc_)

--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -133,7 +133,7 @@ ProbingETLSource::make_SSLHooks() noexcept
         // onConnected
         [this](auto ec) {
             if (currentSrc_)
-                return ETLSourceHooks::Action::stop;
+                return ETLSourceHooks::Action::STOP;
 
             if (!ec)
             {
@@ -142,7 +142,7 @@ ProbingETLSource::make_SSLHooks() noexcept
                 BOOST_LOG_TRIVIAL(info) << "Selected WSS as the main source: "
                                         << currentSrc_->toString();
             }
-            return ETLSourceHooks::Action::proceed;
+            return ETLSourceHooks::Action::PROCEED;
         },
         // onDisconnected
         [this](auto ec) {
@@ -151,7 +151,7 @@ ProbingETLSource::make_SSLHooks() noexcept
                 currentSrc_ = nullptr;
                 plainSrc_->resume();
             }
-            return ETLSourceHooks::Action::stop;
+            return ETLSourceHooks::Action::STOP;
         }};
 }
 
@@ -163,7 +163,7 @@ ProbingETLSource::make_PlainHooks() noexcept
         // onConnected
         [this](auto ec) {
             if (currentSrc_)
-                return ETLSourceHooks::Action::stop;
+                return ETLSourceHooks::Action::STOP;
 
             if (!ec)
             {
@@ -173,7 +173,7 @@ ProbingETLSource::make_PlainHooks() noexcept
                     << "Selected Plain WS as the main source: "
                     << currentSrc_->toString();
             }
-            return ETLSourceHooks::Action::proceed;
+            return ETLSourceHooks::Action::PROCEED;
         },
         // onDisconnected
         [this](auto ec) {
@@ -182,6 +182,6 @@ ProbingETLSource::make_PlainHooks() noexcept
                 currentSrc_ = nullptr;
                 sslSrc_->resume();
             }
-            return ETLSourceHooks::Action::stop;
+            return ETLSourceHooks::Action::STOP;
         }};
 }

--- a/src/etl/ProbingETLSource.h
+++ b/src/etl/ProbingETLSource.h
@@ -1,0 +1,91 @@
+#ifndef RIPPLE_APP_REPORTING_PROBINGETLSOURCE_H_INCLUDED
+#define RIPPLE_APP_REPORTING_PROBINGETLSOURCE_H_INCLUDED
+
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/core/string.hpp>
+#include <boost/beast/ssl.hpp>
+#include <boost/beast/websocket.hpp>
+#include <etl/ETLSource.h>
+#include <mutex>
+
+/// This ETLSource implementation attempts to connect over both secure websocket
+/// and plain websocket. First to connect pauses the other and the probing is
+/// considered done at this point. If however the connected source loses
+/// connection the probing is kickstarted again.
+class ProbingETLSource : public ETLSource
+{
+    std::mutex mtx_;
+    boost::asio::io_context& ioc_;
+    boost::asio::ssl::context sslCtx_;
+    std::shared_ptr<ETLSource> sslSrc_;
+    std::shared_ptr<ETLSource> plainSrc_;
+    std::shared_ptr<ETLSource> currentSrc_;
+
+public:
+    ProbingETLSource(
+        boost::json::object const& config,
+        boost::asio::io_context& ioc,
+        std::shared_ptr<BackendInterface> backend,
+        std::shared_ptr<SubscriptionManager> subscriptions,
+        std::shared_ptr<NetworkValidatedLedgers> nwvl,
+        ETLLoadBalancer& balancer,
+        boost::asio::ssl::context sslCtx = boost::asio::ssl::context{
+            boost::asio::ssl::context::tlsv12});
+
+    ~ProbingETLSource() = default;
+
+    void
+    run() override;
+
+    void
+    pause() override;
+
+    void
+    resume() override;
+
+    bool
+    isConnected() const override;
+
+    bool
+    hasLedger(uint32_t sequence) const override;
+
+    boost::json::object
+    toJson() const override;
+
+    std::string
+    toString() const override;
+
+    bool
+    loadInitialLedger(
+        std::uint32_t ledgerSequence,
+        std::uint32_t numMarkers,
+        bool cacheOnly = false) override;
+
+    std::pair<grpc::Status, org::xrpl::rpc::v1::GetLedgerResponse>
+    fetchLedger(
+        uint32_t ledgerSequence,
+        bool getObjects = true,
+        bool getObjectNeighbors = false) override;
+
+    std::optional<boost::json::object>
+    forwardToRippled(
+        boost::json::object const& request,
+        std::string const& clientIp,
+        boost::asio::yield_context& yield) const override;
+
+private:
+    std::optional<boost::json::object>
+    requestFromRippled(
+        boost::json::object const& request,
+        std::string const& clientIp,
+        boost::asio::yield_context& yield) const override;
+
+    ETLSourceHooks
+    make_SSLHooks(std::mutex& mtx) noexcept;
+
+    ETLSourceHooks
+    make_PlainHooks(std::mutex& mtx) noexcept;
+};
+
+#endif

--- a/src/etl/ProbingETLSource.h
+++ b/src/etl/ProbingETLSource.h
@@ -82,10 +82,10 @@ private:
         boost::asio::yield_context& yield) const override;
 
     ETLSourceHooks
-    make_SSLHooks(std::mutex& mtx) noexcept;
+    make_SSLHooks() noexcept;
 
     ETLSourceHooks
-    make_PlainHooks(std::mutex& mtx) noexcept;
+    make_PlainHooks() noexcept;
 };
 
 #endif

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -272,7 +272,7 @@ main(int argc, char* argv[])
     // The balancer itself publishes to streams (transactions_proposed and
     // accounts_proposed)
     auto balancer = ETLLoadBalancer::make_ETLLoadBalancer(
-        *config, ioc, ctxRef, backend, subscriptions, ledgers);
+        *config, ioc, backend, subscriptions, ledgers);
 
     // ETL is responsible for writing and publishing to streams. In read-only
     // mode, ETL only publishes


### PR DESCRIPTION
Fixing #251

- Remove the requirement for an SSL context to be passed to create an `SslETLSource`
- Implement a probing source that automatically detects SSL/Plain Websocket
- Add recreation of `ws_` for `PlainETLsource` the same way we do for `SslETLSource` (probably was a bug)