### PR TITLE
Implement book_changes RPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ target_sources(clio PRIVATE
   src/rpc/handlers/TransactionEntry.cpp
   src/rpc/handlers/AccountTx.cpp
   # Dex
+  src/rpc/handlers/BookChanges.cpp
   src/rpc/handlers/BookOffers.cpp
   # NFT
   src/rpc/handlers/NFTOffers.cpp

--- a/src/rpc/Handlers.h
+++ b/src/rpc/Handlers.h
@@ -44,7 +44,10 @@ doChannelAuthorize(Context const& context);
 Result
 doChannelVerify(Context const& context);
 
-// offers methods
+// book methods
+Result
+doBookChanges(Context const& context);
+
 Result
 doBookOffers(Context const& context);
 

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -19,7 +19,6 @@ make_WsContext(
     Counters& counters,
     std::string const& clientIp)
 {
-    BOOST_LOG_TRIVIAL(info) << "got request over ws: " << request;
     boost::json::value commandValue = nullptr;
     if (!request.contains("command") && request.contains("method"))
         commandValue = request.at("method");

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -19,6 +19,7 @@ make_WsContext(
     Counters& counters,
     std::string const& clientIp)
 {
+    BOOST_LOG_TRIVIAL(info) << "got request over ws: " << request;
     boost::json::value commandValue = nullptr;
     if (!request.contains("command") && request.contains("method"))
         commandValue = request.at("method");
@@ -219,6 +220,7 @@ static HandlerTable handlerTable{
     {"account_tx", &doAccountTx, LimitRange{1, 50, 100}},
     {"gateway_balances", &doGatewayBalances, {}},
     {"noripple_check", &doNoRippleCheck, {}},
+    {"book_changes", &doBookChanges, {}},
     {"book_offers", &doBookOffers, LimitRange{1, 50, 100}},
     {"ledger", &doLedger, {}},
     {"ledger_data", &doLedgerData, LimitRange{1, 100, 2048}},

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -52,7 +52,7 @@ public:
     {
         reset();
 
-        auto transactions =
+        auto const transactions =
             context_.get().backend->fetchAllTransactionsInLedger(
                 ledger.seq, context_.get().yield);
         for (auto const& tx : transactions)
@@ -79,7 +79,7 @@ private:
     handleAffectedNode(STObject const& node)
     {
         auto const& metaType = node.getFName();
-        auto nodeType = node.getFieldU16(sfLedgerEntryType);
+        auto const nodeType = node.getFieldU16(sfLedgerEntryType);
 
         // we only care about ltOFFER objects being modified or
         // deleted
@@ -115,13 +115,13 @@ private:
 
         // compute the difference in gets and pays actually
         // affected onto the offer
-        auto deltaGets = finalFields.getFieldAmount(sfTakerGets) -
+        auto const deltaGets = finalFields.getFieldAmount(sfTakerGets) -
             previousFields.getFieldAmount(sfTakerGets);
-        auto deltaPays = finalFields.getFieldAmount(sfTakerPays) -
+        auto const deltaPays = finalFields.getFieldAmount(sfTakerPays) -
             previousFields.getFieldAmount(sfTakerPays);
 
-        auto g = to_string(deltaGets.issue());
-        auto p = to_string(deltaPays.issue());
+        auto const g = to_string(deltaGets.issue());
+        auto const p = to_string(deltaPays.issue());
 
         auto const noswap =
             isXRP(deltaGets) ? true : (isXRP(deltaPays) ? false : (g < p));
@@ -133,7 +133,7 @@ private:
         if (second == beast::zero)
             return;
 
-        auto rate = divide(first, second, noIssue());
+        auto const rate = divide(first, second, noIssue());
 
         if (first < beast::zero)
             first = -first;
@@ -141,7 +141,7 @@ private:
         if (second < beast::zero)
             second = -second;
 
-        auto key = noswap ? (g + '|' + p) : (p + '|' + g);
+        auto const key = noswap ? (g + '|' + p) : (p + '|' + g);
         if (tally_.contains(key))
         {
             auto& entry = tally_.at(key);
@@ -229,13 +229,13 @@ tag_invoke(
 Result
 doBookChanges(Context const& context)
 {
-    auto request = context.params;
-    auto v = ledgerInfoFromRequest(context);
-    if (auto status = std::get_if<Status>(&v))
+    auto const request = context.params;
+    auto const v = ledgerInfoFromRequest(context);
+    if (auto const status = std::get_if<Status>(&v))
         return *status;
 
-    auto lgrInfo = std::get<ripple::LedgerInfo>(v);
-    auto changes = BookChangesHandler{context}.handle(lgrInfo);
+    auto const lgrInfo = std::get<ripple::LedgerInfo>(v);
+    auto const changes = BookChangesHandler{context}.handle(lgrInfo);
     auto response = json::object{};
 
     response[JS(type)] = "bookChanges";

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -52,8 +52,9 @@ public:
     {
         reset();
 
-        auto transactions = context_.get().backend->fetchAllTransactionsInLedger(
-            ledger.seq, context_.get().yield);
+        auto transactions =
+            context_.get().backend->fetchAllTransactionsInLedger(
+                ledger.seq, context_.get().yield);
         for (auto const& tx : transactions)
             handleBookChange(tx);
 

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -183,7 +183,7 @@ private:
     }
 
     std::optional<uint32_t>
-    shouldCancelOffer(std::shared_ptr<ripple::STTx const> const& tx)
+    shouldCancelOffer(std::shared_ptr<ripple::STTx const> const& tx) const
     {
         switch (tx->getFieldU16(sfTransactionType))
         {

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -30,7 +30,8 @@ class BookChangesHandler
 
 public:
     ~BookChangesHandler() = default;
-    BookChangesHandler(Context const& context) : context_{std::cref(context)}
+    explicit BookChangesHandler(Context const& context)
+        : context_{std::cref(context)}
     {
     }
 

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -1,8 +1,8 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/basics/ToString.h>
 
-#include <rpc/RPCHelpers.h>
 #include <backend/BackendInterface.h>
+#include <rpc/RPCHelpers.h>
 
 #include <boost/json.hpp>
 #include <algorithm>

--- a/src/rpc/handlers/BookChanges.cpp
+++ b/src/rpc/handlers/BookChanges.cpp
@@ -1,0 +1,250 @@
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/basics/ToString.h>
+
+#include <rpc/RPCHelpers.h>
+#include <backend/BackendInterface.h>
+
+#include <boost/json.hpp>
+#include <algorithm>
+
+namespace json = boost::json;
+using namespace ripple;
+
+namespace RPC {
+
+struct BookChange
+{
+    STAmount sideAVolume;
+    STAmount sideBVolume;
+    STAmount highRate;
+    STAmount lowRate;
+    STAmount openRate;
+    STAmount closeRate;
+};
+
+class BookChangeHandler
+{
+    std::reference_wrapper<Context const> context_;
+    std::map<std::string, BookChange> tally_;
+    std::optional<uint32_t> offerCancel_;
+
+public:
+    ~BookChangeHandler() = default;
+    BookChangeHandler(Context const& context) : context_{std::cref(context)}
+    {
+    }
+
+    BookChangeHandler(BookChangeHandler const&) = delete;
+    BookChangeHandler(BookChangeHandler&&) = delete;
+    BookChangeHandler&
+    operator=(BookChangeHandler const&) = delete;
+    BookChangeHandler&
+    operator=(BookChangeHandler&&) = delete;
+
+    /**
+     * @brief Handles the `book_change` request for given transactions
+     *
+     * @param transactions The transactions to compute changes for
+     * @return std::vector<BookChange> The changes
+     */
+    std::vector<BookChange>
+    handle(std::vector<Backend::TransactionAndMetadata>& transactions)
+    {
+        reset();
+
+        for (auto const& tx : transactions)
+            handleBookChange(tx);
+
+        std::vector<BookChange> changes;
+        std::transform(
+            std::make_move_iterator(std::begin(tally_)),
+            std::make_move_iterator(std::end(tally_)),
+            std::back_inserter(changes),
+            [](auto obj) { return obj.second; });
+        return changes;
+    }
+
+private:
+    inline void
+    reset()
+    {
+        tally_.clear();
+        offerCancel_ = std::nullopt;
+    }
+
+    void
+    handleAffectedNode(STObject const& node)
+    {
+        auto const& metaType = node.getFName();
+        auto nodeType = node.getFieldU16(sfLedgerEntryType);
+
+        // we only care about ltOFFER objects being modified or
+        // deleted
+        if (nodeType != ltOFFER || metaType == sfCreatedNode)
+            return;
+
+        // if either FF or PF are missing we can't compute
+        // but generally these are cancelled rather than crossed
+        // so skipping them is consistent
+        if (!node.isFieldPresent(sfFinalFields) ||
+            !node.isFieldPresent(sfPreviousFields))
+            return;
+
+        auto& finalFields = (const_cast<STObject&>(node))
+                                .getField(sfFinalFields)
+                                .downcast<STObject>();
+
+        auto& previousFields = (const_cast<STObject&>(node))
+                                   .getField(sfPreviousFields)
+                                   .downcast<STObject>();
+
+        // defensive case that should never be hit
+        if (!finalFields.isFieldPresent(sfTakerGets) ||
+            !finalFields.isFieldPresent(sfTakerPays) ||
+            !previousFields.isFieldPresent(sfTakerGets) ||
+            !previousFields.isFieldPresent(sfTakerPays))
+            return;
+
+        // filter out any offers deleted by explicit offer cancels
+        if (metaType == sfDeletedNode && offerCancel_ &&
+            finalFields.getFieldU32(sfSequence) == *offerCancel_)
+            return;
+
+        // compute the difference in gets and pays actually
+        // affected onto the offer
+        auto deltaGets = finalFields.getFieldAmount(sfTakerGets) -
+            previousFields.getFieldAmount(sfTakerGets);
+        auto deltaPays = finalFields.getFieldAmount(sfTakerPays) -
+            previousFields.getFieldAmount(sfTakerPays);
+
+        auto g = to_string(deltaGets.issue());
+        auto p = to_string(deltaPays.issue());
+
+        auto const noswap =
+            isXRP(deltaGets) ? true : (isXRP(deltaPays) ? false : (g < p));
+
+        auto first = noswap ? deltaGets : deltaPays;
+        auto second = noswap ? deltaPays : deltaGets;
+
+        // defensively programmed, should (probably) never happen
+        if (second == beast::zero)
+            return;
+
+        auto rate = divide(first, second, noIssue());
+
+        if (first < beast::zero)
+            first = -first;
+
+        if (second < beast::zero)
+            second = -second;
+
+        auto key = noswap ? (g + '|' + p) : (p + '|' + g);
+        if (tally_.contains(key))
+        {
+            auto& entry = tally_.at(key);
+
+            entry.sideAVolume += first;
+            entry.sideBVolume += second;
+
+            if (entry.highRate < rate)
+                entry.highRate = rate;
+
+            if (entry.lowRate > rate)
+                entry.lowRate = rate;
+
+            entry.closeRate = rate;
+        }
+        else
+        {
+            tally_[key] = {
+                first,   // side A vol
+                second,  // side B vol
+                rate,    // high
+                rate,    // low
+                rate,    // open
+                rate     // close
+            };
+        }
+    }
+
+    void
+    handleBookChange(Backend::TransactionAndMetadata const& blob)
+    {
+        auto const [tx, meta] = deserializeTxPlusMeta(blob);
+        if (!tx || !meta || !tx->isFieldPresent(sfTransactionType))
+            return;
+
+        offerCancel_ = shouldCancelOffer(tx);
+        for (auto const& node : meta->getFieldArray(sfAffectedNodes))
+            handleAffectedNode(node);
+    }
+
+    std::optional<uint32_t>
+    shouldCancelOffer(std::shared_ptr<ripple::STTx const> const& tx)
+    {
+        switch (tx->getFieldU16(sfTransactionType))
+        {
+            // in future if any other ways emerge to cancel an offer
+            // this switch makes them easy to add
+            case ttOFFER_CANCEL:
+            case ttOFFER_CREATE:
+                if (tx->isFieldPresent(sfOfferSequence))
+                    return tx->getFieldU32(sfOfferSequence);
+            default:
+                return std::nullopt;
+        }
+    }
+};
+
+void
+tag_invoke(
+    const json::value_from_tag&,
+    json::value& jv,
+    BookChange const& change)
+{
+    auto amountStr = [](STAmount const& amount) -> std::string {
+        return isXRP(amount) ? to_string(amount.xrp())
+                             : to_string(amount.iou());
+    };
+
+    auto currencyStr = [](STAmount const& amount) -> std::string {
+        return isXRP(amount) ? "XRP_drops" : to_string(amount.issue());
+    };
+
+    jv = {
+        {JS(currency_a), currencyStr(change.sideAVolume)},
+        {JS(currency_b), currencyStr(change.sideBVolume)},
+        {JS(volume_a), amountStr(change.sideAVolume)},
+        {JS(volume_b), amountStr(change.sideBVolume)},
+        {JS(high), to_string(change.highRate.iou())},
+        {JS(low), to_string(change.lowRate.iou())},
+        {JS(open), to_string(change.openRate.iou())},
+        {JS(close), to_string(change.closeRate.iou())},
+    };
+}
+
+Result
+doBookChanges(Context const& context)
+{
+    auto request = context.params;
+    auto v = ledgerInfoFromRequest(context);
+    if (auto status = std::get_if<Status>(&v))
+        return *status;
+
+    auto lgrInfo = std::get<ripple::LedgerInfo>(v);
+    auto response = json::object{};
+
+    auto txns = context.backend->fetchAllTransactionsInLedger(
+        lgrInfo.seq, context.yield);
+    auto changes = BookChangeHandler{context}.handle(txns);
+
+    response[JS(type)] = "bookChanges";
+    response[JS(ledger_index)] = lgrInfo.seq;
+    response[JS(ledger_hash)] = to_string(lgrInfo.hash);
+    response[JS(ledger_time)] = lgrInfo.closeTime.time_since_epoch().count();
+    response[JS(changes)] = json::value_from(changes);
+
+    return response;
+}
+
+}  // namespace RPC

--- a/test.py
+++ b/test.py
@@ -571,7 +571,19 @@ def compare_book_offers(aldous, p2p):
     print("offers match!")
     return True
                     
-        
+async def book_changes(ip, port, ledger):
+    address = 'ws://' + str(ip) + ':' + str(port)
+    try:
+        async with websockets.connect(address) as ws:
+            await ws.send(json.dumps({
+                "command" : "book_changes",
+                "ledger_index" : ledger
+            }))
+            res = json.loads(await ws.recv())
+            print(json.dumps(res, indent=4, sort_keys=True))
+    except websockets.exceptions.connectionclosederror as e:
+        print(e)
+
 async def book_offerses(ip, port, ledger, books, numCalls):
     address = 'ws://' + str(ip) + ':' + str(port)
     random.seed()
@@ -789,6 +801,7 @@ async def fee(ip, port):
             print(json.dumps(res,indent=4,sort_keys=True))
     except websockets.exceptions.connectionclosederror as e:
         print(e)
+
 async def server_info(ip, port):
     address = 'ws://' + str(ip) + ':' + str(port)
     try:
@@ -968,7 +981,7 @@ async def verifySubscribe(ip,clioPort,ripdPort):
     
 
 parser = argparse.ArgumentParser(description='test script for xrpl-reporting')
-parser.add_argument('action', choices=["account_info", "tx", "txs","account_tx", "account_tx_full","ledger_data", "ledger_data_full", "book_offers","ledger","ledger_range","ledger_entry", "ledgers", "ledger_entries","account_txs","account_infos","account_txs_full","book_offerses","ledger_diff","perf","fee","server_info", "gaps","subscribe","verify_subscribe","call"])
+parser.add_argument('action', choices=["account_info", "tx", "txs","account_tx", "account_tx_full","ledger_data", "ledger_data_full", "book_offers","ledger","ledger_range","ledger_entry", "ledgers", "ledger_entries","account_txs","account_infos","account_txs_full","book_changes","book_offerses","ledger_diff","perf","fee","server_info", "gaps","subscribe","verify_subscribe","call"])
 
 parser.add_argument('--ip', default='127.0.0.1')
 parser.add_argument('--port', default='8080')
@@ -1156,14 +1169,17 @@ def run(args):
         end = datetime.datetime.now().timestamp()
         num = int(args.numRunners) * int(args.numCalls)
         print("Completed " + str(num) + " in " + str(end - start) + " seconds. Throughput = " + str(num / (end - start)) + " calls per second")
-    
+   
+    elif args.action == "book_changes":
+        asyncio.get_event_loop().run_until_complete(book_changes(args.ip, args.port, int(args.ledger)))
+            
     elif args.action == "book_offerses":
         books = getBooks(args.filename)
         async def runner():
 
             tasks = []
-            for x in range(0,int(args.numRunners)):
-                tasks.append(asyncio.create_task(book_offerses(args.ip, args.port,int(args.ledger),books, int(args.numCalls))))
+            for x in range(0, int(args.numRunners)):
+                tasks.append(asyncio.create_task(book_offerses(args.ip, args.port, int(args.ledger), books, int(args.numCalls))))
             for t in tasks:
                 await t
 


### PR DESCRIPTION
Fixes #284

- Ported `book_changes` rpc call from `rippled`.
- Implemented `book_changes` support in `test.py`

To try you can execute something like this: `./test.py --ip 127.0.0.1 --port 51233 --ledger 74256240 book_changes`
Example output:
```
{
    "result": {
        "changes": [
            {
                "close": "9240",
                "currency_a": "XRP_drops",
                "currency_b": "raq7pGaYrLZRa88v6Py9V5oWMYEqPYr8Tz/5377697373546563680000000000000000000000",
                "high": "9240",
                "low": "9199.998196515558",
                "open": "9200",
                "volume_a": "96285669",
                "volume_b": "10444.094543578"
            },
            {
                "close": "379325.64751315",
                "currency_a": "XRP_drops",
                "currency_b": "rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz/534F4C4F00000000000000000000000000000000",
                "high": "379325.64751315",
                "low": "379325.64751315",
                "open": "379325.64751315",
                "volume_a": "113941838",
                "volume_b": "300.38"
            }
        ],
        "ledger_hash": "F4FC90CC918C4E4EC33A015CE39603D83CBB44A7E97EE06DAA5CFAC8B835CD1F",
        "ledger_index": 74256240,
        "ledger_time": 715968871,
        "type": "bookChanges",
        "validated": true
    },
    "status": "success",
    "type": "response",
    "warnings": [
        {
            "id": 2001,
            "message": "This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"
        }
    ]
}
```

> Please note: despite the `warning` suggesting to set `ledger_index` to `current` - this will not work as this call is not forwarding to `rippled` but rather uses `clio`'s local database.

There is also currently no unit-tests for this. We should add it at some point when we have refactored for testability.