### PR TITLE
Abstraction for config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,13 +100,16 @@ target_sources(clio PRIVATE
   src/rpc/handlers/ServerInfo.cpp
   # Utility
   src/rpc/handlers/Random.cpp
-  src/util/Taggable.cpp)
+  src/util/Taggable.cpp
+  src/config/Config.cpp)
 
 add_executable(clio_server src/main/main.cpp)
 target_link_libraries(clio_server PUBLIC clio)
 
 if(BUILD_TESTS)
-  add_executable(clio_tests unittests/main.cpp)
+  add_executable(clio_tests 
+    unittests/config.cpp 
+    unittests/main.cpp)
   include(CMake/deps/gtest.cmake)
 endif()
 

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -11,6 +11,8 @@
 #include <backend/SimpleCache.h>
 #include <backend/Types.h>
 
+#include <config/Config.h>
+
 #include <thread>
 #include <type_traits>
 
@@ -96,7 +98,7 @@ protected:
     SimpleCache cache_;
 
 public:
-    BackendInterface(boost::json::object const& config)
+    BackendInterface(clio::Config const& config)
     {
     }
     virtual ~BackendInterface()

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -18,6 +18,8 @@
 #include <mutex>
 #include <thread>
 
+#include <config/Config.h>
+
 namespace Backend {
 
 class CassandraPreparedStatement
@@ -670,15 +672,17 @@ private:
     std::optional<boost::asio::io_context::work> work_;
     std::thread ioThread_;
 
-    boost::json::object config_;
+    clio::Config config_;
+    uint32_t ttl_ = 0;
 
     mutable std::uint32_t ledgerSequence_ = 0;
 
 public:
     CassandraBackend(
         boost::asio::io_context& ioc,
-        boost::json::object const& config)
-        : BackendInterface(config), config_(config)
+        clio::Config const& config,
+        uint32_t ttl)
+        : BackendInterface(config), config_(config), ttl_(ttl)
     {
         work_.emplace(ioContext_);
         ioThread_ = std::thread([this]() { ioContext_.run(); });

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,0 +1,172 @@
+#include <config/Config.h>
+
+#include <boost/log/trivial.hpp>
+#include <fstream>
+
+namespace clio {
+
+// Note: `store_(store)` MUST use `()` instead of `{}` otherwise gcc
+// picks `initializer_list` constructor and anything passed becomes an
+// array :-D
+Config::Config(boost::json::value store) : store_(std::move(store))
+{
+}
+
+Config::operator bool() const noexcept
+{
+    return not store_.is_null();
+}
+
+bool
+Config::contains(key_type key) const
+{
+    return lookup(key).has_value();
+}
+
+std::optional<boost::json::value>
+Config::lookup(key_type key) const
+{
+    if (store_.is_null())
+        return std::nullopt;
+
+    std::reference_wrapper<boost::json::value const> cur = std::cref(store_);
+    auto hasBrokenPath = false;
+    auto tokenized = detail::Tokenizer<key_type, Separator>{key};
+    std::string subkey{};
+
+    auto maybeSection = tokenized.next();
+    while (maybeSection.has_value())
+    {
+        auto section = maybeSection.value();
+        subkey += section;
+
+        if (not hasBrokenPath)
+        {
+            if (not cur.get().is_object())
+                throw detail::StoreException(
+                    "Not an object at '" + subkey + "'");
+            if (not cur.get().as_object().contains(section))
+                hasBrokenPath = true;
+            else
+                cur = std::cref(cur.get().as_object().at(section));
+        }
+
+        subkey += Separator;
+        maybeSection = tokenized.next();
+    }
+
+    if (hasBrokenPath)
+        return std::nullopt;
+    return std::make_optional(cur);
+}
+
+std::optional<Config::array_type>
+Config::maybeArray(key_type key) const
+{
+    try
+    {
+        auto maybe_arr = lookup(key);
+        if (maybe_arr && maybe_arr->is_array())
+        {
+            auto& arr = maybe_arr->as_array();
+            array_type out;
+            out.reserve(arr.size());
+
+            std::transform(
+                std::begin(arr),
+                std::end(arr),
+                std::back_inserter(out),
+                [](auto&& element) { return Config{std::move(element)}; });
+            return std::make_optional<array_type>(std::move(out));
+        }
+    }
+    catch (detail::StoreException const&)
+    {
+        // ignore store error, but rethrow key errors
+    }
+
+    return std::nullopt;
+}
+
+Config::array_type
+Config::array(key_type key) const
+{
+    if (auto maybe_arr = maybeArray(key); maybe_arr)
+        return maybe_arr.value();
+    throw std::logic_error("No array found at '" + key + "'");
+}
+
+Config::array_type
+Config::arrayOr(key_type key, array_type fallback) const
+{
+    if (auto maybe_arr = maybeArray(key); maybe_arr)
+        return maybe_arr.value();
+    return fallback;
+}
+
+Config::array_type
+Config::arrayOrThrow(key_type key, std::string_view err) const
+{
+    try
+    {
+        return maybeArray(key).value();
+    }
+    catch (std::exception const&)
+    {
+        throw std::runtime_error(err.data());
+    }
+}
+
+Config
+Config::section(key_type key) const
+{
+    auto maybe_element = lookup(key);
+    if (maybe_element && maybe_element->is_object())
+        return Config{std::move(*maybe_element)};
+    throw std::logic_error("No section found at '" + key + "'");
+}
+
+Config::array_type
+Config::array() const
+{
+    if (not store_.is_array())
+        throw std::logic_error("_self_ is not an array");
+
+    array_type out;
+    auto const& arr = store_.as_array();
+    out.reserve(arr.size());
+
+    std::transform(
+        std::cbegin(arr),
+        std::cend(arr),
+        std::back_inserter(out),
+        [](auto const& element) { return Config{element}; });
+    return out;
+}
+
+Config
+ConfigReader::open(std::filesystem::path path)
+{
+    try
+    {
+        std::ifstream in(path, std::ios::in | std::ios::binary);
+        if (in)
+        {
+            std::stringstream contents;
+            contents << in.rdbuf();
+            auto opts = boost::json::parse_options{};
+            opts.allow_comments = true;
+            return Config{boost::json::parse(contents.str(), {}, opts)};
+        }
+    }
+    catch (std::exception const& e)
+    {
+        BOOST_LOG_TRIVIAL(error) << "Could not read configuration file from '"
+                                 << path.string() << "': " << e.what();
+    }
+
+    BOOST_LOG_TRIVIAL(warning) << "Using empty default configuration";
+    return Config{};
+}
+
+}  // namespace clio

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -1,0 +1,389 @@
+#ifndef RIPPLE_APP_CONFIG_H_INCLUDED
+#define RIPPLE_APP_CONFIG_H_INCLUDED
+
+#include <config/detail/Helpers.h>
+
+#include <boost/json.hpp>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace clio {
+
+/**
+ * @brief Convenience wrapper to query a JSON configuration file.
+ *
+ * Any custom data type can be supported by implementing the right `tag_invoke`
+ * for `boost::json::value_to`.
+ */
+class Config final
+{
+    boost::json::value store_;
+    static constexpr char Separator = '.';
+
+public:
+    using key_type = std::string;           /*! The type of key used */
+    using array_type = std::vector<Config>; /*! The type of array used */
+    using write_cursor_type = std::pair<
+        std::optional<std::reference_wrapper<boost::json::value>>,
+        key_type>;
+
+    /**
+     * @brief Construct a new Config object.
+     * @param store boost::json::value that backs this instance
+     */
+    explicit Config(boost::json::value store = {});
+
+    //
+    // Querying the store
+    //
+
+    /**
+     * @brief Checks whether underlying store is not null.
+     *
+     * @return true If the store is null
+     * @return false If the store is not null
+     */
+    operator bool() const noexcept;
+
+    /**
+     * @brief Checks whether something exists under given key.
+     *
+     * @param key The key to check
+     * @return true If something exists under key
+     * @return false If nothing exists under key
+     * @throws std::logic_error If the key is of invalid format
+     */
+    [[nodiscard]] bool
+    contains(key_type key) const;
+
+    //
+    // Key value access
+    //
+
+    /**
+     * @brief Interface for fetching values by key that returns std::optional.
+     *
+     * Will attempt to fetch the value under the desired key. If the value
+     * exists and can be represented by the desired type Result then it will be
+     * returned wrapped in an optional. If the value exists but the conversion
+     * to Result is not possible - a runtime_error will be thrown. If the value
+     * does not exist under the specified key - std::nullopt is returned.
+     *
+     * @tparam Result The desired return type
+     * @param key The key to check
+     * @return std::optional<Result> Optional value of desired type
+     * @throws std::logic_error Thrown if conversion to Result is not possible
+     * or key is of invalid format
+     */
+    template <typename Result>
+    [[nodiscard]] std::optional<Result>
+    maybeValue(key_type key) const
+    {
+        auto maybe_element = lookup(key);
+        if (maybe_element)
+            return std::make_optional<Result>(
+                checkedAs<Result>(key, *maybe_element));
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Interface for fetching values by key.
+     *
+     * Will attempt to fetch the value under the desired key. If the value
+     * exists and can be represented by the desired type Result then it will be
+     * returned. If the value exists but the conversion
+     * to Result is not possible OR the value does not exist - a logic_error
+     * will be thrown.
+     *
+     * @tparam Result The desired return type
+     * @param key The key to check
+     * @return Result Value of desired type
+     * @throws std::logic_error Thrown if conversion to Result is not
+     * possible, value does not exist under specified key path or the key is of
+     * invalid format
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    value(key_type key) const
+    {
+        return maybeValue<Result>(key).value();
+    }
+
+    /**
+     * @brief Interface for fetching values by key with fallback.
+     *
+     * Will attempt to fetch the value under the desired key. If the value
+     * exists and can be represented by the desired type Result then it will be
+     * returned. If the value exists but the conversion
+     * to Result is not possible - a logic_error will be thrown. If the value
+     * does not exist under the specified key - user specified fallback is
+     * returned.
+     *
+     * @tparam Result The desired return type
+     * @param key The key to check
+     * @param fallback The fallback value
+     * @return Result Value of desired type
+     * @throws std::logic_error Thrown if conversion to Result is not possible
+     * or the key is of invalid format
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    valueOr(key_type key, Result fallback) const
+    {
+        try
+        {
+            return maybeValue<Result>(key).value_or(fallback);
+        }
+        catch (detail::StoreException const&)
+        {
+            return fallback;
+        }
+    }
+
+    /**
+     * @brief Interface for fetching values by key with custom error handling.
+     *
+     * Will attempt to fetch the value under the desired key. If the value
+     * exists and can be represented by the desired type Result then it will be
+     * returned. If the value exists but the conversion
+     * to Result is not possible OR the value does not exist - a runtime_error
+     * will be thrown with the user specified message.
+     *
+     * @tparam Result The desired return type
+     * @param key The key to check
+     * @param err The custom error message
+     * @return Result Value of desired type
+     * @throws std::runtime_error Thrown if conversion to Result is not possible
+     * or value does not exist under key
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    valueOrThrow(key_type key, std::string_view err) const
+    {
+        try
+        {
+            return maybeValue<Result>(key).value();
+        }
+        catch (std::exception const&)
+        {
+            throw std::runtime_error(err.data());
+        }
+    }
+
+    /**
+     * @brief Interface for fetching an array by key that returns std::optional.
+     *
+     * Will attempt to fetch an array under the desired key. If the array
+     * exists then it will be
+     * returned wrapped in an optional. If the array does not exist under the
+     * specified key - std::nullopt is returned.
+     *
+     * @param key The key to check
+     * @return std::optional<array_type> Optional array
+     * @throws std::logic_error Thrown if the key is of invalid format
+     */
+    [[nodiscard]] std::optional<array_type>
+    maybeArray(key_type key) const;
+
+    /**
+     * @brief Interface for fetching an array by key.
+     *
+     * Will attempt to fetch an array under the desired key. If the array
+     * exists then it will be
+     * returned. If the array does not exist under the
+     * specified key an std::logic_error is thrown.
+     *
+     * @param key The key to check
+     * @return array_type The array
+     * @throws std::logic_error Thrown if there is no array under the desired
+     * key or the key is of invalid format
+     */
+    [[nodiscard]] array_type
+    array(key_type key) const;
+
+    /**
+     * @brief Interface for fetching an array by key with fallback.
+     *
+     * Will attempt to fetch an array under the desired key. If the array
+     * exists then it will be returned.
+     * If the array does not exist or another type is stored under the desired
+     * key - user specified fallback is returned.
+     *
+     * @param key The key to check
+     * @param fallback The fallback array
+     * @return array_type The array
+     * @throws std::logic_error Thrown if the key is of invalid format
+     */
+    [[nodiscard]] array_type
+    arrayOr(key_type key, array_type fallback) const;
+
+    /**
+     * @brief Interface for fetching an array by key with custom error handling.
+     *
+     * Will attempt to fetch an array under the desired key. If the array
+     * exists then it will be returned.
+     * If the array does not exist or another type is stored under the desired
+     * key - std::runtime_error is thrown with the user specified error message.
+     *
+     * @param key The key to check
+     * @param err The custom error message
+     * @return array_type The array
+     * @throws std::runtime_error Thrown if there is no array under the desired
+     * key
+     */
+    [[nodiscard]] array_type
+    arrayOrThrow(key_type key, std::string_view err) const;
+
+    /**
+     * @brief Interface for fetching a sub section by key.
+     *
+     * Will attempt to fetch an entire section under the desired key and return
+     * it as a Config instance. If the section does not exist or another type is
+     * stored under the desired key - std::logic_error is thrown.
+     *
+     * @param key The key to check
+     * @return Config Section represented as a separate instance of Config
+     * @throws std::logic_error Thrown if there is no section under the
+     * desired key or the key is of invalid format
+     */
+    [[nodiscard]] Config
+    section(key_type key) const;
+
+    //
+    // Direct self-value access
+    //
+
+    /**
+     * @brief Interface for reading the value directly referred to by the
+     * instance. Wraps as std::optional.
+     *
+     * See @ref maybeValue(key_type) const for how this works.
+     */
+    template <typename Result>
+    [[nodiscard]] std::optional<Result>
+    maybeValue() const
+    {
+        if (store_.is_null())
+            return std::nullopt;
+        return std::make_optional<Result>(checkedAs<Result>("_self_", store_));
+    }
+
+    /**
+     * @brief Interface for reading the value directly referred to by the
+     * instance.
+     *
+     * See @ref value(key_type) const for how this works.
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    value() const
+    {
+        return maybeValue<Result>().value();
+    }
+
+    /**
+     * @brief Interface for reading the value directly referred to by the
+     * instance with user-specified fallback.
+     *
+     * See @ref valueOr(key_type, Result) const for how this works.
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    valueOr(Result fallback) const
+    {
+        return maybeValue<Result>().valueOr(fallback);
+    }
+
+    /**
+     * @brief Interface for reading the value directly referred to by the
+     * instance with user-specified error message.
+     *
+     * See @ref valueOrThrow(key_type, std::string_view) const for how this
+     * works.
+     */
+    template <typename Result>
+    [[nodiscard]] Result
+    valueOrThrow(std::string_view err) const
+    {
+        try
+        {
+            return maybeValue<Result>().value();
+        }
+        catch (std::exception const&)
+        {
+            throw std::runtime_error(err.data());
+        }
+    }
+
+    /**
+     * @brief Interface for reading the array directly referred to by the
+     * instance.
+     *
+     * See @ref array(key_type) const for how this works.
+     */
+    [[nodiscard]] array_type
+    array() const;
+
+private:
+    template <typename Return>
+    [[nodiscard]] Return
+    checkedAs(key_type key, boost::json::value const& value) const
+    {
+        auto has_error = false;
+        if constexpr (std::is_same_v<Return, bool>)
+        {
+            if (not value.is_bool())
+                has_error = true;
+        }
+        else if constexpr (std::is_same_v<Return, std::string>)
+        {
+            if (not value.is_string())
+                has_error = true;
+        }
+        else if constexpr (std::is_same_v<Return, double>)
+        {
+            if (not value.is_double())
+                has_error = true;
+        }
+        else if constexpr (
+            std::is_convertible_v<Return, uint64_t> ||
+            std::is_convertible_v<Return, int64_t>)
+        {
+            if (not value.is_int64() && not value.is_uint64())
+                has_error = true;
+        }
+
+        if (has_error)
+            throw std::runtime_error(
+                "Type for key '" + key + "' is '" +
+                std::string{to_string(value.kind())} +
+                "' in JSON but requested '" + detail::typeName<Return>() + "'");
+
+        return boost::json::value_to<Return>(value);
+    }
+
+    std::optional<boost::json::value>
+    lookup(key_type key) const;
+
+    write_cursor_type
+    lookupForWrite(key_type key);
+};
+
+/**
+ * @brief Simple configuration file reader.
+ *
+ * Reads the JSON file under specified path and creates a @ref Config object
+ * from its contents.
+ */
+class ConfigReader final
+{
+public:
+    static Config
+    open(std::filesystem::path path);
+};
+
+}  // namespace clio
+
+#endif  // RIPPLE_APP_CONFIG_H_INCLUDED

--- a/src/config/detail/Helpers.h
+++ b/src/config/detail/Helpers.h
@@ -1,0 +1,148 @@
+#ifndef RIPPLE_APP_CONFIG_DETAIL_H_INCLUDED
+#define RIPPLE_APP_CONFIG_DETAIL_H_INCLUDED
+
+#include <optional>
+#include <queue>
+#include <stdexcept>
+#include <string>
+
+namespace clio::detail {
+
+/**
+ * @brief Thrown when a KeyPath related error occurs
+ */
+struct KeyException : public ::std::logic_error
+{
+    KeyException(::std::string msg) : ::std::logic_error{msg}
+    {
+    }
+};
+
+/**
+ * @brief Thrown when a Store (config's storage) related error occurs.
+ */
+struct StoreException : public ::std::logic_error
+{
+    StoreException(::std::string msg) : ::std::logic_error{msg}
+    {
+    }
+};
+
+/**
+ * @brief Simple string tokenizer. Used by @ref Config.
+ *
+ * @tparam KeyType The type of key to use
+ * @tparam Separator The separator character
+ */
+template <typename KeyType, char Separator>
+class Tokenizer final
+{
+    using opt_key_t = std::optional<KeyType>;
+    KeyType key_;
+    KeyType token_{};
+    std::queue<KeyType> tokens_{};
+
+public:
+    explicit Tokenizer(KeyType key) : key_{key}
+    {
+        if (key.empty())
+            throw KeyException("Empty key");
+
+        for (auto const& c : key)
+        {
+            if (c == Separator)
+                saveToken();
+            else
+                token_ += c;
+        }
+
+        saveToken();
+    }
+
+    [[nodiscard]] opt_key_t
+    next()
+    {
+        if (tokens_.empty())
+            return std::nullopt;
+        auto token = tokens_.front();
+        tokens_.pop();
+        return std::make_optional(std::move(token));
+    }
+
+private:
+    void
+    saveToken()
+    {
+        if (token_.empty())
+            throw KeyException("Empty token in key '" + key_ + "'.");
+        tokens_.push(std::move(token_));
+        token_ = {};
+    }
+};
+
+template <typename T>
+static constexpr const char*
+typeName()
+{
+    return typeid(T).name();
+}
+
+template <>
+constexpr const char*
+typeName<uint64_t>()
+{
+    return "uint64_t";
+}
+
+template <>
+constexpr const char*
+typeName<int64_t>()
+{
+    return "int64_t";
+}
+
+template <>
+constexpr const char*
+typeName<uint32_t>()
+{
+    return "uint32_t";
+}
+
+template <>
+constexpr const char*
+typeName<int32_t>()
+{
+    return "int32_t";
+}
+
+template <>
+constexpr const char*
+typeName<bool>()
+{
+    return "bool";
+}
+
+template <>
+constexpr const char*
+typeName<std::string>()
+{
+    return "std::string";
+}
+
+template <>
+constexpr const char*
+typeName<const char*>()
+{
+    return "const char*";
+}
+
+template <>
+constexpr const char*
+typeName<double>()
+{
+    return "double";
+}
+
+};  // namespace clio::detail
+
+#endif  // RIPPLE_APP_CONFIG_DETAIL_H_INCLUDED

--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -1,7 +1,7 @@
 #include <etl/ProbingETLSource.h>
 
 ProbingETLSource::ProbingETLSource(
-    boost::json::object const& config,
+    clio::Config const& config,
     boost::asio::io_context& ioc,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<SubscriptionManager> subscriptions,

--- a/src/etl/ProbingETLSource.h
+++ b/src/etl/ProbingETLSource.h
@@ -6,8 +6,11 @@
 #include <boost/beast/core/string.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
-#include <etl/ETLSource.h>
+
 #include <mutex>
+
+#include <config/Config.h>
+#include <etl/ETLSource.h>
 
 /// This ETLSource implementation attempts to connect over both secure websocket
 /// and plain websocket. First to connect pauses the other and the probing is
@@ -23,7 +26,7 @@ class ProbingETLSource : public ETLSource
 
 public:
     ProbingETLSource(
-        boost::json::object const& config,
+        clio::Config const& config,
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,

--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -311,7 +311,7 @@ private:
 
 public:
     ReportingETL(
-        boost::json::object const& config,
+        clio::Config const& config,
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
@@ -320,7 +320,7 @@ public:
 
     static std::shared_ptr<ReportingETL>
     make_ReportingETL(
-        boost::json::object const& config,
+        clio::Config const& config,
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,

--- a/src/subscriptions/SubscriptionManager.h
+++ b/src/subscriptions/SubscriptionManager.h
@@ -2,6 +2,7 @@
 #define SUBSCRIPTION_MANAGER_H
 
 #include <backend/BackendInterface.h>
+#include <config/Config.h>
 #include <memory>
 #include <subscriptions/Message.h>
 
@@ -107,17 +108,10 @@ class SubscriptionManager
 public:
     static std::shared_ptr<SubscriptionManager>
     make_SubscriptionManager(
-        boost::json::object const& config,
+        clio::Config const& config,
         std::shared_ptr<Backend::BackendInterface const> const& b)
     {
-        auto numThreads = 1;
-
-        if (config.contains("subscription_workers") &&
-            config.at("subscription_workers").is_int64())
-        {
-            numThreads = config.at("subscription_workers").as_int64();
-        }
-
+        auto numThreads = config.valueOr<uint64_t>("subscription_workers", 1);
         return std::make_shared<SubscriptionManager>(numThreads, b);
     }
 

--- a/src/util/Taggable.cpp
+++ b/src/util/Taggable.cpp
@@ -1,6 +1,5 @@
 #include <util/Taggable.h>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/json.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -47,25 +46,6 @@ TagDecoratorFactory::make() const
         default:
             return std::make_unique<TagDecorator<detail::NullTagGenerator>>();
     }
-}
-
-TagDecoratorFactory::Type
-TagDecoratorFactory::parseType(boost::json::object const& config)
-{
-    if (!config.contains("log_tag_style"))
-        return TagDecoratorFactory::Type::NONE;
-
-    auto style = config.at("log_tag_style").as_string();
-    if (boost::iequals(style, "int") || boost::iequals(style, "uint"))
-        return TagDecoratorFactory::Type::UINT;
-    else if (boost::iequals(style, "null") || boost::iequals(style, "none"))
-        return TagDecoratorFactory::Type::NONE;
-    else if (boost::iequals(style, "uuid"))
-        return TagDecoratorFactory::Type::UUID;
-    else
-        throw std::runtime_error(
-            "Could not parse `log_tag_style`: expected `uint`, `uuid` or "
-            "`null`");
 }
 
 TagDecoratorFactory

--- a/unittests/config.cpp
+++ b/unittests/config.cpp
@@ -1,0 +1,240 @@
+#include <config/Config.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/log/core.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <exception>
+#include <fstream>
+#include <iostream>
+
+using namespace clio;
+using namespace boost::log;
+using namespace std;
+namespace json = boost::json;
+
+constexpr static auto JSONData = R"JSON(
+    {
+        "arr": [                
+            { "first": 1234 },
+            { "second": true },
+            { "inner_section": [{ "inner": "works" }] },
+            ["127.0.0.1", "192.168.0.255"]
+        ],
+        "section": {
+            "test": {
+                "str": "hello",
+                "int": 9042,
+                "bool": true
+            }
+        },
+        "top": 420
+    }
+)JSON";
+
+class ConfigTest : public ::testing::Test
+{
+protected:
+    Config cfg{json::parse(JSONData)};
+
+    void
+    SetUp() override
+    {
+        // disable logging in test
+        core::get()->set_logging_enabled(false);
+    }
+};
+
+TEST_F(ConfigTest, SanityCheck)
+{
+    // throw on wrong key format etc.:
+    ASSERT_ANY_THROW((void)cfg.value<bool>(""));
+    ASSERT_ANY_THROW((void)cfg.value<bool>("a."));
+    ASSERT_ANY_THROW((void)cfg.value<bool>(".a"));
+    ASSERT_ANY_THROW((void)cfg.valueOr<bool>("", false));
+    ASSERT_ANY_THROW((void)cfg.valueOr<bool>("a.", false));
+    ASSERT_ANY_THROW((void)cfg.valueOr<bool>(".a", false));
+    ASSERT_ANY_THROW((void)cfg.maybeValue<bool>(""));
+    ASSERT_ANY_THROW((void)cfg.maybeValue<bool>("a."));
+    ASSERT_ANY_THROW((void)cfg.maybeValue<bool>(".a"));
+    ASSERT_ANY_THROW((void)cfg.valueOrThrow<bool>("", "custom"));
+    ASSERT_ANY_THROW((void)cfg.valueOrThrow<bool>("a.", "custom"));
+    ASSERT_ANY_THROW((void)cfg.valueOrThrow<bool>(".a", "custom"));
+    ASSERT_ANY_THROW((void)cfg.contains(""));
+    ASSERT_ANY_THROW((void)cfg.contains("a."));
+    ASSERT_ANY_THROW((void)cfg.contains(".a"));
+    ASSERT_ANY_THROW((void)cfg.section(""));
+    ASSERT_ANY_THROW((void)cfg.section("a."));
+    ASSERT_ANY_THROW((void)cfg.section(".a"));
+
+    // valid path, value does not exists -> optional functions should not throw
+    ASSERT_ANY_THROW((void)cfg.value<bool>("b"));
+    ASSERT_EQ(cfg.valueOr<bool>("b", false), false);
+    ASSERT_EQ(cfg.maybeValue<bool>("b"), std::nullopt);
+    ASSERT_ANY_THROW((void)cfg.valueOrThrow<bool>("b", "custom"));
+}
+
+TEST_F(ConfigTest, Access)
+{
+    ASSERT_EQ(cfg.value<int64_t>("top"), 420);
+    ASSERT_EQ(cfg.value<string>("section.test.str"), "hello");
+    ASSERT_EQ(cfg.value<int64_t>("section.test.int"), 9042);
+    ASSERT_EQ(cfg.value<bool>("section.test.bool"), true);
+
+    ASSERT_ANY_THROW((void)cfg.value<uint64_t>(
+        "section.test.bool"));  // wrong type requested
+    ASSERT_ANY_THROW((void)cfg.value<bool>("section.doesnotexist"));
+
+    ASSERT_EQ(cfg.valueOr<string>("section.test.str", "fallback"), "hello");
+    ASSERT_EQ(
+        cfg.valueOr<string>("section.test.nonexistent", "fallback"),
+        "fallback");
+    ASSERT_EQ(cfg.valueOr("section.test.bool", false), true);
+
+    ASSERT_ANY_THROW(
+        (void)cfg.valueOr("section.test.bool", 1234));  // wrong type requested
+}
+
+TEST_F(ConfigTest, ErrorHandling)
+{
+    try
+    {
+        (void)cfg.valueOrThrow<bool>("section.test.int", "msg");
+        ASSERT_FALSE(true);  // should not get here
+    }
+    catch (std::runtime_error const& e)
+    {
+        ASSERT_STREQ(e.what(), "msg");
+    }
+
+    ASSERT_EQ(cfg.valueOrThrow<bool>("section.test.bool", ""), true);
+
+    auto arr = cfg.array("arr");
+    try
+    {
+        (void)arr[3].array()[1].valueOrThrow<int>("msg");  // wrong type
+        ASSERT_FALSE(true);  // should not get here
+    }
+    catch (std::runtime_error const& e)
+    {
+        ASSERT_STREQ(e.what(), "msg");
+    }
+
+    ASSERT_EQ(arr[3].array()[1].valueOrThrow<string>(""), "192.168.0.255");
+
+    try
+    {
+        (void)cfg.arrayOrThrow("nonexisting.key", "msg");
+        ASSERT_FALSE(true);  // should not get here
+    }
+    catch (std::runtime_error const& e)
+    {
+        ASSERT_STREQ(e.what(), "msg");
+    }
+
+    ASSERT_EQ(cfg.arrayOrThrow("arr", "")[0].value<int>("first"), 1234);
+}
+
+TEST_F(ConfigTest, Section)
+{
+    auto sub = cfg.section("section.test");
+
+    ASSERT_EQ(sub.value<string>("str"), "hello");
+    ASSERT_EQ(sub.value<int64_t>("int"), 9042);
+    ASSERT_EQ(sub.value<bool>("bool"), true);
+}
+
+TEST_F(ConfigTest, Array)
+{
+    auto arr = cfg.array("arr");
+
+    ASSERT_EQ(arr.size(), 4);
+    ASSERT_EQ(arr[0].value<int64_t>("first"), 1234);
+
+    // check twice to verify that previous array(key) access did not destroy the
+    // store by using move
+    ASSERT_EQ(arr[2].array("inner_section")[0].value<string>("inner"), "works");
+    ASSERT_EQ(arr[2].array("inner_section")[0].value<string>("inner"), "works");
+
+    ASSERT_EQ(arr[3].array()[1].value<string>(), "192.168.0.255");
+
+    vector exp{"192.168.0.255", "127.0.0.1"};
+    for (auto inner = arr[3].array(); auto const& el : inner)
+    {
+        ASSERT_EQ(el.value<string>(), exp.back());
+        exp.pop_back();
+    }
+
+    ASSERT_TRUE(exp.empty());
+}
+
+/**
+ * @brief Simple custom data type with json parsing support
+ */
+struct Custom
+{
+    string a;
+    int b;
+    bool c;
+
+    friend Custom
+    tag_invoke(json::value_to_tag<Custom>, json::value const& value)
+    {
+        assert(value.is_object());
+        auto const& obj = value.as_object();
+        return {
+            obj.at("str").as_string().c_str(),
+            obj.at("int").as_int64(),
+            obj.at("bool").as_bool()};
+    }
+};
+
+TEST_F(ConfigTest, Extend)
+{
+    auto custom = cfg.value<Custom>("section.test");
+
+    ASSERT_EQ(custom.a, "hello");
+    ASSERT_EQ(custom.b, 9042);
+    ASSERT_EQ(custom.c, true);
+}
+
+/**
+ * @brief Simple temporary file util
+ */
+class TmpFile
+{
+public:
+    TmpFile(std::string const& data)
+        : tmpPath_{boost::filesystem::unique_path().string()}
+    {
+        std::ofstream of;
+        of.open(tmpPath_);
+        of << data;
+        of.close();
+    }
+    ~TmpFile()
+    {
+        std::remove(tmpPath_.c_str());
+    }
+    std::string
+    path() const
+    {
+        return tmpPath_;
+    }
+
+private:
+    std::string tmpPath_;
+};
+
+TEST_F(ConfigTest, File)
+{
+    auto tmp = TmpFile(JSONData);
+    auto conf = ConfigReader::open(tmp.path());
+
+    ASSERT_EQ(conf.value<int64_t>("top"), 420);
+
+    auto doesntexist = ConfigReader::open("nope");
+    ASSERT_EQ(doesntexist.valueOr<bool>("found", false), false);
+}

--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -9,6 +9,7 @@
 #include <boost/log/trivial.hpp>
 #include <backend/BackendFactory.h>
 #include <backend/BackendInterface.h>
+#include <config/Config.h>
 
 TEST(BackendTest, Basic)
 {
@@ -41,7 +42,7 @@ TEST(BackendTest, Basic)
             for (auto& config : configs)
             {
                 std::cout << keyspace << std::endl;
-                auto backend = Backend::make_Backend(ioc, config);
+                auto backend = Backend::make_Backend(ioc, clio::Config{config});
 
                 std::string rawHeader =
                     "03C3141A01633CD656F91B4EBB5EB89B791BD34DBC8A04BB6F407C5335"
@@ -1844,7 +1845,7 @@ TEST(Backend, cacheIntegration)
             for (auto& config : configs)
             {
                 std::cout << keyspace << std::endl;
-                auto backend = Backend::make_Backend(ioc, config);
+                auto backend = Backend::make_Backend(ioc, clio::Config{config});
                 backend->cache().setFull();
 
                 std::string rawHeader =


### PR DESCRIPTION
Fixes #321

This implements a simple abstraction on top of `boost::json` that allows to uniformly manage configuration options for `clio`.
It introduces helper functions to read config options using `keys` (mapped directly to the json configuration file). These functions allow for different access patterns such as automatically falling back to a user-specified value if the option is not present, throwing custom error messages, returning `std::optional` values, etc.     