### PR TITLE
Return noPermission in ledger admin call

### DIFF
--- a/src/rpc/handlers/Ledger.cpp
+++ b/src/rpc/handlers/Ledger.cpp
@@ -46,6 +46,12 @@ doLedger(Context const& context)
         diff = params.at("diff").as_bool();
     }
 
+    if (params.contains(JS(full)))
+        return Status{RippledError::rpcNOT_SUPPORTED};
+
+    if (params.contains(JS(accounts)))
+        return Status{RippledError::rpcNOT_SUPPORTED};
+
     auto v = ledgerInfoFromRequest(context);
     if (auto status = std::get_if<Status>(&v))
         return *status;


### PR DESCRIPTION
**Issue** (#280): ledger API call does not return an error message at all instead of returning noPermission error message when using admin methods.
**Fix**: Add noPermission error and conditional.