### PR TITLE
Make NFT URI lookup O(1)

### DIFF
--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -655,6 +655,8 @@ private:
     CassandraPreparedStatement insertNFT_;
     CassandraPreparedStatement selectNFT_;
     CassandraPreparedStatement insertIssuerNFT_;
+    CassandraPreparedStatement insertNFTURI_;
+    CassandraPreparedStatement selectNFTURI_;
     CassandraPreparedStatement insertNFTTx_;
     CassandraPreparedStatement selectNFTTx_;
     CassandraPreparedStatement selectNFTTxForward_;

--- a/src/backend/Types.h
+++ b/src/backend/Types.h
@@ -83,6 +83,7 @@ struct NFT
     ripple::uint256 tokenID;
     std::uint32_t ledgerSequence;
     ripple::AccountID owner;
+    Blob uri;
     bool isBurned;
 
     // clearly two tokens are the same if they have the same ID, but this

--- a/src/etl/ETLSource.cpp
+++ b/src/etl/ETLSource.cpp
@@ -27,6 +27,7 @@
 
 #include <backend/DBHelpers.h>
 #include <etl/ETLSource.h>
+#include <etl/NFTHelpers.h>
 #include <etl/ProbingETLSource.h>
 #include <etl/ReportingETL.h>
 #include <log/Logger.h>
@@ -680,6 +681,8 @@ public:
                         request_.ledger().sequence(),
                         std::string{obj.key()});
                 lastKey_ = obj.key();
+                backend.writeNFTs(getNFTDataFromObj(
+                    request_.ledger().sequence(), obj.key(), obj.data()));
                 backend.writeLedgerObject(
                     std::move(*obj.mutable_key()),
                     request_.ledger().sequence(),

--- a/src/etl/NFTHelpers.cpp
+++ b/src/etl/NFTHelpers.cpp
@@ -17,7 +17,6 @@
 */
 //==============================================================================
 
-#include <ripple/app/tx/impl/details/NFTokenUtils.h>
 #include <ripple/protocol/STBase.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/TxMeta.h>
@@ -123,7 +122,11 @@ getNFTokenMintData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
         return {
             {NFTTransactionsData(
                 tokenIDResult.front(), txMeta, sttx.getTransactionID())},
-            NFTsData(tokenIDResult.front(), *owner, txMeta, false)};
+            NFTsData(
+                tokenIDResult.front(),
+                *owner,
+                sttx.getFieldVL(ripple::sfURI),
+                txMeta)};
 
     std::stringstream msg;
     msg << " - unexpected NFTokenMint data in tx " << sttx.getTransactionID();
@@ -150,11 +153,11 @@ getNFTokenBurnData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
         // NFT burn can result in an NFTokenPage being modified to no longer
         // include the target, or an NFTokenPage being deleted. If this is
         // modified, we want to look for the target in the fields prior to
-        // modification. If deleted, it's possible that the page was modified
-        // to remove the target NFT prior to the entire page being deleted. In
-        // this case, we need to look in the PreviousFields. Otherwise, the
-        // page was not modified prior to deleting and we need to look in the
-        // FinalFields.
+        // modification. If deleted, it's possible that the page was
+        // modified to remove the target NFT prior to the entire page being
+        // deleted. In this case, we need to look in the PreviousFields.
+        // Otherwise, the page was not modified prior to deleting and we
+        // need to look in the FinalFields.
         std::optional<ripple::STArray> prevNFTs;
 
         if (node.isFieldPresent(ripple::sfPreviousFields))
@@ -360,7 +363,7 @@ getNFTokenCreateOfferData(
 }
 
 std::pair<std::vector<NFTTransactionsData>, std::optional<NFTsData>>
-getNFTData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
+getNFTDataFromTx(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
 {
     if (txMeta.getResultTER() != ripple::tesSUCCESS)
         return {{}, {}};
@@ -385,4 +388,29 @@ getNFTData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
         default:
             return {{}, {}};
     }
+}
+
+std::vector<NFTsData>
+getNFTDataFromObj(
+    std::uint32_t const seq,
+    std::string const& key,
+    std::string const& blob)
+{
+    std::vector<NFTsData> nfts;
+    ripple::STLedgerEntry const sle = ripple::STLedgerEntry(
+        ripple::SerialIter{blob.data(), blob.size()},
+        ripple::uint256::fromVoid(key.data()));
+
+    if (sle.getFieldU16(ripple::sfLedgerEntryType) != ripple::ltNFTOKEN_PAGE)
+        return nfts;
+
+    auto const owner = ripple::AccountID::fromVoid(key.data());
+    for (ripple::STObject const& node : sle.getFieldArray(ripple::sfNFTokens))
+        nfts.emplace_back(
+            node.getFieldH256(ripple::sfNFTokenID),
+            seq,
+            owner,
+            node.getFieldVL(ripple::sfURI));
+
+    return nfts;
 }

