### PR TITLE
Return dstAmtMalformed in book offers

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1380,12 +1380,12 @@ parseBook(boost::json::object const& request)
     ripple::Currency pay_currency;
     if (!ripple::to_currency(
             pay_currency, taker_pays.at("currency").as_string().c_str()))
-        return Status{Error::rpcINVALID_PARAMS, "badTakerPaysCurrency"};
+        return Status{Error::rpcSRC_CUR_MALFORMED, "badTakerPaysCurrency"};
 
     ripple::Currency get_currency;
     if (!ripple::to_currency(
             get_currency, taker_gets["currency"].as_string().c_str()))
-        return Status{Error::rpcINVALID_PARAMS, "badTakerGetsCurrency"};
+        return Status{Error::rpcDST_AMT_MALFORMED, "badTakerGetsCurrency"};
 
     ripple::AccountID pay_issuer;
     if (taker_pays.contains("issuer"))


### PR DESCRIPTION
**Issue** (#268): book_offers API request incorrectly returns invalidParams instead of dstAmtMalformed.
**Fix**: Add rpcDST_AMT_MALFORMED in get_currency.