### PR TITLE
Handle client disconnect during rpc

### DIFF
--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -81,6 +81,12 @@ private:
     {
         std::string ip;
         int port;
+
+        // TODO: remove when clang catches up to gcc/msvc in regards to
+        // emplace_back with brace initialization (c++20)
+        ClioPeer(std::string ip, int port) : ip{ip}, port{port}
+        {
+        }
     };
 
     std::vector<ClioPeer> clioPeers;

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -1,11 +1,19 @@
 #include <rpc/WorkQueue.h>
 
-WorkQueue::WorkQueue(std::uint32_t numWorkers, uint32_t maxSize)
+WorkQueue::WorkQueue(std::uint32_t numWorkers, std::optional<uint32_t> maxSize)
+    : maxSize_{maxSize.value_or(std::numeric_limits<uint32_t>::max())}
 {
-    if (maxSize != 0)
-        maxSize_ = maxSize;
     while (--numWorkers)
-    {
         threads_.emplace_back([this] { ioc_.run(); });
-    }
+}
+
+boost::json::object
+WorkQueue::report() const
+{
+    boost::json::object obj;
+    obj["queued"] = queued_;
+    obj["queued_duration_us"] = durationUs_;
+    obj["current_queue_size"] = curSize_;
+    obj["max_queue_size"] = maxSize_;
+    return obj;
 }

--- a/src/rpc/WorkQueue.h
+++ b/src/rpc/WorkQueue.h
@@ -21,8 +21,14 @@ class WorkQueue
     std::atomic_uint64_t curSize_ = 0;
     uint32_t maxSize_ = std::numeric_limits<uint32_t>::max();
 
+    std::vector<std::thread> threads_ = {};
+    boost::asio::io_context ioc_ = {};
+    std::optional<boost::asio::io_context::work> work_{ioc_};
+
 public:
-    WorkQueue(std::uint32_t numWorkers, uint32_t maxSize = 0);
+    WorkQueue(
+        std::uint32_t numWorkers,
+        std::optional<uint32_t> maxSize = std::nullopt);
 
     template <typename F>
     bool
@@ -61,21 +67,7 @@ public:
     }
 
     boost::json::object
-    report() const
-    {
-        boost::json::object obj;
-        obj["queued"] = queued_;
-        obj["queued_duration_us"] = durationUs_;
-        obj["current_queue_size"] = curSize_;
-        obj["max_queue_size"] = maxSize_;
-        return obj;
-    }
-
-private:
-    std::vector<std::thread> threads_ = {};
-
-    boost::asio::io_context ioc_ = {};
-    std::optional<boost::asio::io_context::work> work_{ioc_};
+    report() const;
 };
 
 #endif  // CLIO_WORK_QUEUE_H

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -198,7 +198,9 @@ public:
     }
 
     void
-    on_read(boost::beast::error_code ec, [[maybe_unused]] std::size_t bytes_transferred)
+    on_read(
+        boost::beast::error_code ec,
+        [[maybe_unused]] std::size_t bytes_transferred)
     {
         // This means they closed the connection
         if (ec == http::error::end_of_stream)

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -198,10 +198,8 @@ public:
     }
 
     void
-    on_read(boost::beast::error_code ec, std::size_t bytes_transferred)
+    on_read(boost::beast::error_code ec, [[maybe_unused]] std::size_t bytes_transferred)
     {
-        boost::ignore_unused(bytes_transferred);
-
         // This means they closed the connection
         if (ec == http::error::end_of_stream)
             return derived().do_close();
@@ -280,10 +278,8 @@ public:
     on_write(
         bool close,
         boost::beast::error_code ec,
-        std::size_t bytes_transferred)
+        [[maybe_unused]] std::size_t bytes_transferred)
     {
-        boost::ignore_unused(bytes_transferred);
-
         if (ec)
             return httpFail(ec, "write");
 

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -218,7 +218,7 @@ public:
     Listener(
         boost::asio::io_context& ioc,
         uint32_t numWorkerThreads,
-        uint32_t maxQueueSize,
+        std::optional<uint32_t> maxQueueSize,
         std::optional<std::reference_wrapper<ssl::context>> ctx,
         tcp::endpoint endpoint,
         std::shared_ptr<BackendInterface const> backend,
@@ -349,11 +349,13 @@ make_HttpServer(
     uint32_t numThreads = std::thread::hardware_concurrency();
     if (config.contains("workers"))
         numThreads = config.at("workers").as_int64();
-    uint32_t maxQueueSize = 0;  // no max
+    std::optional<uint32_t> maxQueueSize = std::nullopt;
     if (serverConfig.contains("max_queue_size"))
         maxQueueSize = serverConfig.at("max_queue_size").as_int64();
+    auto const maxQueueSizeStr =
+        maxQueueSize ? std::to_string(*maxQueueSize) : std::string{"no limit"};
     BOOST_LOG_TRIVIAL(info) << __func__ << " Number of workers = " << numThreads
-                            << ". Max queue size = " << maxQueueSize;
+                            << ". Max queue size = " << maxQueueSizeStr;
 
     auto server = std::make_shared<HttpServer>(
         ioc,

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -272,6 +272,14 @@ public:
         boost::json::value const& id,
         boost::asio::yield_context& yield)
     {
+        if (dead())
+        {
+            BOOST_LOG_TRIVIAL(warning)
+                << __func__
+                << ": abandon request as ws session is already dead";
+            return;
+        }
+
         auto ip = derived().ip();
         if (!ip)
             return;

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -275,7 +275,7 @@ public:
         if (dead())
         {
             BOOST_LOG_TRIVIAL(warning)
-                << __func__
+                << tag() << __func__
                 << ": abandon request as ws session is already dead";
             return;
         }


### PR DESCRIPTION
Fixes #211 

Initially we wanted to gracefully abort handling any `rpc` for disconnected clients on both websocket and over http. However only `ws` allows us to detect client disconnects. The way it could be done in the future is by introducing our own heartbeat system - something we don't want to do now.

This "fix" detects clients that dropped the connection while their request was in `clio`s work queue. Once detected, a warning log message is written which includes the `tag` of the session that dropped out.