### PR TITLE
Throw error if server bind or listen fails

### DIFF
--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -241,7 +241,8 @@ public:
         if (ec)
         {
             BOOST_LOG_TRIVIAL(error)
-                << "Failed to bind to endpoint: " << endpoint;
+                << "Failed to bind to endpoint: " << endpoint
+                << ". message: " << ec.message();
             throw std::runtime_error("Failed to bind to specified endpoint");
         }
 
@@ -250,7 +251,8 @@ public:
         if (ec)
         {
             BOOST_LOG_TRIVIAL(error)
-                << "Failed to listen at endpoint: " << endpoint;
+                << "Failed to listen at endpoint: " << endpoint
+                << ". message: " << ec.message();
             throw std::runtime_error("Failed to listen at specified endpoint");
         }
     }

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -239,12 +239,20 @@ public:
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if (ec)
-            return;
+        {
+            BOOST_LOG_TRIVIAL(error)
+                << "Failed to bind to endpoint: " << endpoint;
+            throw std::runtime_error("Failed to bind to specified endpoint");
+        }
 
         // Start listening for connections
         acceptor_.listen(net::socket_base::max_listen_connections, ec);
         if (ec)
-            return;
+        {
+            BOOST_LOG_TRIVIAL(error)
+                << "Failed to listen at endpoint: " << endpoint;
+            throw std::runtime_error("Failed to listen at specified endpoint");
+        }
     }
 
     // Start accepting incoming connections


### PR DESCRIPTION
Previously, if the server failed to bind to the specified endpoint, it would continue to run, but not handle any requests. Now, the server will fail to start if it can't bind.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/309)
<!-- Reviewable:end -->
