### PR TITLE
Add function to fetch NFTokenIDs from issuer_nf_tokens

### DIFF
--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -190,7 +190,7 @@ public:
     virtual std::optional<IssuerNFTs>
     fetchIssuerNFTs(
         ripple::AccountID const& issuer,
-        ripple::uint256 const& cursor,
+        std::optional<ripple::uint256> const& cursor,
         std::uint32_t const limit,
         boost::asio::yield_context& yield) const = 0;
 

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -188,7 +188,7 @@ public:
         boost::asio::yield_context& yield) const = 0;
 
     virtual std::optional<IssuerNFTs>
-    fetchIssuerNFT(
+    fetchIssuerNFTs(
         ripple::AccountID const& issuer,
         ripple::uint256 const& cursor,
         std::uint32_t const limit,

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -187,6 +187,13 @@ public:
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const = 0;
 
+    virtual std::optional<IssuerNFTs>
+    fetchIssuerNFT(
+        ripple::AccountID const& issuer,
+        ripple::uint256 const& cursor,
+        std::uint32_t const limit,
+        boost::asio::yield_context& yield) const = 0;
+
     virtual TransactionsAndCursor
     fetchNFTTransactions(
         ripple::uint256 const& tokenID,

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -591,13 +591,16 @@ CassandraBackend::fetchNFT(
 std::optional<IssuerNFTs>
 CassandraBackend::fetchIssuerNFTs(
     ripple::AccountID const& issuer,
-    ripple::uint256 const& cursorIn,
+    std::optional<ripple::uint256> const& cursorIn,
     std::uint32_t const limit,
     boost::asio::yield_context& yield) const
 {
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
-    statement.bindNextBytes(cursorIn);
+    if(cursorIn)
+        statement.bindNextBytes(cursorIn);
+    else
+        statement.bindNextBytes(0);
     statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
     if (!response)

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -589,7 +589,7 @@ CassandraBackend::fetchNFT(
 }
 
 std::optional<IssuerNFTs>
-CassandraBackend::fetchIssuerNFT(
+CassandraBackend::fetchIssuerNFTs(
     ripple::AccountID const& issuer,
     ripple::uint256 const& cursor,
     std::uint32_t const limit,
@@ -618,7 +618,7 @@ CassandraBackend::fetchIssuerNFT(
 
     if(hasCursor)
         return {issuer, nf_tokens, cursor};
-    return {issuer, nf_tokens, {}}
+    return {issuer, nf_tokens, {}};
 }
 
 

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -597,12 +597,12 @@ CassandraBackend::fetchIssuerNFTs(
 {
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
+
     if(cursorIn)
         statement.bindNextBytes(cursorIn.value());
     else
          statement.bindNextBytes(static_cast<ripple::uint256>(0));
    
-  
     statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
     if (!response)

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -595,9 +595,6 @@ CassandraBackend::fetchIssuerNFTs(
     std::uint32_t const limit,
     boost::asio::yield_context& yield) const
 {
-
-      BOOST_LOG_TRIVIAL(debug) << __func__    <<" issuer testtttttttttttttttttttttttttttt";
-            BOOST_LOG_TRIVIAL(debug) << __func__    << "curssorrrrrrrrrrrrrrr "<<  ripple::strHex(cursorIn.value());
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
 
@@ -608,13 +605,11 @@ CassandraBackend::fetchIssuerNFTs(
    
     statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
-      BOOST_LOG_TRIVIAL(debug) << __func__    << "DEBUGGGGGGGG POINTTTTTTTTTTTTTTTT";
     if (!response)
         return {};
 
     auto cursor = cursorIn;
     auto numRows = response.numRows();
-     BOOST_LOG_TRIVIAL(debug) << __func__    <<" NUMMMMMMMMM ROWWWWWWWWWWWWS "<< numRows;
     auto hasCursor = (limit + 1 == static_cast<std::uint32_t>(numRows)) ? true : false;
     std::vector<ripple::uint256> nf_tokens = {};
     do
@@ -1601,14 +1596,6 @@ CassandraBackend::open(bool readOnly)
               << " LIMIT ?";
         if (!selectIssuerNFT_.prepareStatement(query, session_.get()))
             continue;
-        // query.str("");
-        // query << "SELECT token_id"
-        //       << " FROM " << tablePrefix << "issuer_nf_tokens WHERE"
-        //       << " issuer = ? "
-        //         << " ORDER BY token_id ASC"
-        //         << " LIMIT ?";
-        // if (!selectIssuerNFT_.prepareStatement(query, session_.get()))
-        //     continue;
 
         query.str("");
         query << "INSERT INTO " << tablePrefix << "nf_token_transactions"

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -600,7 +600,9 @@ CassandraBackend::fetchIssuerNFTs(
     if(cursorIn)
         statement.bindNextBytes(cursorIn.value());
     else
-        statement.bindNextBytes(0);
+         statement.bindNextBytes(static_cast<ripple::uint256>(0));
+   
+  
     statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
     if (!response)

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -598,7 +598,7 @@ CassandraBackend::fetchIssuerNFTs(
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
     if(cursorIn)
-        statement.bindNextBytes(cursorIn);
+        statement.bindNextBytes(cursorIn.value());
     else
         statement.bindNextBytes(0);
     statement.bindNextUInt(limit + 1);

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -595,6 +595,9 @@ CassandraBackend::fetchIssuerNFTs(
     std::uint32_t const limit,
     boost::asio::yield_context& yield) const
 {
+
+      BOOST_LOG_TRIVIAL(debug) << __func__    <<" issuer testtttttttttttttttttttttttttttt";
+            BOOST_LOG_TRIVIAL(debug) << __func__    << "curssorrrrrrrrrrrrrrr "<<  ripple::strHex(cursorIn.value());
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
 
@@ -605,21 +608,22 @@ CassandraBackend::fetchIssuerNFTs(
    
     statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
+      BOOST_LOG_TRIVIAL(debug) << __func__    << "DEBUGGGGGGGG POINTTTTTTTTTTTTTTTT";
     if (!response)
         return {};
 
     auto cursor = cursorIn;
     auto numRows = response.numRows();
+     BOOST_LOG_TRIVIAL(debug) << __func__    <<" NUMMMMMMMMM ROWWWWWWWWWWWWS "<< numRows;
     auto hasCursor = (limit + 1 == static_cast<std::uint32_t>(numRows)) ? true : false;
     std::vector<ripple::uint256> nf_tokens = {};
     do
     {
         ripple::uint256 const nf_token = response.getUInt256();
-        nf_tokens.push_back(nf_token);
         if (hasCursor && --numRows == 0)
-        {
             cursor = nf_token;
-        }
+        else
+            nf_tokens.push_back(nf_token);
     } while (response.nextRow());
 
     IssuerNFTs result;
@@ -1597,6 +1601,14 @@ CassandraBackend::open(bool readOnly)
               << " LIMIT ?";
         if (!selectIssuerNFT_.prepareStatement(query, session_.get()))
             continue;
+        // query.str("");
+        // query << "SELECT token_id"
+        //       << " FROM " << tablePrefix << "issuer_nf_tokens WHERE"
+        //       << " issuer = ? "
+        //         << " ORDER BY token_id ASC"
+        //         << " LIMIT ?";
+        // if (!selectIssuerNFT_.prepareStatement(query, session_.get()))
+        //     continue;
 
         query.str("");
         query << "INSERT INTO " << tablePrefix << "nf_token_transactions"

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -598,7 +598,7 @@ CassandraBackend::fetchIssuerNFT(
     CassandraStatement statement{selectIssuerNFT_};
     statement.bindNextBytes(issuer);
     statement.bindNextBytes(cursor);
-    statement.bindNextUInt(limit);
+    statement.bindNextUInt(limit + 1);
     CassandraResult response = executeAsyncRead(statement, yield);
     if (!response)
         return {};

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -626,7 +626,6 @@ CassandraBackend::fetchIssuerNFTs(
     return result;
 }
 
-
 TransactionsAndCursor
 CassandraBackend::fetchNFTTransactions(
     ripple::uint256 const& tokenID,

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -892,6 +892,13 @@ public:
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
 
+    std::optional<IssuerNFTs>
+    fetchIssuerNFTs(
+        ripple::AccountID const& issuer,
+        ripple::uint256 const& cursor,
+        std::uint32_t const limit,
+        boost::asio::yield_context& yield) const override;
+
     TransactionsAndCursor
     fetchNFTTransactions(
         ripple::uint256 const& tokenID,

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -629,6 +629,7 @@ private:
     CassandraPreparedStatement insertNFT_;
     CassandraPreparedStatement selectNFT_;
     CassandraPreparedStatement insertIssuerNFT_;
+    CassandraPreparedStatement selectIssuerNFT_;
     CassandraPreparedStatement insertNFTTx_;
     CassandraPreparedStatement selectNFTTx_;
     CassandraPreparedStatement selectNFTTxForward_;

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -895,7 +895,7 @@ public:
     std::optional<IssuerNFTs>
     fetchIssuerNFTs(
         ripple::AccountID const& issuer,
-        ripple::uint256 const& cursor,
+        std::optional<ripple::uint256> const& cursor,
         std::uint32_t const limit,
         boost::asio::yield_context& yield) const override;
 

--- a/src/backend/PostgresBackend.cpp
+++ b/src/backend/PostgresBackend.cpp
@@ -444,7 +444,7 @@ PostgresBackend::fetchNFT(
 std::optional<IssuerNFTs>
 PostgresBackend::fetchIssuerNFTs(
     ripple::AccountID const& issuer,
-    ripple::uint256 const& cursor,
+    std::optional<ripple::uint256> const& cursor,
     std::uint32_t const limit,
     boost::asio::yield_context& yield) const
 {

--- a/src/backend/PostgresBackend.cpp
+++ b/src/backend/PostgresBackend.cpp
@@ -441,6 +441,16 @@ PostgresBackend::fetchNFT(
     throw std::runtime_error("Not implemented");
 }
 
+std::optional<IssuerNFTs>
+PostgresBackend::fetchIssuerNFTs(
+    ripple::AccountID const& issuer,
+    ripple::uint256 const& cursor,
+    std::uint32_t const limit,
+    boost::asio::yield_context& yield) const
+{
+    throw std::runtime_error("Not implemented");
+}
+
 std::optional<ripple::uint256>
 PostgresBackend::doFetchSuccessorKey(
     ripple::uint256 key,

--- a/src/backend/PostgresBackend.h
+++ b/src/backend/PostgresBackend.h
@@ -67,6 +67,13 @@ public:
         ripple::uint256 const& tokenID,
         std::uint32_t const ledgerSequence,
         boost::asio::yield_context& yield) const override;
+        
+    std::optional<IssuerNFTs>
+    fetchIssuerNFTs(
+        ripple::AccountID const& issuer,
+        ripple::uint256 const& cursor,
+        std::uint32_t const limit,
+        boost::asio::yield_context& yield) const override;
 
     TransactionsAndCursor
     fetchNFTTransactions(

--- a/src/backend/PostgresBackend.h
+++ b/src/backend/PostgresBackend.h
@@ -71,7 +71,7 @@ public:
     std::optional<IssuerNFTs>
     fetchIssuerNFTs(
         ripple::AccountID const& issuer,
-        ripple::uint256 const& cursor,
+        std::optional<ripple::uint256> const& cursor,
         std::uint32_t const limit,
         boost::asio::yield_context& yield) const override;
 

--- a/src/backend/Types.h
+++ b/src/backend/Types.h
@@ -82,7 +82,7 @@ struct IssuerNFTs
     ripple::AccountID issuer;
     std::vector<ripple::uint256> nf_tokens;
     std::optional<ripple::uint256> cursor;
-}
+};
 
 struct LedgerRange
 {

--- a/src/backend/Types.h
+++ b/src/backend/Types.h
@@ -77,6 +77,13 @@ struct NFT
     }
 };
 
+struct IssuerNFTs
+{
+    ripple::AccountID issuer;
+    std::vector<ripple::uint256> nf_tokens;
+    std::optional<ripple::uint256> cursor;
+}
+
 struct LedgerRange
 {
     std::uint32_t minSequence;


### PR DESCRIPTION
This PR fetches the list of NFTokenIDs that an account has issued. An extra record is always fetched to be used as the marker, which will be used in the next fetch.