### PR TITLE
add work queue output to server_info

### DIFF
--- a/src/rpc/Counters.cpp
+++ b/src/rpc/Counters.cpp
@@ -1,5 +1,6 @@
 #include <rpc/Counters.h>
 #include <rpc/RPC.h>
+#include <rpc/RPCHelpers.h>
 
 namespace RPC {
 
@@ -66,6 +67,8 @@ Counters::report()
 {
     std::shared_lock lk(mutex_);
     boost::json::object obj = {};
+    obj[JS(rpc)] = boost::json::object{};
+    auto& rpc = obj[JS(rpc)].as_object();
 
     for (auto const& [method, info] : methodInfo_)
     {
@@ -76,8 +79,9 @@ Counters::report()
         counters["forwarded"] = std::to_string(info.forwarded);
         counters["duration_us"] = std::to_string(info.duration);
 
-        obj[method] = std::move(counters);
+        rpc[method] = std::move(counters);
     }
+    obj["work_queue"] = workQueue_.get().report();
 
     return obj;
 }

--- a/src/rpc/Counters.cpp
+++ b/src/rpc/Counters.cpp
@@ -73,11 +73,11 @@ Counters::report()
     for (auto const& [method, info] : methodInfo_)
     {
         boost::json::object counters = {};
-        counters["started"] = std::to_string(info.started);
-        counters["finished"] = std::to_string(info.finished);
-        counters["errored"] = std::to_string(info.errored);
+        counters[JS(started)] = std::to_string(info.started);
+        counters[JS(finished)] = std::to_string(info.finished);
+        counters[JS(errored)] = std::to_string(info.errored);
         counters["forwarded"] = std::to_string(info.forwarded);
-        counters["duration_us"] = std::to_string(info.duration);
+        counters[JS(duration_us)] = std::to_string(info.duration);
 
         rpc[method] = std::move(counters);
     }

--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -4,6 +4,8 @@
 #include <boost/json.hpp>
 #include <chrono>
 #include <cstdint>
+#include <functional>
+#include <rpc/WorkQueue.h>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -30,8 +32,10 @@ private:
     std::shared_mutex mutex_;
     std::unordered_map<std::string, MethodInfo> methodInfo_;
 
+    std::reference_wrapper<const WorkQueue> workQueue_;
+
 public:
-    Counters() = default;
+    Counters(WorkQueue const& wq) : workQueue_(std::cref(wq)){};
 
     void
     rpcErrored(std::string const& method);

--- a/src/rpc/WorkQueue.h
+++ b/src/rpc/WorkQueue.h
@@ -60,9 +60,8 @@ public:
         return true;
     }
 
-    // TODO: this is not actually being called. Wait for application refactor
     boost::json::object
-    report()
+    report() const
     {
         boost::json::object obj;
         obj["queued"] = queued_;

--- a/src/rpc/handlers/ServerInfo.cpp
+++ b/src/rpc/handlers/ServerInfo.cpp
@@ -47,8 +47,7 @@ doServerInfo(Context const& context)
 
     if (admin)
     {
-        info[JS(counters)] = boost::json::object{};
-        info[JS(counters)].as_object() = context.counters.report();
+        info[JS(counters)] = context.counters.report();
         info[JS(counters)].as_object()["subscriptions"] =
             context.subscriptions->report();
     }

--- a/src/rpc/handlers/ServerInfo.cpp
+++ b/src/rpc/handlers/ServerInfo.cpp
@@ -48,7 +48,7 @@ doServerInfo(Context const& context)
     if (admin)
     {
         info[JS(counters)] = boost::json::object{};
-        info[JS(counters)].as_object()[JS(rpc)] = context.counters.report();
+        info[JS(counters)].as_object() = context.counters.report();
         info[JS(counters)].as_object()["subscriptions"] =
             context.subscriptions->report();
     }

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -223,6 +223,7 @@ public:
         , etl_(etl)
         , dosGuard_(dosGuard)
         , queue_(numWorkerThreads, maxQueueSize)
+        , counters_(queue_)
     {
         boost::beast::error_code ec;
 


### PR DESCRIPTION
Previously, the length of the work queue was not in server_info. This made it impossible to monitor. The length of the work queue is a crucial metric that signals when the server is under heavy load. This change puts the work queue info in server_info.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/322)
<!-- Reviewable:end -->
