### PR TITLE
Make ProbingETL toJson serialize underlying source states while disconnected or probing

### DIFF
--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -69,7 +69,16 @@ boost::json::object
 ProbingETLSource::toJson() const
 {
     if (!currentSrc_)
-        return {};
+    {
+        boost::json::object sourcesJson = {
+            {"ws", plainSrc_->toJson()},
+            {"wss", sslSrc_->toJson()},
+        };
+
+        return {
+            {"probing", sourcesJson},
+        };
+    }
     return currentSrc_->toJson();
 }
 


### PR DESCRIPTION
Fixes #323 

ProbingETL source's `toJson` will now dump its underlying two sources whenever probing is ongoing (no source have connected yet or both are disconnected atm.).

Sample output:
```
                "etl_sources": [
                    {
                        "probing": {
                            "ws": {
                                "grpc_port": "50051",
                                "ip": "127.0.0.1",
                                "is_connected": "0",
                                "last_msg_age_seconds": "41",
                                "validated_range": "",
                                "ws_port": "6006"
                            },
                            "wss": {
                                "grpc_port": "50051",
                                "ip": "127.0.0.1",
                                "is_connected": "0",
                                "validated_range": "",
                                "ws_port": "6006"
                            }
                        }
                    }
                ],
```

When probing succeeds and a source is selected, the output of `toJson` is as before:
```
                "etl_sources": [
                    {
                        "grpc_port": "50051",
                        "ip": "127.0.0.1",
                        "is_connected": "1",
                        "last_msg_age_seconds": "0",
                        "validated_range": "",
                        "ws_port": "6006"
                    }
                ],
```