--- a/src/etl/NFTHelpers.h
+++ b/src/etl/NFTHelpers.h
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <backend/DBHelpers.h>
+
+#include <ripple/protocol/STTx.h>
+#include <ripple/protocol/TxMeta.h>
+
+// Pulling from tx via ReportingETL
+std::pair<std::vector<NFTTransactionsData>, std::optional<NFTsData>>
+getNFTDataFromTx(ripple::TxMeta const& txMeta, ripple::STTx const& sttx);
+
+// Pulling from ledger object via loadInitialLedger
+std::vector<NFTsData>
+getNFTDataFromObj(
+    std::uint32_t const seq,
+    std::string const& key,
+    std::string const& blob);

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -21,6 +21,8 @@
 #include <ripple/beast/core/CurrentThreadName.h>
 
 #include <backend/DBHelpers.h>
+
+#include <etl/NFTHelpers.h>
 #include <etl/ReportingETL.h>
 #include <log/Logger.h>
 #include <subscriptions/SubscriptionManager.h>
@@ -73,7 +75,7 @@ ReportingETL::insertTransactions(
         ripple::TxMeta txMeta{
             sttx.getTransactionID(), ledger.seq, txn.metadata_blob()};
 
-        auto const [nftTxs, maybeNFT] = getNFTData(txMeta, sttx);
+        auto const [nftTxs, maybeNFT] = getNFTDataFromTx(txMeta, sttx);
         result.nfTokenTxData.insert(
             result.nfTokenTxData.end(), nftTxs.begin(), nftTxs.end());
         if (maybeNFT)

--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -38,13 +38,6 @@
 
 #include <chrono>
 
-/**
- * Helper function for the ReportingETL, implemented in NFTHelpers.cpp, to
- * pull to-write data out of a transaction that relates to NFTs.
- */
-std::pair<std::vector<NFTTransactionsData>, std::optional<NFTsData>>
-getNFTData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx);
-
 struct AccountTransactionsData;
 struct NFTTransactionsData;
 struct NFTsData;

--- a/src/rpc/handlers/NFTInfo.cpp
+++ b/src/rpc/handlers/NFTInfo.cpp
@@ -24,89 +24,12 @@
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
 
