### PR TITLE
Limit concurrent requests

### DIFF
--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -218,8 +218,8 @@ public:
     {
         if (whitelist_.contains(ip))
             return true;
-        std::shared_lock lk(ftMtx_);
-        std::shared_lock lk(reqMtx_);
+        std::shared_lock flk(ftMtx_);
+        std::shared_lock rlk(reqMtx_);
         bool fetchesOk = maxFetches_ == -1 || getFetches(ip) < maxFetches_;
         bool requestsOk = maxConcurrentRequests_ == -1 ||
             getRequests(ip) < maxConcurrentRequests_;

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -235,7 +235,7 @@ public:
         {
             std::unique_lock lck{fetchMtx_};
             auto it = ipFetchCount_.find(ip);
-            auto count = 0;
+            uint32_t count = 0;
             if (it == ipFetchCount_.end())
                 count = ipFetchCount_[ip] = numObjects;
             else

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -2,6 +2,7 @@
 #define RIPPLE_REPORTING_DOS_GUARD_H
 
 #include <boost/asio.hpp>
+#include <atomic>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -9,11 +10,37 @@
 class DOSGuard
 {
     boost::asio::io_context& ctx_;
-    std::mutex mtx_;  // protects ipFetchCount_
-    std::unordered_map<std::string, std::uint32_t> ipFetchCount_;
+    std::shared_mutex ftMtx_;   // protects ipFetchCount_
+    std::shared_mutex reqMtx_;  // protects ipRequestCount_
+    std::unordered_map<std::string, std::atomic_uint32_t> ipFetchCount_;
+    std::unordered_map<std::string, std::atomic_uint32_t> ipRequestCount_;
     std::unordered_set<std::string> const whitelist_;
     std::uint32_t const maxFetches_;
     std::uint32_t const sweepInterval_;
+    std::uint32_t const maxConcurrentRequests_;
+
+    struct RPCScope
+    {
+        std::uint32_t count_;
+        std::string ip_;
+        DOSGuard& parent_;
+
+        RPCScope(std::string ip, DOSGuard& parent) : ip_(ip), parent_(parent)
+        {
+            count_ = parent_.incrementRequestCount(ip_);
+        }
+
+        ~RPCScope()
+        {
+            parent_.decrementRequestCount(ip_);
+        }
+
+        bool
+        isValid()
+        {
+            return parent_.isOk(ip_, count_);
+        }
+    };
 
     // Load config setting for DOSGuard
     std::optional<boost::json::object>
@@ -69,12 +96,99 @@ class DOSGuard
         }
     }
 
+    std::uint32_t
+    getFetches(std::string const& ip)
+    {
+        std::shared_lock lk(ftMtx_);
+        auto it = ipFetchCount_.find(ip);
+        if (it == ipFetchCount_.end())
+            return 0;
+        else
+            return it->second;
+    }
+
+    std::uint32_t
+    getRequests(std::string const& ip)
+    {
+        std::shared_lock lk(reqMtx_);
+        auto it = ipRequestCount_.find(ip);
+        if (it == ipRequestCount_.end())
+            return 0;
+        else
+            return it->second;
+    }
+
+    // increment atomic request counter for ip in a threadsafe manner.
+    // returns result (not a reference)
+    std::uint32_t
+    incrementRequestCount(std::string const& ip)
+    {
+        // reading ipReqiestCount_[ip] can potentially mutate the internal
+        // ipRequestCount_ data structure. One of two things will happen:
+        // 1) ipRequestCount_[ip] contains a reference to an atomic
+        // 2) ipRequestCount_[ip] creates a new reference
+        //      -this mutates the data structure
+
+        {
+            std::shared_lock read_lock(reqMtx_);
+            auto it = ipRequestCount_.find(ip);
+            if (it != ipRequestCount_.end())
+                return ipRequestCount_[ip]++;
+        }
+        {
+            // at this point the ip does not exist in the map. Must grab
+            // writer lock
+            std::unique_lock write_lock(reqMtx_);
+            // this will create and increment the atomic OR
+            // increment the atomic if another thread succeeded for this ip.
+            return ipRequestCount_[ip]++;
+        }
+    }
+
+    void
+    decrementRequestCount(std::string const& ip)
+    {
+        // assuming that ip is in the map
+        {
+            std::shared_lock read_lock(reqMtx_);
+            auto it = ipRequestCount_.find(ip);
+            if (it == ipRequestCount_.end())
+                assert(false);
+            if (--ipRequestCount_[ip])
+                return;
+        }
+        // erase if count is still zero
+        {
+            std::unique_lock write_lock(reqMtx_);
+            auto it = ipRequestCount_.find(ip);
+            if (it == ipRequestCount_.end())
+                return;  // another thread erased the reference
+
+            if (!it->second)  // if still zero
+                ipRequestCount_.erase(ip);
+        }
+        return;
+    }
+
+    bool
+    isOk(std::string const& ip, std::uint32_t requestCount)
+    {
+        if (whitelist_.contains(ip))
+            return true;
+        std::shared_lock lk(ftMtx_);
+        bool fetchesOk = maxFetches_ == -1 || getFetches(ip) < maxFetches_;
+        bool requestsOk = maxConcurrentRequests_ == -1 ||
+            requestCount < maxConcurrentRequests_;
+        return fetchesOk && requestsOk;
+    }
+
 public:
     DOSGuard(boost::json::object const& config, boost::asio::io_context& ctx)
         : ctx_(ctx)
         , whitelist_(getWhitelist(config))
         , maxFetches_(get(config, "max_fetches", 100))
         , sweepInterval_(get(config, "sweep_interval", 1))
+        , maxConcurrentRequests_(get(config, "max_concurrent_requests", 4))
     {
         createTimer();
     }
@@ -104,37 +218,41 @@ public:
     {
         if (whitelist_.contains(ip))
             return true;
-
-        std::unique_lock lck(mtx_);
-        auto it = ipFetchCount_.find(ip);
-        if (it == ipFetchCount_.end())
-            return true;
-
-        return it->second < maxFetches_;
+        std::shared_lock lk(ftMtx_);
+        std::shared_lock lk(reqMtx_);
+        bool fetchesOk = maxFetches_ == -1 || getFetches(ip) < maxFetches_;
+        bool requestsOk = maxConcurrentRequests_ == -1 ||
+            getRequests(ip) < maxConcurrentRequests_;
+        return fetchesOk && requestsOk;
     }
 
+    RPCScope
+    checkout(std::string const& ip)
+    {
+        return RPCScope(ip, *this);
+    }
+
+    // add numObjects bytes to the fetch count for ip
     bool
     add(std::string const& ip, uint32_t numObjects)
     {
-        if (whitelist_.contains(ip))
+        if (whitelist_.contains(ip) || maxFetches_ == -1)
             return true;
-
         {
-            std::unique_lock lck(mtx_);
+            std::unique_lock lck(ftMtx_);
             auto it = ipFetchCount_.find(ip);
             if (it == ipFetchCount_.end())
                 ipFetchCount_[ip] = numObjects;
             else
                 it->second += numObjects;
+            return ipFetchCount_[ip] < maxFetches_;
         }
-
-        return isOk(ip);
     }
 
     void
     clear()
     {
-        std::unique_lock lck(mtx_);
+        std::unique_lock lck(ftMtx_);
         ipFetchCount_.clear();
     }
 };

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -263,6 +263,13 @@ public:
             this->send(boost::json::serialize(e));
         };
 
