### PR TITLE
Remove useless mutex from BackendInterface and its usage

### DIFF
--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -89,9 +89,6 @@ protected:
     std::optional<LedgerRange> range;
     SimpleCache cache_;
 
-    // mutex used for open() and close()
-    mutable std::mutex mutex_;
-
 public:
     BackendInterface(boost::json::object const& config)
     {

--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -1001,7 +1001,6 @@ CassandraBackend::open(bool readOnly)
 
     BOOST_LOG_TRIVIAL(info) << "Opening Cassandra Backend";
 
-    std::lock_guard<std::mutex> lock(mutex_);
     CassCluster* cluster = cass_cluster_new();
     if (!cluster)
         throw std::runtime_error("nodestore:: Failed to create CassCluster");


### PR DESCRIPTION
Fixes #304 

Note: if there was really a race it will definitely not be fixed by this change. However it should no longer complain about this particular `mutex` which was only ever locked in one place which should be called once and does not really need this synchronization in the first place.