-// {
-//   nft_id: <ident>
-//   ledger_hash: <ledger>
-//   ledger_index: <ledger_index>
-// }
-
 namespace RPC {
-
-std::variant<std::monostate, std::string, Status>
-getURI(Backend::NFT const& dbResponse, Context const& context)
-{
-    // Fetch URI from ledger
-    // The correct page will be > bookmark and <= last. We need to calculate
-    // the first possible page however, since bookmark is not guaranteed to
-    // exist.
-    auto const bookmark = ripple::keylet::nftpage(
-        ripple::keylet::nftpage_min(dbResponse.owner), dbResponse.tokenID);
-    auto const last = ripple::keylet::nftpage_max(dbResponse.owner);
-
-    ripple::uint256 nextKey = last.key;
-    std::optional<ripple::STLedgerEntry> sle;
-
-    // when this loop terminates, `sle` will contain the correct page for
-    // this NFT.
-    //
-    // 1) We start at the last NFTokenPage, which is guaranteed to exist,
-    // grab the object from the DB and deserialize it.
-    //
-    // 2) If that NFTokenPage has a PreviousPageMin value and the
-    // PreviousPageMin value is > bookmark, restart loop. Otherwise
-    // terminate and use the `sle` from this iteration.
-    do
-    {
-        auto const blob = context.backend->fetchLedgerObject(
-            ripple::Keylet(ripple::ltNFTOKEN_PAGE, nextKey).key,
-            dbResponse.ledgerSequence,
-            context.yield);
-
-        if (!blob || blob->size() == 0)
-            return Status{
-                RippledError::rpcINTERNAL,
-                "Cannot find NFTokenPage for this NFT"};
-
-        sle = ripple::STLedgerEntry(
-            ripple::SerialIter{blob->data(), blob->size()}, nextKey);
-
-        if (sle->isFieldPresent(ripple::sfPreviousPageMin))
-            nextKey = sle->getFieldH256(ripple::sfPreviousPageMin);
-
-    } while (sle && sle->key() != nextKey && nextKey > bookmark.key);
-
-    if (!sle)
-        return Status{
-            RippledError::rpcINTERNAL, "Cannot find NFTokenPage for this NFT"};
-
-    auto const nfts = sle->getFieldArray(ripple::sfNFTokens);
-    auto const nft = std::find_if(
-        nfts.begin(),
-        nfts.end(),
-        [&dbResponse](ripple::STObject const& candidate) {
-            return candidate.getFieldH256(ripple::sfNFTokenID) ==
-                dbResponse.tokenID;
-        });
-
-    if (nft == nfts.end())
-        return Status{
-            RippledError::rpcINTERNAL, "Cannot find NFTokenPage for this NFT"};
-
-    ripple::Blob const uriField = nft->getFieldVL(ripple::sfURI);
-
-    // NOTE this cannot use a ternary or value_or because then the
-    // expression's type is unclear. We want to explicitly set the `uri`
-    // field to null when not present to avoid any confusion.
-    if (std::string const uri = std::string(uriField.begin(), uriField.end());
-        uri.size() > 0)
-        return uri;
-    return std::monostate{};
-}
 
 Result
 doNFTInfo(Context const& context)
 {
-    auto request = context.params;
+    auto const request = context.params;
     boost::json::object response = {};
 
     auto const maybeTokenID = getNFTID(request);
@@ -115,41 +38,29 @@ doNFTInfo(Context const& context)
     auto const tokenID = std::get<ripple::uint256>(maybeTokenID);
 
     auto const maybeLedgerInfo = ledgerInfoFromRequest(context);
-    if (auto status = std::get_if<Status>(&maybeLedgerInfo); status)
+    if (auto const status = std::get_if<Status>(&maybeLedgerInfo); status)
         return *status;
     auto const lgrInfo = std::get<ripple::LedgerInfo>(maybeLedgerInfo);
 
-    std::optional<Backend::NFT> dbResponse =
+    auto const dbResponse =
         context.backend->fetchNFT(tokenID, lgrInfo.seq, context.yield);
     if (!dbResponse)
         return Status{RippledError::rpcOBJECT_NOT_FOUND, "NFT not found"};
 
-    response["nft_id"] = ripple::strHex(dbResponse->tokenID);
-    response["ledger_index"] = dbResponse->ledgerSequence;
-    response["owner"] = ripple::toBase58(dbResponse->owner);
+    response[JS(nft_id)] = ripple::strHex(dbResponse->tokenID);
+    response[JS(ledger_index)] = dbResponse->ledgerSequence;
+    response[JS(owner)] = ripple::toBase58(dbResponse->owner);
     response["is_burned"] = dbResponse->isBurned;
+    response[JS(uri)] = ripple::strHex(dbResponse->uri);
 
-    response["flags"] = ripple::nft::getFlags(dbResponse->tokenID);
-    response["transfer_fee"] = ripple::nft::getTransferFee(dbResponse->tokenID);
-    response["issuer"] =
+    response[JS(flags)] = ripple::nft::getFlags(dbResponse->tokenID);
+    response["transfer_rate"] =
+        ripple::nft::getTransferFee(dbResponse->tokenID);
+    response[JS(issuer)] =
         ripple::toBase58(ripple::nft::getIssuer(dbResponse->tokenID));
     response["nft_taxon"] =
         ripple::nft::toUInt32(ripple::nft::getTaxon(dbResponse->tokenID));
-    response["nft_sequence"] = ripple::nft::getSerial(dbResponse->tokenID);
-
-    if (!dbResponse->isBurned)
-    {
-        auto const maybeURI = getURI(*dbResponse, context);
-        // An error occurred
-        if (Status const* status = std::get_if<Status>(&maybeURI); status)
-            return *status;
-        // A URI was found
-        if (std::string const* uri = std::get_if<std::string>(&maybeURI); uri)
-            response["uri"] = *uri;
-        // A URI was not found, explicitly set to null
-        else
-            response["uri"] = nullptr;
-    }
+    response[JS(nft_serial)] = ripple::nft::getSerial(dbResponse->tokenID);
 
     return response;
 }

--- a/unittests/Backend.cpp
+++ b/unittests/Backend.cpp
@@ -21,6 +21,7 @@
 #include <backend/BackendInterface.h>
 #include <backend/DBHelpers.h>
 #include <config/Config.h>
+#include <etl/NFTHelpers.h>
 #include <etl/ReportingETL.h>
 #include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
@@ -461,7 +462,7 @@ TEST_F(BackendTest, Basic)
                     ripple::SerialIter it{nftTxnBlob.data(), nftTxnBlob.size()};
                     ripple::STTx sttx{it};
                     auto const [parsedNFTTxsRef, parsedNFT] =
-                        getNFTData(nftTxMeta, sttx);
+                        getNFTDataFromTx(nftTxMeta, sttx);
                     // need to copy the nft txns so we can std::move later
                     std::vector<NFTTransactionsData> parsedNFTTxs;
                     parsedNFTTxs.insert(


### PR DESCRIPTION
* In cassandra, adds `nf_token_uris` table that maps an NFT ID to its URI. This table is _NOT_ sparse. Because of the re-minting of NFTs edge case, we have to:
  * Include a sequence number in this table
  * Write an empty URI if a token is minted without one, because it could have previously been minted with a different URI :(
  * (But, there should only be one row written to the table for each NFT, except in the case of a re-mint in which case you'll get another, and so on. So number of rows is as small as we can make it)
* Refactors NFT lookup code such that we hit this new table. This means that looking up an NFT is now O(1), whereas before it was O(n) where is is the number of NFTokenPages owned by the account that currently owns the NFT in question.
* Replaces the `issuer_nf_tokens` table with the `issuer_nf_tokens_v2` table. The new one also stores the taxon and includes it as part of a composite key. This new table will be used for the upcoming `issuer_nfts` RPC call to filter on issuer/taxon combo. NOTE - the old `issuer_nf_tokens` table was being written to, but not yet serving any data, so it is totally safe to delete this table.
* Refactors NFT writing such that the `issuer_nf_tokens_v2` table is only ever written to when there is a net new token. Ditto with the new `nf_token_uris`. Previously, the `issuer_nf_tokens` table would be clobbered with the same data. This never would have resulted in bad data, but would result in unnecessary writes.
* Adds logic to load the various NFT states when reading from a ledger instead of transaction-by-transaction. This allows us to accomplish all of the above without serving bad data. That is, when loading the initial ledger we now pull in all the NFT data form that ledger.


_NOTE_ - when we deploy this to an environment with existing data, the following needs to happen:

* Stop allowing incoming users requests to the clio instance. You can use another running instance of clio on the old version to continue serving requests.
* Upgrade clio to this version and restart. This will create all the new tables.
* To migrate existing data, run the utility [here](https://github.com/ledhed2222/clio_migrator) to migrate existing data. This tool _can_ be run while simultaneously writing new ledgers using clio.
* Once this migration is complete, you can resume serving requests.


_NOTE_ - this pr _technically_ has breaking changes to the `nft_info` API call:

1) the returned `uri` field is no longer hex decoded
2) the returned `nft_sequence` field is renamed `nft_serial` to match rippled `account_nfts`
3) the returned `transfer_fee` field is renamed `transfer_rate`
4) the returned `uri` field is no longer null when empty, but an empty string
5) `nft_info` can raise a new error if clio doesn't know the URI for the requested NFT. This should not happen unless there is a really unexpected race condition, in which case just trying the request again will work.


_NOTES_ on performance improvements:

nft_info API on standalone with 1 account that has 100K NFTs (to simulate worst cases)

Old Code (63872 requests):
    Worst Case: 10664 ms
    Best Case: 2 ms
    Average: 2983 ms
    Median: 2376 ms
New Code (99892 requests):
   Worst Case: 25 ms
   Best Case: 1 ms
   Average: 3 ms
   Median: 2 ms
In other words - it’s about 3 orders of magnitude  faster on average

----

Anecdotally with specific production examples:

Previously 000A1AF4DBDE606E6D2819D1E99AB9B086ABF7B01ABFFCF51320BAA100001849 at index 75471206 took 194ms

Now the same request takes 2ms.