+        // The DOS guard allocates tickets to concurrent requests.
+        // The resource is automatically checked in when ticket goes out of
+        // scope.
+        auto ticket = dosGuard_.checkout(*ip);
+        if (!ticket.isValid())
+            return sendError(RPC::Error::rpcSLOW_DOWN, id);
+            
         try
         {
             BOOST_LOG_TRIVIAL(debug) << " received request : " << request;

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -268,8 +268,8 @@ public:
         // scope.
         auto ticket = dosGuard_.checkout(*ip);
         if (!ticket.isValid())
-            return sendError(RPC::Error::rpcSLOW_DOWN, id);
-            
+            return sendError(RPC::Error::rpcSLOW_DOWN);
+
         try
         {
             BOOST_LOG_TRIVIAL(debug) << " received request : " << request;


### PR DESCRIPTION
This is a follow up to https://github.com/XRPLF/clio/pull/187

I changed the logic of that PR to just clear the whole request counting map, instead of deleting as requests finish.

Defaults were also changed. Now, the byte based rate limiter limits to 10 MB/s, and the request based limiter limits to 1 concurrent request. Sweep period defaults to 10 seconds. 10 MB/s is roughly the throughput of calling ledger_data repeatedly in a loop from localhost when the cache is full.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/337)
<!-- Reviewable:end -->
