### PR TITLE
Push relevant perf-loglines down to trace level

### DIFF
--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -38,7 +38,7 @@ Context::Context(
     , counters(counters_)
     , clientIp(clientIp_)
 {
-    BOOST_LOG_TRIVIAL(debug) << tag() << "new Context created";
+    BOOST_LOG_TRIVIAL(trace) << tag() << "new Context created";
 }
 
 std::optional<Context>
@@ -395,11 +395,11 @@ buildResponse(Context const& ctx)
 
     try
     {
-        BOOST_LOG_TRIVIAL(debug)
+        BOOST_LOG_TRIVIAL(trace)
             << ctx.tag() << __func__ << " start executing rpc `" << ctx.method
             << '`';
         auto v = (*method)(ctx);
-        BOOST_LOG_TRIVIAL(debug)
+        BOOST_LOG_TRIVIAL(trace)
             << ctx.tag() << __func__ << " finish executing rpc `" << ctx.method
             << '`';
 

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -168,11 +168,11 @@ public:
         , lambda_(*this)
         , buffer_(std::move(buffer))
     {
-        BOOST_LOG_TRIVIAL(debug) << tag() << "http session created";
+        BOOST_LOG_TRIVIAL(trace) << tag() << "http session created";
     }
     virtual ~HttpBase()
     {
-        BOOST_LOG_TRIVIAL(debug) << tag() << "http session closed";
+        BOOST_LOG_TRIVIAL(trace) << tag() << "http session closed";
     }
 
     void

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -147,7 +147,7 @@ public:
         , counters_(counters)
         , queue_(queue)
     {
-        BOOST_LOG_TRIVIAL(info) << tag() << "session created";
+        BOOST_LOG_TRIVIAL(trace) << tag() << "session created";
     }
     virtual ~WsSession()
     {
@@ -244,7 +244,7 @@ public:
         if (ec)
             return wsFail(ec, "accept");
 
-        BOOST_LOG_TRIVIAL(info) << tag() << "accepting new connection";
+        BOOST_LOG_TRIVIAL(trace) << tag() << "accepting new connection";
 
         // Read a message
         do_read();
@@ -428,7 +428,7 @@ public:
         }
         else
         {
-            BOOST_LOG_TRIVIAL(debug)
+            BOOST_LOG_TRIVIAL(trace)
                 << tag() << __func__ << " adding to work queue";
 
             if (!queue_.postCoro(


### PR DESCRIPTION
Fixes #362 

This change was requested due to new loglines introduced while working on #212 started eating up more performance than desired. 

In the future the idea is to implement a separate Logger for performance metrics and have it configured separately from the main log. 