### PR TITLE
Add rpcINVALID_PARAMS error code

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -592,7 +592,7 @@ ledgerInfoFromRequest(Context const& ctx)
     }
 
     if (!ledgerSequence)
-        return Status{Error::rpcLGR_NOT_FOUND, "ledgerIndexMalformed"};
+        return Status{Error::rpcINVALID_PARAMS, "ledgerIndexMalformed"};
 
     auto lgrInfo =
         ctx.backend->fetchLedgerBySequence(*ledgerSequence, ctx.yield);


### PR DESCRIPTION
**Issue (#279)**: Ledger API call with one or more fields specified incorrectly does not return invalidParams
**FIx**: Add rpcINVALID_PARAMS error code 

**Note**: Upon testing, hit ledgerIndexMalformed error instead of ledgerNotFound. Don't think it's a good idea to downgrade from lgrNotFound to invalidParams (as the error message is less specific), but pushed the PR anyway