### PR TITLE
Return badMarket for same currency in taker_gets and taker_pays in book_offers

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1355,7 +1355,7 @@ std::variant<Status, ripple::Book>
 parseBook(boost::json::object const& request)
 {
     if (!request.contains("taker_pays"))
-        return Status{Error::rpcINVALID_PARAMS, "missingTakerPays"};
+        return Status{Error::rpcBAD_MARKET, "missingTakerPays"};
 
     if (!request.contains("taker_gets"))
         return Status{Error::rpcINVALID_PARAMS, "missingTakerGets"};
@@ -1458,7 +1458,7 @@ parseBook(boost::json::object const& request)
             "Invalid field 'taker_gets.issuer', expected non-XRP issuer."};
 
     if (pay_currency == get_currency && pay_issuer == get_issuer)
-        return Status{Error::rpcINVALID_PARAMS, "badMarket"};
+        return Status{Error::rpcBAD_MARKET, "badMarket"};
 
     return ripple::Book{{pay_currency, pay_issuer}, {get_currency, get_issuer}};
 }


### PR DESCRIPTION
**Issue** (#269): book_offers API request returns "invalidParams" instead of "badMarket" when taker_gets and taker_pays have the same currency.
**Fix**: Add badMarket to taker_gets and taker_pays having equivalent currency conditional.