### PR TITLE
Return limit for assorted account methods

### DIFF
--- a/src/rpc/handlers/AccountChannels.cpp
+++ b/src/rpc/handlers/AccountChannels.cpp
@@ -85,6 +85,7 @@ doAccountChannels(Context const& context)
 
     response[JS(account)] = ripple::to_string(accountID);
     response[JS(channels)] = boost::json::value(boost::json::array_kind);
+    response[JS(limit)] = limit;
     boost::json::array& jsonChannels = response.at(JS(channels)).as_array();
 
     auto const addToResponse = [&](ripple::SLE&& sle) {

--- a/src/rpc/handlers/AccountLines.cpp
+++ b/src/rpc/handlers/AccountLines.cpp
@@ -139,6 +139,7 @@ doAccountLines(Context const& context)
     response[JS(account)] = ripple::to_string(accountID);
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
     response[JS(ledger_index)] = lgrInfo.seq;
+    response[JS(limit)] = limit;
     response[JS(lines)] = boost::json::value(boost::json::array_kind);
     boost::json::array& jsonLines = response.at(JS(lines)).as_array();
 

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -63,6 +63,7 @@ doAccountNFTs(Context const& context)
 
     response[JS(account)] = ripple::toBase58(accountID);
     response[JS(validated)] = true;
+    response[JS(limit)] = limit;
 
     std::uint32_t numPages = 0;
     response[JS(account_nfts)] = boost::json::value(boost::json::array_kind);

--- a/src/rpc/handlers/AccountOffers.cpp
+++ b/src/rpc/handlers/AccountOffers.cpp
@@ -100,6 +100,7 @@ doAccountOffers(Context const& context)
     }
 
     response[JS(account)] = ripple::to_string(accountID);
+    response[JS(limit)] = limit;
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
     response[JS(ledger_index)] = lgrInfo.seq;
     response[JS(offers)] = boost::json::value(boost::json::array_kind);


### PR DESCRIPTION
**Issue** (#221): Limit parameter is not returned for account_lines, account_channels, account_objects, account_offers checks
**Fix**: Add limit parameter within response object for each respective file