### PR TITLE
Return account not found error for unfunded account in account_tx

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1,8 +1,6 @@
 #include <boost/algorithm/string.hpp>
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
-#include <webserver/WsBase.h>
-
 namespace RPC {
 
 std::optional<bool>
@@ -218,6 +216,11 @@ getAccount(
     {
         account = a.value();
         return {};
+    }
+
+    if (!request.contains(account))
+    {
+        return Status{Error::rpcACT_NOT_FOUND, field.to_string() + "NotFound"};
     }
 
     return Status{Error::rpcINVALID_PARAMS, field.to_string() + "Malformed"};
@@ -1473,7 +1476,6 @@ parseTaker(boost::json::value const& taker)
         return Status{Error::rpcINVALID_PARAMS, "invalidTakerAccount"};
     return *takerID;
 }
-
 bool
 specifiesCurrentOrClosedLedger(boost::json::object const& request)
 {


### PR DESCRIPTION
**Issue** (#261): account_tx API call with unfunded account does not return any error message
**Fix**: Return rpcACT_NOT_FOUND and implement new conditional for specific error message