### PR TITLE
Mark package release's version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT GIT_COMMIT_HASH)
   endif()
   find_package(Git)
   if(Git_FOUND)
-      execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=8
+      execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
           OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE gch)
       if(gch)
           set(GIT_COMMIT_HASH "${gch}")
@@ -29,6 +29,10 @@ if(NOT GIT_COMMIT_HASH)
       endif()
   endif()
 endif() #git
+if(PACKAGING)
+  add_definitions(-DPKG=1)
+endif()
+
 
 add_library(clio)
 target_compile_features(clio PUBLIC cxx_std_20)

--- a/src/main/impl/Build.cpp
+++ b/src/main/impl/Build.cpp
@@ -32,6 +32,9 @@ char const* const versionString = "1.0.2"
     BOOST_PP_STRINGIZE(SANITIZER)
 #endif
 #endif
+#ifdef PKG
+        "-release"
+#endif
 
     //--------------------------------------------------------------------------
     ;


### PR DESCRIPTION
When Clio is packaged, `-release` is appended to version string. This will just make it obvious if a server if from a package.
If the executable is from a release, you can already know which git commit it was built from.
Built in debug mode, the git commit is part of the version string.
Another issue is actually building `Release` mode but that's another issue altogether that also affects rippled.