### PR TITLE
Implement logging abstraction

### DIFF
--- a/CMake/deps/gtest.cmake
+++ b/CMake/deps/gtest.cmake
@@ -11,6 +11,7 @@ if(NOT googletest_POPULATED)
 endif()
 
 target_link_libraries(clio_tests PUBLIC clio gtest_main)
+target_include_directories(clio_tests PRIVATE unittests)
 
 enable_testing()
 

--- a/CMake/settings.cmake
+++ b/CMake/settings.cmake
@@ -1,1 +1,1 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing -Wall -Werror -Wno-dangling-else")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-narrowing -Wno-dangling-else -Wno-deprecated-declarations")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,19 +99,21 @@ target_sources(clio PRIVATE
   src/rpc/handlers/Subscribe.cpp
   # Server
   src/rpc/handlers/ServerInfo.cpp
-  # Utility
+  # Utilities
   src/rpc/handlers/Random.cpp
-  src/util/Taggable.cpp
-  src/config/Config.cpp)
+  src/config/Config.cpp
+  src/log/Logger.cpp
+  src/util/Taggable.cpp)
 
 add_executable(clio_server src/main/main.cpp)
 target_link_libraries(clio_server PUBLIC clio)
 
 if(BUILD_TESTS)
-  add_executable(clio_tests
+  add_executable(clio_tests 
     unittests/RPCErrors.cpp 
-    unittests/config.cpp 
-    unittests/main.cpp)
+    unittests/Backend.cpp
+    unittests/Logger.cpp
+    unittests/Config.cpp)
   include(CMake/deps/gtest.cmake)
 endif()
 

--- a/example-config.json
+++ b/example-config.json
@@ -1,25 +1,22 @@
 {
-    "database":
-    {
-        "type":"cassandra",
-        "cassandra":
-        {
-            "contact_points":"127.0.0.1",
-            "port":9042,
-            "keyspace":"clio",
-            "replication_factor":1,
-            "table_prefix":"",
-            "max_write_requests_outstanding":25000,
-            "max_read_requests_outstanding":30000,
-            "threads":8
+    "database": {
+        "type": "cassandra",
+        "cassandra": {
+            "contact_points": "127.0.0.1",
+            "port": 9042,
+            "keyspace": "clio",
+            "replication_factor": 1,
+            "table_prefix": "",
+            "max_write_requests_outstanding": 25000,
+            "max_read_requests_outstanding": 30000,
+            "threads": 8
         }
     },
-    "etl_sources":
-    [
+    "etl_sources": [
         {
-            "ip":"127.0.0.1",
-            "ws_port":"6006",
-            "grpc_port":"50051"
+            "ip": "127.0.0.1",
+            "ws_port": "6006",
+            "grpc_port": "50051"
         }
     ],
     "dos_guard":
@@ -31,16 +28,43 @@
         "peers": [{"ip":"127.0.0.1","port":51234}]
     },
     "server":{
-        "ip":"0.0.0.0",
-        "port":51233
+        "ip": "0.0.0.0",
+        "port": 51233
     },
-    "log_level":"debug",
+    "log_channels": [
+        {
+            "channel": "Backend",
+            "log_level": "fatal"
+        },
+        {
+            "channel": "WebServer",
+            "log_level": "info"
+        },
+        {
+            "channel": "Subscriptions",
+            "log_level": "info"
+        },
+        {
+            "channel": "RPC",
+            "log_level": "error"
+        },
+        {
+            "channel": "ETL",
+            "log_level": "debug"
+        },
+        {
+            "channel": "Performance",
+            "log_level": "trace"
+        }
+    ],
+    "log_level": "info",
+    "log_format": "%TimeStamp% (%SourceLocation%) [%ThreadID%] %Channel%:%Severity% %Message%", // This is the default format
     "log_to_console": true,
-    "log_directory":"./clio_log",
+    "log_directory": "./clio_log",
     "log_rotation_size": 2048,
     "log_directory_max_size": 51200,
     "log_rotation_hour_interval": 12,
     "log_tag_style": "uint",
-    "extractor_threads":8,
-    "read_only":false
+    "extractor_threads": 8,
+    "read_only": false
 }

--- a/src/backend/BackendFactory.h
+++ b/src/backend/BackendFactory.h
@@ -1,16 +1,19 @@
 #ifndef RIPPLE_APP_REPORTING_BACKENDFACTORY_H_INCLUDED
 #define RIPPLE_APP_REPORTING_BACKENDFACTORY_H_INCLUDED
 
-#include <boost/algorithm/string.hpp>
 #include <backend/BackendInterface.h>
 #include <backend/CassandraBackend.h>
 #include <config/Config.h>
+#include <log/Logger.h>
+
+#include <boost/algorithm/string.hpp>
 
 namespace Backend {
 std::shared_ptr<BackendInterface>
 make_Backend(boost::asio::io_context& ioc, clio::Config const& config)
 {
-    BOOST_LOG_TRIVIAL(info) << __func__ << ": Constructing BackendInterface";
+    static clio::Logger log{"Backend"};
+    log.info() << "Constructing BackendInterface";
 
     auto readOnly = config.valueOr("read_only", false);
     auto type = config.value<std::string>("database.type");
@@ -34,8 +37,7 @@ make_Backend(boost::asio::io_context& ioc, clio::Config const& config)
         backend->updateRange(rng->maxSequence);
     }
 
-    BOOST_LOG_TRIVIAL(info)
-        << __func__ << ": Constructed BackendInterface Successfully";
+    log.info() << "Constructed BackendInterface Successfully";
 
     return backend;
 }

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -1,17 +1,15 @@
 #ifndef RIPPLE_APP_REPORTING_BACKENDINTERFACE_H_INCLUDED
 #define RIPPLE_APP_REPORTING_BACKENDINTERFACE_H_INCLUDED
 
-#include <boost/asio/spawn.hpp>
-#include <boost/json.hpp>
-#include <boost/log/trivial.hpp>
-
 #include <ripple/ledger/ReadView.h>
-
 #include <backend/DBHelpers.h>
 #include <backend/SimpleCache.h>
 #include <backend/Types.h>
-
 #include <config/Config.h>
+#include <log/Logger.h>
+
+#include <boost/asio/spawn.hpp>
+#include <boost/json.hpp>
 
 #include <thread>
 #include <type_traits>
@@ -46,6 +44,8 @@ template <class F>
 auto
 retryOnTimeout(F func, size_t waitMs = 500)
 {
+    static clio::Logger log{"Backend"};
+
     while (true)
     {
         try
@@ -54,9 +54,8 @@ retryOnTimeout(F func, size_t waitMs = 500)
         }
         catch (DatabaseTimeout& t)
         {
-            BOOST_LOG_TRIVIAL(error)
-                << __func__
-                << " Database request timed out. Sleeping and retrying ... ";
+            log.error()
+                << "Database request timed out. Sleeping and retrying ... ";
             std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
         }
     }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,6 +1,6 @@
 #include <config/Config.h>
+#include <log/Logger.h>
 
-#include <boost/log/trivial.hpp>
 #include <fstream>
 
 namespace clio {
@@ -161,11 +161,11 @@ ConfigReader::open(std::filesystem::path path)
     }
     catch (std::exception const& e)
     {
-        BOOST_LOG_TRIVIAL(error) << "Could not read configuration file from '"
-                                 << path.string() << "': " << e.what();
+        LogService::error() << "Could not read configuration file from '"
+                            << path.string() << "': " << e.what();
     }
 
-    BOOST_LOG_TRIVIAL(warning) << "Using empty default configuration";
+    LogService::warn() << "Using empty default configuration";
     return Config{};
 }
 

--- a/src/etl/ETLSource.cpp
+++ b/src/etl/ETLSource.cpp
@@ -5,18 +5,22 @@
 #include <boost/beast/ssl.hpp>
 #include <boost/json.hpp>
 #include <boost/json/src.hpp>
-#include <boost/log/trivial.hpp>
+
 #include <backend/DBHelpers.h>
 #include <etl/ETLSource.h>
 #include <etl/ProbingETLSource.h>
 #include <etl/ReportingETL.h>
+#include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
+
 #include <thread>
+
+using namespace clio;
 
 void
 ForwardCache::freshen()
 {
-    BOOST_LOG_TRIVIAL(trace) << "Freshening ForwardCache";
+    log_.trace() << "Freshening ForwardCache";
 
     auto numOutstanding =
         std::make_shared<std::atomic_uint>(latestForwarded_.size());
@@ -127,15 +131,11 @@ ETLSourceImpl<Derived>::reconnect(boost::beast::error_code ec)
     if (ec != boost::asio::error::operation_aborted &&
         ec != boost::asio::error::connection_refused)
     {
-        BOOST_LOG_TRIVIAL(error)
-            << __func__ << " : "
-            << "error code = " << ec << " - " << toString();
+        log_.error() << "error code = " << ec << " - " << toString();
     }
     else
     {
-        BOOST_LOG_TRIVIAL(warning)
-            << __func__ << " : "
-            << "error code = " << ec << " - " << toString();
+        log_.warn() << "error code = " << ec << " - " << toString();
     }
 
     // exponentially increasing timeouts, with a max of 30 seconds
@@ -144,7 +144,7 @@ ETLSourceImpl<Derived>::reconnect(boost::beast::error_code ec)
     timer_.expires_after(boost::asio::chrono::seconds(waitTime));
     timer_.async_wait([this](auto ec) {
         bool startAgain = (ec != boost::asio::error::operation_aborted);
-        BOOST_LOG_TRIVIAL(trace) << __func__ << " async_wait : ec = " << ec;
+        log_.trace() << "async_wait : ec = " << ec;
         derived().close(startAgain);
     });
 }
@@ -168,8 +168,8 @@ PlainETLSource::close(bool startAgain)
                 [this, startAgain](auto ec) {
                     if (ec)
                     {
-                        BOOST_LOG_TRIVIAL(error)
-                            << __func__ << " async_close : "
+                        log_.error()
+                            << " async_close : "
                             << "error code = " << ec << " - " << toString();
                     }
                     closing_ = false;
@@ -213,8 +213,8 @@ SslETLSource::close(bool startAgain)
                 [this, startAgain](auto ec) {
                     if (ec)
                     {
-                        BOOST_LOG_TRIVIAL(error)
-                            << __func__ << " async_close : "
+                        log_.error()
+                            << " async_close : "
                             << "error code = " << ec << " - " << toString();
                     }
                     closing_ = false;
@@ -246,8 +246,7 @@ ETLSourceImpl<Derived>::onResolve(
     boost::beast::error_code ec,
     boost::asio::ip::tcp::resolver::results_type results)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     if (ec)
     {
         // try again
@@ -269,8 +268,7 @@ PlainETLSource::onConnect(
     boost::beast::error_code ec,
     boost::asio::ip::tcp::resolver::results_type::endpoint_type endpoint)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     if (ec)
     {
         // start over
@@ -311,8 +309,7 @@ SslETLSource::onConnect(
     boost::beast::error_code ec,
     boost::asio::ip::tcp::resolver::results_type::endpoint_type endpoint)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     if (ec)
     {
         // start over
@@ -371,8 +368,7 @@ template <class Derived>
 void
 ETLSourceImpl<Derived>::onHandshake(boost::beast::error_code ec)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     if (auto action = hooks_.onConnected(ec);
         action == ETLSourceHooks::Action::STOP)
         return;
@@ -389,7 +385,7 @@ ETLSourceImpl<Derived>::onHandshake(boost::beast::error_code ec)
             {"streams",
              {"ledger", "manifests", "validations", "transactions_proposed"}}};
         std::string s = boost::json::serialize(jv);
-        BOOST_LOG_TRIVIAL(trace) << "Sending subscribe stream message";
+        log_.trace() << "Sending subscribe stream message";
 
         derived().ws().set_option(
             boost::beast::websocket::stream_base::decorator(
@@ -415,8 +411,7 @@ ETLSourceImpl<Derived>::onWrite(
     boost::beast::error_code ec,
     size_t bytesWritten)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     if (ec)
     {
         // start over
@@ -433,8 +428,7 @@ template <class Derived>
 void
 ETLSourceImpl<Derived>::onRead(boost::beast::error_code ec, size_t size)
 {
-    BOOST_LOG_TRIVIAL(trace)
-        << __func__ << " : ec = " << ec << " - " << toString();
+    log_.trace() << "ec = " << ec << " - " << toString();
     // if error or error reading message, start over
     if (ec)
     {
@@ -446,8 +440,7 @@ ETLSourceImpl<Derived>::onRead(boost::beast::error_code ec, size_t size)
         boost::beast::flat_buffer buffer;
         swap(readBuffer_, buffer);
 
-        BOOST_LOG_TRIVIAL(trace)
-            << __func__ << " : calling async_read - " << toString();
+        log_.trace() << "calling async_read - " << toString();
         derived().ws().async_read(
             readBuffer_, [this](auto ec, size_t size) { onRead(ec, size); });
     }
@@ -457,7 +450,7 @@ template <class Derived>
 bool
 ETLSourceImpl<Derived>::handleMessage()
 {
-    BOOST_LOG_TRIVIAL(trace) << __func__ << " : " << toString();
+    log_.trace() << toString();
 
     setLastMsgTime();
     connected_ = true;
@@ -466,9 +459,9 @@ ETLSourceImpl<Derived>::handleMessage()
         std::string msg{
             static_cast<char const*>(readBuffer_.data().data()),
             readBuffer_.size()};
-        BOOST_LOG_TRIVIAL(trace) << __func__ << msg;
+        log_.trace() << msg;
         boost::json::value raw = boost::json::parse(msg);
-        BOOST_LOG_TRIVIAL(trace) << __func__ << " parsed";
+        log_.trace() << "parsed";
         boost::json::object response = raw.as_object();
 
         uint32_t ledgerIndex = 0;
@@ -487,20 +480,16 @@ ETLSourceImpl<Derived>::handleMessage()
                 setValidatedRange(
                     {validatedLedgers.c_str(), validatedLedgers.size()});
             }
-            BOOST_LOG_TRIVIAL(debug)
-                << __func__ << " : "
-                << "Received a message on ledger "
-                << " subscription stream. Message : " << response << " - "
-                << toString();
+            log_.info() << "Received a message on ledger "
+                        << " subscription stream. Message : " << response
+                        << " - " << toString();
         }
         else if (
             response.contains("type") && response["type"] == "ledgerClosed")
         {
-            BOOST_LOG_TRIVIAL(debug)
-                << __func__ << " : "
-                << "Received a message on ledger "
-                << " subscription stream. Message : " << response << " - "
-                << toString();
+            log_.info() << "Received a message on ledger "
+                        << " subscription stream. Message : " << response
+                        << " - " << toString();
             if (response.contains("ledger_index"))
             {
                 ledgerIndex = response["ledger_index"].as_int64();
@@ -539,23 +528,23 @@ ETLSourceImpl<Derived>::handleMessage()
 
         if (ledgerIndex != 0)
         {
-            BOOST_LOG_TRIVIAL(trace)
-                << __func__ << " : "
-                << "Pushing ledger sequence = " << ledgerIndex << " - "
-                << toString();
+            log_.trace() << "Pushing ledger sequence = " << ledgerIndex << " - "
+                         << toString();
             networkValidatedLedgers_->push(ledgerIndex);
         }
         return true;
     }
     catch (std::exception const& e)
     {
-        BOOST_LOG_TRIVIAL(error) << "Exception in handleMessage : " << e.what();
+        log_.error() << "Exception in handleMessage : " << e.what();
         return false;
     }
 }
 
 class AsyncCallData
 {
+    clio::Logger log_{"ETL"};
+
     std::unique_ptr<org::xrpl::rpc::v1::GetLedgerDataResponse> cur_;
     std::unique_ptr<org::xrpl::rpc::v1::GetLedgerDataResponse> next_;
 
@@ -585,11 +574,11 @@ public:
 
         unsigned char prefix = marker.data()[0];
 
-        BOOST_LOG_TRIVIAL(debug)
-            << "Setting up AsyncCallData. marker = " << ripple::strHex(marker)
-            << " . prefix = " << ripple::strHex(std::string(1, prefix))
-            << " . nextPrefix_ = "
-            << ripple::strHex(std::string(1, nextPrefix_));
+        log_.debug() << "Setting up AsyncCallData. marker = "
+                     << ripple::strHex(marker)
+                     << " . prefix = " << ripple::strHex(std::string(1, prefix))
+                     << " . nextPrefix_ = "
+                     << ripple::strHex(std::string(1, nextPrefix_));
 
         assert(nextPrefix_ > prefix || nextPrefix_ == 0x00);
 
@@ -609,26 +598,24 @@ public:
         bool abort,
         bool cacheOnly = false)
     {
-        BOOST_LOG_TRIVIAL(trace) << "Processing response. "
-                                 << "Marker prefix = " << getMarkerPrefix();
+        log_.trace() << "Processing response. "
+                     << "Marker prefix = " << getMarkerPrefix();
         if (abort)
         {
-            BOOST_LOG_TRIVIAL(error) << "AsyncCallData aborted";
+            log_.error() << "AsyncCallData aborted";
             return CallStatus::ERRORED;
         }
         if (!status_.ok())
         {
-            BOOST_LOG_TRIVIAL(error)
-                << "AsyncCallData status_ not ok: "
-                << " code = " << status_.error_code()
-                << " message = " << status_.error_message();
+            log_.error() << "AsyncCallData status_ not ok: "
+                         << " code = " << status_.error_code()
+                         << " message = " << status_.error_message();
             return CallStatus::ERRORED;
         }
         if (!next_->is_unlimited())
         {
-            BOOST_LOG_TRIVIAL(warning)
-                << "AsyncCallData is_unlimited is false. Make sure "
-                   "secure_gateway is set correctly at the ETL source";
+            log_.warn() << "AsyncCallData is_unlimited is false. Make sure "
+                           "secure_gateway is set correctly at the ETL source";
         }
 
         std::swap(cur_, next_);
@@ -651,7 +638,7 @@ public:
             call(stub, cq);
         }
 
-        BOOST_LOG_TRIVIAL(trace) << "Writing objects";
+        log_.trace() << "Writing objects";
         std::vector<Backend::LedgerObject> cacheUpdates;
         cacheUpdates.reserve(cur_->ledger_objects().objects_size());
         for (int i = 0; i < cur_->ledger_objects().objects_size(); ++i)
@@ -681,7 +668,7 @@ public:
         }
         backend.cache().update(
             cacheUpdates, request_.ledger().sequence(), cacheOnly);
-        BOOST_LOG_TRIVIAL(trace) << "Wrote objects";
+        log_.trace() << "Wrote objects";
 
         return more ? CallStatus::MORE : CallStatus::DONE;
     }
@@ -745,8 +732,8 @@ ETLSourceImpl<Derived>::loadInitialLedger(
         calls.emplace_back(sequence, markers[i], nextMarker);
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "Starting data download for ledger " << sequence
-                             << ". Using source = " << toString();
+    log_.debug() << "Starting data download for ledger " << sequence
+                 << ". Using source = " << toString();
 
     for (auto& c : calls)
         c.call(stub_, cq);
@@ -764,21 +751,19 @@ ETLSourceImpl<Derived>::loadInitialLedger(
 
         if (!ok)
         {
-            BOOST_LOG_TRIVIAL(error) << "loadInitialLedger - ok is false";
+            log_.error() << "loadInitialLedger - ok is false";
             return false;
             // handle cancelled
         }
         else
         {
-            BOOST_LOG_TRIVIAL(trace)
-                << "Marker prefix = " << ptr->getMarkerPrefix();
+            log_.trace() << "Marker prefix = " << ptr->getMarkerPrefix();
             auto result = ptr->process(stub_, cq, *backend_, abort, cacheOnly);
             if (result != AsyncCallData::CallStatus::MORE)
             {
                 numFinished++;
-                BOOST_LOG_TRIVIAL(debug)
-                    << "Finished a marker. "
-                    << "Current number of finished = " << numFinished;
+                log_.debug() << "Finished a marker. "
+                             << "Current number of finished = " << numFinished;
                 std::string lastKey = ptr->getLastKey();
                 if (lastKey.size())
                     edgeKeys.push_back(ptr->getLastKey());
@@ -789,16 +774,14 @@ ETLSourceImpl<Derived>::loadInitialLedger(
             }
             if (backend_->cache().size() > progress)
             {
-                BOOST_LOG_TRIVIAL(info)
-                    << "Downloaded " << backend_->cache().size()
-                    << " records from rippled";
+                log_.info() << "Downloaded " << backend_->cache().size()
+                            << " records from rippled";
                 progress += incr;
             }
         }
     }
-    BOOST_LOG_TRIVIAL(info)
-        << __func__ << " - finished loadInitialLedger. cache size = "
-        << backend_->cache().size();
+    log_.info() << "Finished loadInitialLedger. cache size = "
+                << backend_->cache().size();
     size_t numWrites = 0;
     if (!abort)
     {
@@ -808,9 +791,7 @@ ETLSourceImpl<Derived>::loadInitialLedger(
             auto start = std::chrono::system_clock::now();
             for (auto& key : edgeKeys)
             {
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__
-                    << " writing edge key = " << ripple::strHex(key);
+                log_.debug() << "Writing edge key = " << ripple::strHex(key);
                 auto succ = backend_->cache().getSuccessor(
                     *ripple::uint256::fromVoidChecked(key), sequence);
                 if (succ)
@@ -840,10 +821,9 @@ ETLSourceImpl<Derived>::loadInitialLedger(
                         assert(succ);
                         if (succ->key == cur->key)
                         {
-                            BOOST_LOG_TRIVIAL(debug)
-                                << __func__ << " Writing book successor = "
-                                << ripple::strHex(base) << " - "
-                                << ripple::strHex(cur->key);
+                            log_.debug() << "Writing book successor = "
+                                         << ripple::strHex(base) << " - "
+                                         << ripple::strHex(cur->key);
 
                             backend_->writeSuccessor(
                                 uint256ToString(base),
@@ -855,8 +835,7 @@ ETLSourceImpl<Derived>::loadInitialLedger(
                 }
                 prev = std::move(cur->key);
                 if (numWrites % 100000 == 0 && numWrites != 0)
-                    BOOST_LOG_TRIVIAL(info) << __func__ << " Wrote "
-                                            << numWrites << " book successors";
+                    log_.info() << "Wrote " << numWrites << " book successors";
             }
 
             backend_->writeSuccessor(
@@ -869,9 +848,8 @@ ETLSourceImpl<Derived>::loadInitialLedger(
             auto seconds =
                 std::chrono::duration_cast<std::chrono::seconds>(end - start)
                     .count();
-            BOOST_LOG_TRIVIAL(info)
-                << __func__
-                << " - Looping through cache and submitting all writes took "
+            log_.info()
+                << "Looping through cache and submitting all writes took "
                 << seconds
                 << " seconds. numWrites = " << std::to_string(numWrites);
         }
@@ -902,11 +880,10 @@ ETLSourceImpl<Derived>::fetchLedger(
     grpc::Status status = stub_->GetLedger(&context, request, &response);
     if (status.ok() && !response.is_unlimited())
     {
-        BOOST_LOG_TRIVIAL(warning)
-            << "ETLSourceImpl::fetchLedger - is_unlimited is "
-               "false. Make sure secure_gateway is set "
-               "correctly on the ETL source. source = "
-            << toString() << " status = " << status.error_message();
+        log_.warn() << "ETLSourceImpl::fetchLedger - is_unlimited is "
+                       "false. Make sure secure_gateway is set "
+                       "correctly on the ETL source. source = "
+                    << toString() << " status = " << status.error_message();
     }
     return {status, std::move(response)};
 }
@@ -951,8 +928,7 @@ ETLLoadBalancer::ETLLoadBalancer(
             entry, ioContext, backend, subscriptions, nwvl, *this);
 
         sources_.push_back(std::move(source));
-        BOOST_LOG_TRIVIAL(info) << __func__ << " : added etl source - "
-                                << sources_.back()->toString();
+        log_.info() << "Added etl source - " << sources_.back()->toString();
     }
 }
 
@@ -965,9 +941,9 @@ ETLLoadBalancer::loadInitialLedger(uint32_t sequence, bool cacheOnly)
                 source->loadInitialLedger(sequence, downloadRanges_, cacheOnly);
             if (!res)
             {
-                BOOST_LOG_TRIVIAL(error) << "Failed to download initial ledger."
-                                         << " Sequence = " << sequence
-                                         << " source = " << source->toString();
+                log_.error() << "Failed to download initial ledger."
+                             << " Sequence = " << sequence
+                             << " source = " << source->toString();
             }
             return res;
         },
@@ -982,26 +958,24 @@ ETLLoadBalancer::fetchLedger(
 {
     org::xrpl::rpc::v1::GetLedgerResponse response;
     bool success = execute(
-        [&response, ledgerSequence, getObjects, getObjectNeighbors](
+        [&response, ledgerSequence, getObjects, getObjectNeighbors, log = log_](
             auto& source) {
             auto [status, data] = source->fetchLedger(
                 ledgerSequence, getObjects, getObjectNeighbors);
             response = std::move(data);
             if (status.ok() && response.validated())
             {
-                BOOST_LOG_TRIVIAL(info)
-                    << "Successfully fetched ledger = " << ledgerSequence
-                    << " from source = " << source->toString();
+                log.info() << "Successfully fetched ledger = " << ledgerSequence
+                           << " from source = " << source->toString();
                 return true;
             }
             else
             {
-                BOOST_LOG_TRIVIAL(warning)
-                    << "Error getting ledger = " << ledgerSequence
-                    << " Reply : " << response.DebugString()
-                    << " error_code : " << status.error_code()
-                    << " error_msg : " << status.error_message()
-                    << " source = " << source->toString();
+                log.warn() << "Error getting ledger = " << ledgerSequence
+                           << ", Reply: " << response.DebugString()
+                           << ", error_code: " << status.error_code()
+                           << ", error_msg: " << status.error_message()
+                           << ", source = " << source->toString();
                 return false;
             }
         },
@@ -1042,7 +1016,7 @@ ETLSourceImpl<Derived>::forwardToRippled(
 {
     if (auto resp = forwardCache_.get(request); resp)
     {
-        BOOST_LOG_TRIVIAL(debug) << "request hit forwardCache";
+        log_.debug() << "request hit forwardCache";
         return resp;
     }
 
@@ -1056,14 +1030,13 @@ ETLSourceImpl<Derived>::requestFromRippled(
     std::string const& clientIp,
     boost::asio::yield_context& yield) const
 {
-    BOOST_LOG_TRIVIAL(trace) << "Attempting to forward request to tx. "
-                             << "request = " << boost::json::serialize(request);
+    log_.trace() << "Attempting to forward request to tx. "
+                 << "request = " << boost::json::serialize(request);
 
     boost::json::object response;
     if (!connected_)
     {
-        BOOST_LOG_TRIVIAL(error)
-            << "Attempted to proxy but failed to connect to tx";
+        log_.error() << "Attempted to proxy but failed to connect to tx";
         return {};
     }
     namespace beast = boost::beast;          // from <boost/beast.hpp>
@@ -1077,7 +1050,7 @@ ETLSourceImpl<Derived>::requestFromRippled(
         // These objects perform our I/O
         tcp::resolver resolver{ioc_};
 
-        BOOST_LOG_TRIVIAL(trace) << "Creating websocket";
+        log_.trace() << "Creating websocket";
         auto ws = std::make_unique<websocket::stream<beast::tcp_stream>>(ioc_);
 
         // Look up the domain name
@@ -1087,7 +1060,7 @@ ETLSourceImpl<Derived>::requestFromRippled(
 
         ws->next_layer().expires_after(std::chrono::seconds(3));
 
-        BOOST_LOG_TRIVIAL(trace) << "Connecting websocket";
+        log_.trace() << "Connecting websocket";
         // Make the connection on the IP address we get from a lookup
         ws->next_layer().async_connect(results, yield[ec]);
         if (ec)
@@ -1106,15 +1079,15 @@ ETLSourceImpl<Derived>::requestFromRippled(
                         " websocket-client-coro");
                 req.set(http::field::forwarded, "for=" + clientIp);
             }));
-        BOOST_LOG_TRIVIAL(trace) << "client ip: " << clientIp;
+        log_.trace() << "client ip: " << clientIp;
 
-        BOOST_LOG_TRIVIAL(trace) << "Performing websocket handshake";
+        log_.trace() << "Performing websocket handshake";
         // Perform the websocket handshake
         ws->async_handshake(ip_, "/", yield[ec]);
         if (ec)
             return {};
 
-        BOOST_LOG_TRIVIAL(trace) << "Sending request";
+        log_.trace() << "Sending request";
         // Send the message
         ws->async_write(
             net::buffer(boost::json::serialize(request)), yield[ec]);
@@ -1132,11 +1105,11 @@ ETLSourceImpl<Derived>::requestFromRippled(
 
         if (!parsed.is_object())
         {
-            BOOST_LOG_TRIVIAL(error)
-                << "Error parsing response: " << std::string{begin, end};
+            log_.error() << "Error parsing response: "
+                         << std::string{begin, end};
             return {};
         }
-        BOOST_LOG_TRIVIAL(trace) << "Successfully forward request";
+        log_.trace() << "Successfully forward request";
 
         response = parsed.as_object();
 
@@ -1145,7 +1118,7 @@ ETLSourceImpl<Derived>::requestFromRippled(
     }
     catch (std::exception const& e)
     {
-        BOOST_LOG_TRIVIAL(error) << "Encountered exception : " << e.what();
+        log_.error() << "Encountered exception : " << e.what();
         return {};
     }
 }
@@ -1162,47 +1135,38 @@ ETLLoadBalancer::execute(Func f, uint32_t ledgerSequence)
     {
         auto& source = sources_[sourceIdx];
 
-        BOOST_LOG_TRIVIAL(debug)
-            << __func__ << " : "
-            << "Attempting to execute func. ledger sequence = "
-            << ledgerSequence << " - source = " << source->toString();
+        log_.debug() << "Attempting to execute func. ledger sequence = "
+                     << ledgerSequence << " - source = " << source->toString();
         if (source->hasLedger(ledgerSequence) || true)
         {
             bool res = f(source);
             if (res)
             {
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " : "
-                    << "Successfully executed func at source = "
-                    << source->toString()
-                    << " - ledger sequence = " << ledgerSequence;
+                log_.debug() << "Successfully executed func at source = "
+                             << source->toString()
+                             << " - ledger sequence = " << ledgerSequence;
                 break;
             }
             else
             {
-                BOOST_LOG_TRIVIAL(warning)
-                    << __func__ << " : "
-                    << "Failed to execute func at source = "
-                    << source->toString()
-                    << " - ledger sequence = " << ledgerSequence;
+                log_.warn() << "Failed to execute func at source = "
+                            << source->toString()
+                            << " - ledger sequence = " << ledgerSequence;
             }
         }
         else
         {
-            BOOST_LOG_TRIVIAL(warning)
-                << __func__ << " : "
-                << "Ledger not present at source = " << source->toString()
-                << " - ledger sequence = " << ledgerSequence;
+            log_.warn() << "Ledger not present at source = "
+                        << source->toString()
+                        << " - ledger sequence = " << ledgerSequence;
         }
         sourceIdx = (sourceIdx + 1) % sources_.size();
         numAttempts++;
         if (numAttempts % sources_.size() == 0)
         {
-            BOOST_LOG_TRIVIAL(error)
-                << __func__ << " : "
-                << "Error executing function "
-                << " - ledger sequence = " << ledgerSequence
-                << " - Tried all sources. Sleeping and trying again";
+            log_.error() << "Error executing function "
+                         << " - ledger sequence = " << ledgerSequence
+                         << " - Tried all sources. Sleeping and trying again";
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
     }

--- a/src/etl/NFTHelpers.cpp
+++ b/src/etl/NFTHelpers.cpp
@@ -107,8 +107,7 @@ getNFTokenMintData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
             NFTsData(tokenIDResult.front(), *owner, txMeta, false)};
 
     std::stringstream msg;
-    msg << __func__ << " - unexpected NFTokenMint data in tx "
-        << sttx.getTransactionID();
+    msg << " - unexpected NFTokenMint data in tx " << sttx.getTransactionID();
     throw std::runtime_error(msg.str());
 }
 
@@ -173,7 +172,7 @@ getNFTokenBurnData(ripple::TxMeta const& txMeta, ripple::STTx const& sttx)
     }
 
     std::stringstream msg;
-    msg << __func__ << " - could not determine owner at burntime for tx "
+    msg << " - could not determine owner at burntime for tx "
         << sttx.getTransactionID();
     throw std::runtime_error(msg.str());
 }
@@ -198,7 +197,7 @@ getNFTokenAcceptOfferData(
         if (affectedBuyOffer == txMeta.getNodes().end())
         {
             std::stringstream msg;
-            msg << __func__ << " - unexpected NFTokenAcceptOffer data in tx "
+            msg << " - unexpected NFTokenAcceptOffer data in tx "
                 << sttx.getTransactionID();
             throw std::runtime_error(msg.str());
         }
@@ -228,7 +227,7 @@ getNFTokenAcceptOfferData(
     if (affectedSellOffer == txMeta.getNodes().end())
     {
         std::stringstream msg;
-        msg << __func__ << " - unexpected NFTokenAcceptOffer data in tx "
+        msg << " - unexpected NFTokenAcceptOffer data in tx "
             << sttx.getTransactionID();
         throw std::runtime_error(msg.str());
     }
@@ -278,7 +277,7 @@ getNFTokenAcceptOfferData(
     }
 
     std::stringstream msg;
-    msg << __func__ << " - unexpected NFTokenAcceptOffer data in tx "
+    msg << " - unexpected NFTokenAcceptOffer data in tx "
         << sttx.getTransactionID();
     throw std::runtime_error(msg.str());
 }

--- a/src/etl/ProbingETLSource.cpp
+++ b/src/etl/ProbingETLSource.cpp
@@ -1,4 +1,7 @@
 #include <etl/ProbingETLSource.h>
+#include <log/Logger.h>
+
+using namespace clio;
 
 ProbingETLSource::ProbingETLSource(
     clio::Config const& config,
@@ -85,7 +88,8 @@ std::string
 ProbingETLSource::toString() const
 {
     if (!currentSrc_)
-        return "{ probing }";
+        return "{probing... ws: " + plainSrc_->toString() +
+            ", wss: " + sslSrc_->toString() + "}";
     return currentSrc_->toString();
 }
 
@@ -148,9 +152,8 @@ ProbingETLSource::make_SSLHooks() noexcept
                 {
                     plainSrc_->pause();
                     currentSrc_ = sslSrc_;
-                    BOOST_LOG_TRIVIAL(info)
-                        << "Selected WSS as the main source: "
-                        << currentSrc_->toString();
+                    log_.info() << "Selected WSS as the main source: "
+                                << currentSrc_->toString();
                 }
                 return ETLSourceHooks::Action::PROCEED;
             },
@@ -179,9 +182,8 @@ ProbingETLSource::make_PlainHooks() noexcept
                 {
                     sslSrc_->pause();
                     currentSrc_ = plainSrc_;
-                    BOOST_LOG_TRIVIAL(info)
-                        << "Selected Plain WS as the main source: "
-                        << currentSrc_->toString();
+                    log_.info() << "Selected Plain WS as the main source: "
+                                << currentSrc_->toString();
                 }
                 return ETLSourceHooks::Action::PROCEED;
             },

--- a/src/etl/ProbingETLSource.h
+++ b/src/etl/ProbingETLSource.h
@@ -11,6 +11,7 @@
 
 #include <config/Config.h>
 #include <etl/ETLSource.h>
+#include <log/Logger.h>
 
 /// This ETLSource implementation attempts to connect over both secure websocket
 /// and plain websocket. First to connect pauses the other and the probing is
@@ -18,6 +19,8 @@
 /// connection the probing is kickstarted again.
 class ProbingETLSource : public ETLSource
 {
+    clio::Logger log_{"ETL"};
+
     std::mutex mtx_;
     boost::asio::ssl::context sslCtx_;
     std::shared_ptr<ETLSource> sslSrc_;

--- a/src/etl/ReportingETL.cpp
+++ b/src/etl/ReportingETL.cpp
@@ -1,20 +1,25 @@
 #include <ripple/basics/StringUtilities.h>
+#include <ripple/beast/core/CurrentThreadName.h>
+
 #include <backend/DBHelpers.h>
 #include <etl/ReportingETL.h>
+#include <log/Logger.h>
+#include <subscriptions/SubscriptionManager.h>
 
-#include <ripple/beast/core/CurrentThreadName.h>
 #include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
+
 #include <cstdlib>
 #include <iostream>
 #include <string>
-#include <subscriptions/SubscriptionManager.h>
 #include <thread>
 #include <variant>
 
-namespace detail {
+using namespace clio;
+
+namespace clio::detail {
 /// Convenience function for printing out basic ledger info
 std::string
 toString(ripple::LedgerInfo const& info)
@@ -26,7 +31,7 @@ toString(ripple::LedgerInfo const& info)
        << " ParentHash : " << strHex(info.parentHash) << " }";
     return ss.str();
 }
-}  // namespace detail
+}  // namespace clio::detail
 
 FormattedTransactionsData
 ReportingETL::insertTransactions(
@@ -43,9 +48,7 @@ ReportingETL::insertTransactions(
         ripple::SerialIter it{raw->data(), raw->size()};
         ripple::STTx sttx{it};
 
-        BOOST_LOG_TRIVIAL(trace)
-            << __func__ << " : "
-            << "Inserting transaction = " << sttx.getTransactionID();
+        log_.trace() << "Inserting transaction = " << sttx.getTransactionID();
 
         ripple::TxMeta txMeta{
             sttx.getTransactionID(), ledger.seq, txn.metadata_blob()};
@@ -97,8 +100,7 @@ ReportingETL::loadInitialLedger(uint32_t startingSequence)
     auto rng = backend_->hardFetchLedgerRangeNoThrow();
     if (rng)
     {
-        BOOST_LOG_TRIVIAL(fatal) << __func__ << " : "
-                                 << "Database is not empty";
+        log_.fatal() << "Database is not empty";
         assert(false);
         return {};
     }
@@ -114,23 +116,21 @@ ReportingETL::loadInitialLedger(uint32_t startingSequence)
     ripple::LedgerInfo lgrInfo =
         deserializeHeader(ripple::makeSlice(ledgerData->ledger_header()));
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Deserialized ledger header. " << detail::toString(lgrInfo);
+    log_.debug() << "Deserialized ledger header. " << detail::toString(lgrInfo);
 
     auto start = std::chrono::system_clock::now();
 
     backend_->startWrites();
 
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " started writes";
+    log_.debug() << "Started writes";
 
     backend_->writeLedger(
         lgrInfo, std::move(*ledgerData->mutable_ledger_header()));
 
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " wrote ledger";
+    log_.debug() << "Wrote ledger";
     FormattedTransactionsData insertTxResult =
         insertTransactions(lgrInfo, *ledgerData);
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " inserted txns";
+    log_.debug() << "Inserted txns";
 
     // download the full account state map. This function downloads full ledger
     // data and pushes the downloaded data into the writeQueue. asyncWriter
@@ -138,7 +138,7 @@ ReportingETL::loadInitialLedger(uint32_t startingSequence)
     // Once the below call returns, all data has been pushed into the queue
     loadBalancer_->loadInitialLedger(startingSequence);
 
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " loaded initial ledger";
+    log_.debug() << "Loaded initial ledger";
 
     if (!stopping_)
     {
@@ -150,20 +150,19 @@ ReportingETL::loadInitialLedger(uint32_t startingSequence)
     backend_->finishWrites(startingSequence);
 
     auto end = std::chrono::system_clock::now();
-    BOOST_LOG_TRIVIAL(debug) << "Time to download and store ledger = "
-                             << ((end - start).count()) / 1000000000.0;
+    log_.debug() << "Time to download and store ledger = "
+                 << ((end - start).count()) / 1000000000.0;
     return lgrInfo;
 }
 
 void
 ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
 {
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " - Publishing ledger " << std::to_string(lgrInfo.seq);
+    log_.info() << "Publishing ledger " << std::to_string(lgrInfo.seq);
 
     if (!writing_)
     {
-        BOOST_LOG_TRIVIAL(debug) << __func__ << " - Updating cache";
+        log_.info() << "Updating cache";
 
         std::vector<Backend::LedgerObject> diff =
             Backend::synchronousAndRetryOnTimeout([&](auto yield) {
@@ -205,12 +204,11 @@ ReportingETL::publishLedger(ripple::LedgerInfo const& lgrInfo)
 
         subscriptions_->pubBookChanges(lgrInfo, transactions);
 
-        BOOST_LOG_TRIVIAL(info) << __func__ << " - Published ledger "
-                                << std::to_string(lgrInfo.seq);
+        log_.info() << "Published ledger " << std::to_string(lgrInfo.seq);
     }
     else
-        BOOST_LOG_TRIVIAL(info) << __func__ << " - Skipping publishing ledger "
-                                << std::to_string(lgrInfo.seq);
+        log_.info() << "Skipping publishing ledger "
+                    << std::to_string(lgrInfo.seq);
     setLastPublish();
 }
 
@@ -219,9 +217,7 @@ ReportingETL::publishLedger(
     uint32_t ledgerSequence,
     std::optional<uint32_t> maxAttempts)
 {
-    BOOST_LOG_TRIVIAL(info)
-        << __func__ << " : "
-        << "Attempting to publish ledger = " << ledgerSequence;
+    log_.info() << "Attempting to publish ledger = " << ledgerSequence;
     size_t numAttempts = 0;
     while (!stopping_)
     {
@@ -229,17 +225,15 @@ ReportingETL::publishLedger(
 
         if (!range || range->maxSequence < ledgerSequence)
         {
-            BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                                     << "Trying to publish. Could not find "
-                                        "ledger with sequence = "
-                                     << ledgerSequence;
+            log_.debug() << "Trying to publish. Could not find "
+                            "ledger with sequence = "
+                         << ledgerSequence;
             // We try maxAttempts times to publish the ledger, waiting one
             // second in between each attempt.
             if (maxAttempts && numAttempts >= maxAttempts)
             {
-                BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                                         << "Failed to publish ledger after "
-                                         << numAttempts << " attempts.";
+                log_.debug() << "Failed to publish ledger after " << numAttempts
+                             << " attempts.";
                 return false;
             }
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -264,25 +258,19 @@ ReportingETL::publishLedger(
 std::optional<org::xrpl::rpc::v1::GetLedgerResponse>
 ReportingETL::fetchLedgerData(uint32_t seq)
 {
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Attempting to fetch ledger with sequence = " << seq;
+    log_.debug() << "Attempting to fetch ledger with sequence = " << seq;
 
     std::optional<org::xrpl::rpc::v1::GetLedgerResponse> response =
         loadBalancer_->fetchLedger(seq, false, false);
     if (response)
-        BOOST_LOG_TRIVIAL(trace)
-            << __func__ << " : "
-            << "GetLedger reply = " << response->DebugString();
+        log_.trace() << "GetLedger reply = " << response->DebugString();
     return response;
 }
 
 std::optional<org::xrpl::rpc::v1::GetLedgerResponse>
 ReportingETL::fetchLedgerDataAndDiff(uint32_t seq)
 {
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Attempting to fetch ledger with sequence = " << seq;
+    log_.debug() << "Attempting to fetch ledger with sequence = " << seq;
 
     std::optional<org::xrpl::rpc::v1::GetLedgerResponse> response =
         loadBalancer_->fetchLedger(
@@ -291,47 +279,36 @@ ReportingETL::fetchLedgerDataAndDiff(uint32_t seq)
             !backend_->cache().isFull() ||
                 backend_->cache().latestLedgerSequence() >= seq);
     if (response)
-        BOOST_LOG_TRIVIAL(trace)
-            << __func__ << " : "
-            << "GetLedger reply = " << response->DebugString();
+        log_.trace() << "GetLedger reply = " << response->DebugString();
     return response;
 }
 
 std::pair<ripple::LedgerInfo, bool>
 ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
 {
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "Beginning ledger update";
-
+    log_.debug() << "Beginning ledger update";
     ripple::LedgerInfo lgrInfo =
         deserializeHeader(ripple::makeSlice(rawData.ledger_header()));
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Deserialized ledger header. " << detail::toString(lgrInfo);
-
+    log_.debug() << "Deserialized ledger header. " << detail::toString(lgrInfo);
     backend_->startWrites();
-
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "started writes";
+    log_.debug() << "started writes";
 
     backend_->writeLedger(lgrInfo, std::move(*rawData.mutable_ledger_header()));
-
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "wrote ledger header";
+    log_.debug() << "wrote ledger header";
 
     // Write successor info, if included from rippled
     if (rawData.object_neighbors_included())
     {
-        BOOST_LOG_TRIVIAL(debug) << __func__ << " object neighbors included";
+        log_.debug() << "object neighbors included";
         for (auto& obj : *(rawData.mutable_book_successors()))
         {
             auto firstBook = std::move(*obj.mutable_first_book());
             if (!firstBook.size())
                 firstBook = uint256ToString(Backend::lastKey);
-            BOOST_LOG_TRIVIAL(debug) << __func__ << " writing book successor "
-                                     << ripple::strHex(obj.book_base()) << " - "
-                                     << ripple::strHex(firstBook);
+            log_.debug() << "writing book successor "
+                         << ripple::strHex(obj.book_base()) << " - "
+                         << ripple::strHex(firstBook);
 
             backend_->writeSuccessor(
                 std::move(*obj.mutable_book_base()),
@@ -352,23 +329,20 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                 if (obj.mod_type() ==
                     org::xrpl::rpc::v1::RawLedgerObject::DELETED)
                 {
-                    BOOST_LOG_TRIVIAL(debug)
-                        << __func__
-                        << " modifying successors for deleted object "
-                        << ripple::strHex(obj.key()) << " - "
-                        << ripple::strHex(*predPtr) << " - "
-                        << ripple::strHex(*succPtr);
+                    log_.debug() << "Modifying successors for deleted object "
+                                 << ripple::strHex(obj.key()) << " - "
+                                 << ripple::strHex(*predPtr) << " - "
+                                 << ripple::strHex(*succPtr);
 
                     backend_->writeSuccessor(
                         std::move(*predPtr), lgrInfo.seq, std::move(*succPtr));
                 }
                 else
                 {
-                    BOOST_LOG_TRIVIAL(debug)
-                        << __func__ << " adding successor for new object "
-                        << ripple::strHex(obj.key()) << " - "
-                        << ripple::strHex(*predPtr) << " - "
-                        << ripple::strHex(*succPtr);
+                    log_.debug() << "adding successor for new object "
+                                 << ripple::strHex(obj.key()) << " - "
+                                 << ripple::strHex(*predPtr) << " - "
+                                 << ripple::strHex(*succPtr);
 
                     backend_->writeSuccessor(
                         std::move(*predPtr),
@@ -381,8 +355,7 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                 }
             }
             else
-                BOOST_LOG_TRIVIAL(debug) << __func__ << " object modified "
-                                         << ripple::strHex(obj.key());
+                log_.debug() << "object modified " << ripple::strHex(obj.key());
         }
     }
     std::vector<Backend::LedgerObject> cacheUpdates;
@@ -396,15 +369,13 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
         assert(key);
         cacheUpdates.push_back(
             {*key, {obj.mutable_data()->begin(), obj.mutable_data()->end()}});
-        BOOST_LOG_TRIVIAL(debug)
-            << __func__ << " key = " << ripple::strHex(*key)
-            << " - mod type = " << obj.mod_type();
+        log_.debug() << "key = " << ripple::strHex(*key)
+                     << " - mod type = " << obj.mod_type();
 
         if (obj.mod_type() != org::xrpl::rpc::v1::RawLedgerObject::MODIFIED &&
             !rawData.object_neighbors_included())
         {
-            BOOST_LOG_TRIVIAL(debug)
-                << __func__ << " object neighbors not included. using cache";
+            log_.debug() << "object neighbors not included. using cache";
             if (!backend_->cache().isFull() ||
                 backend_->cache().latestLedgerSequence() != lgrInfo.seq - 1)
                 throw std::runtime_error(
@@ -423,9 +394,7 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                 checkBookBase = isBookDir(*key, *blob);
             if (checkBookBase)
             {
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__
-                    << " is book dir. key = " << ripple::strHex(*key);
+                log_.debug() << "Is book dir. key = " << ripple::strHex(*key);
                 auto bookBase = getBookBase(*key);
                 auto oldFirstDir =
                     backend_->cache().getSuccessor(bookBase, lgrInfo.seq - 1);
@@ -435,9 +404,8 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                 if ((isDeleted && key == oldFirstDir->key) ||
                     (!isDeleted && key < oldFirstDir->key))
                 {
-                    BOOST_LOG_TRIVIAL(debug)
-                        << __func__
-                        << " Need to recalculate book base successor. base = "
+                    log_.debug()
+                        << "Need to recalculate book base successor. base = "
                         << ripple::strHex(bookBase)
                         << " - key = " << ripple::strHex(*key)
                         << " - isDeleted = " << isDeleted
@@ -458,8 +426,7 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
     // rippled didn't send successor information, so use our cache
     if (!rawData.object_neighbors_included())
     {
-        BOOST_LOG_TRIVIAL(debug)
-            << __func__ << " object neighbors not included. using cache";
+        log_.debug() << "object neighbors not included. using cache";
         if (!backend_->cache().isFull() ||
             backend_->cache().latestLedgerSequence() != lgrInfo.seq)
             throw std::runtime_error(
@@ -477,11 +444,10 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                 ub = {Backend::lastKey, {}};
             if (obj.blob.size() == 0)
             {
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " writing successor for deleted object "
-                    << ripple::strHex(obj.key) << " - "
-                    << ripple::strHex(lb->key) << " - "
-                    << ripple::strHex(ub->key);
+                log_.debug() << "writing successor for deleted object "
+                             << ripple::strHex(obj.key) << " - "
+                             << ripple::strHex(lb->key) << " - "
+                             << ripple::strHex(ub->key);
 
                 backend_->writeSuccessor(
                     uint256ToString(lb->key),
@@ -499,11 +465,10 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                     lgrInfo.seq,
                     uint256ToString(ub->key));
 
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " writing successor for new object "
-                    << ripple::strHex(lb->key) << " - "
-                    << ripple::strHex(obj.key) << " - "
-                    << ripple::strHex(ub->key);
+                log_.debug() << "writing successor for new object "
+                             << ripple::strHex(lb->key) << " - "
+                             << ripple::strHex(obj.key) << " - "
+                             << ripple::strHex(ub->key);
             }
         }
         for (auto const& base : bookSuccessorsToCalculate)
@@ -516,10 +481,9 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                     lgrInfo.seq,
                     uint256ToString(succ->key));
 
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " Updating book successor "
-                    << ripple::strHex(base) << " - "
-                    << ripple::strHex(succ->key);
+                log_.debug()
+                    << "Updating book successor " << ripple::strHex(base)
+                    << " - " << ripple::strHex(succ->key);
             }
             else
             {
@@ -528,42 +492,33 @@ ReportingETL::buildNextLedger(org::xrpl::rpc::v1::GetLedgerResponse& rawData)
                     lgrInfo.seq,
                     uint256ToString(Backend::lastKey));
 
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " Updating book successor "
-                    << ripple::strHex(base) << " - "
-                    << ripple::strHex(Backend::lastKey);
+                log_.debug()
+                    << "Updating book successor " << ripple::strHex(base)
+                    << " - " << ripple::strHex(Backend::lastKey);
             }
         }
     }
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
+    log_.debug()
         << "Inserted/modified/deleted all objects. Number of objects = "
         << rawData.ledger_objects().objects_size();
     FormattedTransactionsData insertTxResult =
         insertTransactions(lgrInfo, rawData);
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Inserted all transactions. Number of transactions  = "
-        << rawData.transactions_list().transactions_size();
+    log_.debug() << "Inserted all transactions. Number of transactions  = "
+                 << rawData.transactions_list().transactions_size();
     backend_->writeAccountTransactions(std::move(insertTxResult.accountTxData));
     backend_->writeNFTs(std::move(insertTxResult.nfTokensData));
     backend_->writeNFTTransactions(std::move(insertTxResult.nfTokenTxData));
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "wrote account_tx";
+    log_.debug() << "wrote account_tx";
+
     auto start = std::chrono::system_clock::now();
-
     bool success = backend_->finishWrites(lgrInfo.seq);
-
     auto end = std::chrono::system_clock::now();
-
     auto duration = ((end - start).count()) / 1000000000.0;
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " finished writes. took " << std::to_string(duration);
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Finished ledger update. " << detail::toString(lgrInfo);
+    log_.debug() << "Finished writes. took " << std::to_string(duration);
+    log_.debug() << "Finished ledger update. " << detail::toString(lgrInfo);
+
     return {lgrInfo, success};
 }
 
@@ -596,8 +551,7 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
      * optional, returns.
      */
 
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "Starting etl pipeline";
+    log_.debug() << "Starting etl pipeline";
     writing_ = true;
 
     auto rng = backend_->hardFetchLedgerRangeNoThrow();
@@ -670,13 +624,12 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
                     fetchResponse->transactions_list().transactions_size() /
                     time;
 
-                BOOST_LOG_TRIVIAL(info)
-                    << "Extract phase time = " << time
-                    << " . Extract phase tps = " << tps
-                    << " . Avg extract time = "
-                    << totalTime / (currentSequence - startSequence + 1)
-                    << " . thread num = " << i
-                    << " . seq = " << currentSequence;
+                log_.info() << "Extract phase time = " << time
+                            << " . Extract phase tps = " << tps
+                            << " . Avg extract time = "
+                            << totalTime / (currentSequence - startSequence + 1)
+                            << " . thread num = " << i
+                            << " . seq = " << currentSequence;
 
                 transformQueue->push(std::move(fetchResponse));
                 currentSequence += numExtractors;
@@ -720,7 +673,7 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
 
             auto duration = ((end - start).count()) / 1000000000.0;
             if (success)
-                BOOST_LOG_TRIVIAL(info)
+                log_.info()
                     << "Load phase of etl : "
                     << "Successfully wrote ledger! Ledger info: "
                     << detail::toString(lgrInfo) << ". txn count = " << numTxns
@@ -729,7 +682,7 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
                     << ". load txns per second = " << numTxns / duration
                     << ". load objs per second = " << numObjects / duration;
             else
-                BOOST_LOG_TRIVIAL(error)
+                log_.error()
                     << "Error writing ledger. " << detail::toString(lgrInfo);
             // success is false if the ledger was already written
             if (success)
@@ -747,7 +700,7 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
             {
                 deleting_ = true;
                 ioContext_.post([this, &minSequence]() {
-                    BOOST_LOG_TRIVIAL(info) << "Running online delete";
+                    log_.info() << "Running online delete";
 
                     Backend::synchronous(
                         [&](boost::asio::yield_context& yield) {
@@ -755,7 +708,7 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
                                 *onlineDeleteInterval_, yield);
                         });
 
-                    BOOST_LOG_TRIVIAL(info) << "Finished online delete";
+                    log_.info() << "Finished online delete";
                     auto rng = backend_->fetchLedgerRange();
                     minSequence = rng->minSequence;
                     deleting_ = false;
@@ -774,13 +727,12 @@ ReportingETL::runETLPipeline(uint32_t startSequence, int numExtractors)
     for (auto& t : extractors)
         t.join();
     auto end = std::chrono::system_clock::now();
-    BOOST_LOG_TRIVIAL(debug)
-        << "Extracted and wrote " << *lastPublishedSequence - startSequence
-        << " in " << ((end - begin).count()) / 1000000000.0;
+    log_.debug() << "Extracted and wrote "
+                 << *lastPublishedSequence - startSequence << " in "
+                 << ((end - begin).count()) / 1000000000.0;
     writing_ = false;
 
-    BOOST_LOG_TRIVIAL(debug) << __func__ << " : "
-                             << "Stopping etl pipeline";
+    log_.debug() << "Stopping etl pipeline";
 
     return lastPublishedSequence;
 }
@@ -801,40 +753,34 @@ ReportingETL::monitor()
     auto rng = backend_->hardFetchLedgerRangeNoThrow();
     if (!rng)
     {
-        BOOST_LOG_TRIVIAL(info) << __func__ << " : "
-                                << "Database is empty. Will download a ledger "
-                                   "from the network.";
+        log_.info() << "Database is empty. Will download a ledger "
+                       "from the network.";
         std::optional<ripple::LedgerInfo> ledger;
         if (startSequence_)
         {
-            BOOST_LOG_TRIVIAL(info)
-                << __func__ << " : "
-                << "ledger sequence specified in config. "
-                << "Will begin ETL process starting with ledger "
-                << *startSequence_;
+            log_.info() << "ledger sequence specified in config. "
+                        << "Will begin ETL process starting with ledger "
+                        << *startSequence_;
             ledger = loadInitialLedger(*startSequence_);
         }
         else
         {
-            BOOST_LOG_TRIVIAL(info)
-                << __func__ << " : "
+            log_.info()
                 << "Waiting for next ledger to be validated by network...";
             std::optional<uint32_t> mostRecentValidated =
                 networkValidatedLedgers_->getMostRecent();
             if (mostRecentValidated)
             {
-                BOOST_LOG_TRIVIAL(info) << __func__ << " : "
-                                        << "Ledger " << *mostRecentValidated
-                                        << " has been validated. "
-                                        << "Downloading...";
+                log_.info() << "Ledger " << *mostRecentValidated
+                            << " has been validated. "
+                            << "Downloading...";
                 ledger = loadInitialLedger(*mostRecentValidated);
             }
             else
             {
-                BOOST_LOG_TRIVIAL(info) << __func__ << " : "
-                                        << "The wait for the next validated "
-                                        << "ledger has been aborted. "
-                                        << "Exiting monitor loop";
+                log_.info() << "The wait for the next validated "
+                            << "ledger has been aborted. "
+                            << "Exiting monitor loop";
                 return;
             }
         }
@@ -842,8 +788,7 @@ ReportingETL::monitor()
             rng = backend_->hardFetchLedgerRangeNoThrow();
         else
         {
-            BOOST_LOG_TRIVIAL(error)
-                << __func__ << " : "
+            log_.error()
                 << "Failed to load initial ledger. Exiting monitor loop";
             return;
         }
@@ -852,21 +797,18 @@ ReportingETL::monitor()
     {
         if (startSequence_)
         {
-            BOOST_LOG_TRIVIAL(warning)
+            log_.warn()
                 << "start sequence specified but db is already populated";
         }
-        BOOST_LOG_TRIVIAL(info)
-            << __func__ << " : "
+        log_.info()
             << "Database already populated. Picking up from the tip of history";
         loadCache(rng->maxSequence);
     }
     assert(rng);
     uint32_t nextSequence = rng->maxSequence + 1;
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " : "
-        << "Database is populated. "
-        << "Starting monitor loop. sequence = " << nextSequence;
+    log_.debug() << "Database is populated. "
+                 << "Starting monitor loop. sequence = " << nextSequence;
     while (true)
     {
         if (auto rng = backend_->hardFetchLedgerRangeNoThrow();
@@ -878,11 +820,9 @@ ReportingETL::monitor()
         else if (networkValidatedLedgers_->waitUntilValidatedByNetwork(
                      nextSequence, 1000))
         {
-            BOOST_LOG_TRIVIAL(info)
-                << __func__ << " : "
-                << "Ledger with sequence = " << nextSequence
-                << " has been validated by the network. "
-                << "Attempting to find in database and publish";
+            log_.info() << "Ledger with sequence = " << nextSequence
+                        << " has been validated by the network. "
+                        << "Attempting to find in database and publish";
             // Attempt to take over responsibility of ETL writer after 10 failed
             // attempts to publish the ledger. publishLedger() fails if the
             // ledger that has been validated by the network is not found in the
@@ -893,17 +833,13 @@ ReportingETL::monitor()
             bool success = publishLedger(nextSequence, timeoutSeconds);
             if (!success)
             {
-                BOOST_LOG_TRIVIAL(warning)
-                    << __func__ << " : "
-                    << "Failed to publish ledger with sequence = "
-                    << nextSequence << " . Beginning ETL";
+                log_.warn() << "Failed to publish ledger with sequence = "
+                            << nextSequence << " . Beginning ETL";
                 // doContinousETLPipelined returns the most recent sequence
                 // published empty optional if no sequence was published
                 std::optional<uint32_t> lastPublished =
                     runETLPipeline(nextSequence, extractorThreads_);
-                BOOST_LOG_TRIVIAL(info)
-                    << __func__ << " : "
-                    << "Aborting ETL. Falling back to publishing";
+                log_.info() << "Aborting ETL. Falling back to publishing";
                 // if no ledger was published, don't increment nextSequence
                 if (lastPublished)
                     nextSequence = *lastPublished + 1;
@@ -920,8 +856,8 @@ ReportingETL::loadCacheFromClioPeer(
     std::string const& port,
     boost::asio::yield_context& yield)
 {
-    BOOST_LOG_TRIVIAL(info)
-        << "Loading cache from peer. ip = " << ip << " . port = " << port;
+    log_.info() << "Loading cache from peer. ip = " << ip
+                << " . port = " << port;
     namespace beast = boost::beast;          // from <boost/beast.hpp>
     namespace http = beast::http;            // from <boost/beast/http.hpp>
     namespace websocket = beast::websocket;  // from
@@ -933,7 +869,7 @@ ReportingETL::loadCacheFromClioPeer(
         // These objects perform our I/O
         tcp::resolver resolver{ioContext_};
 
-        BOOST_LOG_TRIVIAL(trace) << __func__ << " Creating websocket";
+        log_.trace() << "Creating websocket";
         auto ws =
             std::make_unique<websocket::stream<beast::tcp_stream>>(ioContext_);
 
@@ -942,14 +878,13 @@ ReportingETL::loadCacheFromClioPeer(
         if (ec)
             return {};
 
-        BOOST_LOG_TRIVIAL(trace) << __func__ << " Connecting websocket";
+        log_.trace() << "Connecting websocket";
         // Make the connection on the IP address we get from a lookup
         ws->next_layer().async_connect(results, yield[ec]);
         if (ec)
             return false;
 
-        BOOST_LOG_TRIVIAL(trace)
-            << __func__ << " Performing websocket handshake";
+        log_.trace() << "Performing websocket handshake";
         // Perform the websocket handshake
         ws->async_handshake(ip, "/", yield[ec]);
         if (ec)
@@ -957,7 +892,7 @@ ReportingETL::loadCacheFromClioPeer(
 
         std::optional<boost::json::value> marker;
 
-        BOOST_LOG_TRIVIAL(trace) << __func__ << " Sending request";
+        log_.trace() << "Sending request";
         auto getRequest = [&](auto marker) {
             boost::json::object request = {
                 {"command", "ledger_data"},
@@ -981,8 +916,7 @@ ReportingETL::loadCacheFromClioPeer(
                 yield[ec]);
             if (ec)
             {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " error writing = " << ec.message();
+                log_.error() << "error writing = " << ec.message();
                 return false;
             }
 
@@ -990,8 +924,7 @@ ReportingETL::loadCacheFromClioPeer(
             ws->async_read(buffer, yield[ec]);
             if (ec)
             {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " error reading = " << ec.message();
+                log_.error() << "error reading = " << ec.message();
                 return false;
             }
 
@@ -1000,36 +933,30 @@ ReportingETL::loadCacheFromClioPeer(
 
             if (!parsed.is_object())
             {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " Error parsing response: " << raw;
+                log_.error() << "Error parsing response: " << raw;
                 return false;
             }
-            BOOST_LOG_TRIVIAL(trace)
-                << __func__ << " Successfully parsed response " << parsed;
+            log_.trace() << "Successfully parsed response " << parsed;
 
             if (auto const& response = parsed.as_object();
                 response.contains("error"))
             {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " Response contains error: " << response;
+                log_.error() << "Response contains error: " << response;
                 auto const& err = response.at("error");
                 if (err.is_string() && err.as_string() == "lgrNotFound")
                 {
                     ++numAttempts;
                     if (numAttempts >= 5)
                     {
-                        BOOST_LOG_TRIVIAL(error)
-                            << __func__
+                        log_.error()
                             << " ledger not found at peer after 5 attempts. "
                                "peer = "
                             << ip << " ledger = " << ledgerIndex
                             << ". Check your config and the health of the peer";
                         return false;
                     }
-                    BOOST_LOG_TRIVIAL(warning)
-                        << __func__
-                        << " ledger not found. ledger = " << ledgerIndex
-                        << ". Sleeping and trying again";
+                    log_.warn() << "Ledger not found. ledger = " << ledgerIndex
+                                << ". Sleeping and trying again";
                     std::this_thread::sleep_for(std::chrono::seconds(1));
                     continue;
                 }
@@ -1041,8 +968,7 @@ ReportingETL::loadCacheFromClioPeer(
             if (!response.contains("cache_full") ||
                 !response.at("cache_full").as_bool())
             {
-                BOOST_LOG_TRIVIAL(error)
-                    << __func__ << " cache not full for clio node. ip = " << ip;
+                log_.error() << "cache not full for clio node. ip = " << ip;
                 return false;
             }
             if (response.contains("marker"))
@@ -1063,8 +989,7 @@ ReportingETL::loadCacheFromClioPeer(
                 if (!stateObject.key.parseHex(
                         obj.at("index").as_string().c_str()))
                 {
-                    BOOST_LOG_TRIVIAL(error)
-                        << __func__ << " failed to parse object id";
+                    log_.error() << "failed to parse object id";
                     return false;
                 }
                 boost::algorithm::unhex(
@@ -1075,22 +1000,19 @@ ReportingETL::loadCacheFromClioPeer(
             backend_->cache().update(objects, ledgerIndex, true);
 
             if (marker)
-                BOOST_LOG_TRIVIAL(debug)
-                    << __func__ << " - At marker " << *marker;
-
+                log_.debug() << "At marker " << *marker;
         } while (marker || !started);
-        BOOST_LOG_TRIVIAL(info)
-            << __func__
-            << " Finished downloading ledger from clio node. ip = " << ip;
-        backend_->cache().setFull();
 
+        log_.info() << "Finished downloading ledger from clio node. ip = "
+                    << ip;
+
+        backend_->cache().setFull();
         return true;
     }
     catch (std::exception const& e)
     {
-        BOOST_LOG_TRIVIAL(error)
-            << __func__ << " Encountered exception : " << e.what()
-            << " - ip = " << ip;
+        log_.error() << "Encountered exception : " << e.what()
+                     << " - ip = " << ip;
         return false;
     }
 }
@@ -1101,7 +1023,7 @@ ReportingETL::loadCache(uint32_t seq)
     if (cacheLoadStyle_ == CacheLoadStyle::NOT_AT_ALL)
     {
         backend_->cache().setDisabled();
-        BOOST_LOG_TRIVIAL(warning) << "Cache is disabled. Not loading";
+        log_.warn() << "Cache is disabled. Not loading";
         return;
     }
     // sanity check to make sure we are not calling this multiple times
@@ -1142,12 +1064,11 @@ ReportingETL::loadCache(uint32_t seq)
     while (cacheLoadStyle_ == CacheLoadStyle::SYNC &&
            !backend_->cache().isFull())
     {
-        BOOST_LOG_TRIVIAL(debug)
-            << "Cache not full. Cache size = " << backend_->cache().size()
-            << ". Sleeping ...";
+        log_.debug() << "Cache not full. Cache size = "
+                     << backend_->cache().size() << ". Sleeping ...";
         std::this_thread::sleep_for(std::chrono::seconds(10));
-        BOOST_LOG_TRIVIAL(info)
-            << "Cache is full. Cache size = " << backend_->cache().size();
+        log_.info() << "Cache is full. Cache size = "
+                    << backend_->cache().size();
     }
 }
 
@@ -1198,9 +1119,8 @@ ReportingETL::loadCacheFromDb(uint32_t seq)
         if (c)
             cursorStr << ripple::strHex(*c) << ", ";
     }
-    BOOST_LOG_TRIVIAL(info)
-        << "Loading cache. num cursors = " << cursors.size() - 1;
-    BOOST_LOG_TRIVIAL(trace) << __func__ << " cursors = " << cursorStr.str();
+    log_.info() << "Loading cache. num cursors = " << cursors.size() - 1;
+    log_.trace() << "cursors = " << cursorStr.str();
 
     cacheDownloader_ = std::thread{[this, seq, cursors]() {
         auto startTime = std::chrono::system_clock::now();
@@ -1221,9 +1141,8 @@ ReportingETL::loadCacheFromDb(uint32_t seq)
                     std::string cursorStr = cursor.has_value()
                         ? ripple::strHex(cursor.value())
                         : ripple::strHex(Backend::firstKey);
-                    BOOST_LOG_TRIVIAL(debug)
-                        << "Starting a cursor: " << cursorStr
-                        << " markers = " << *markers;
+                    log_.debug() << "Starting a cursor: " << cursorStr
+                                 << " markers = " << *markers;
 
                     while (!stopping_)
                     {
@@ -1237,7 +1156,7 @@ ReportingETL::loadCacheFromDb(uint32_t seq)
                         backend_->cache().update(res.objects, seq, true);
                         if (!res.cursor || (end && *(res.cursor) > *end))
                             break;
-                        BOOST_LOG_TRIVIAL(trace)
+                        log_.trace()
                             << "Loading cache. cache size = "
                             << backend_->cache().size() << " - cursor = "
                             << ripple::strHex(res.cursor.value())
@@ -1254,18 +1173,16 @@ ReportingETL::loadCacheFromDb(uint32_t seq)
                         auto duration =
                             std::chrono::duration_cast<std::chrono::seconds>(
                                 endTime - startTime);
-                        BOOST_LOG_TRIVIAL(info)
-                            << "Finished loading cache. cache size = "
-                            << backend_->cache().size() << ". Took "
-                            << duration.count() << " seconds";
+                        log_.info() << "Finished loading cache. cache size = "
+                                    << backend_->cache().size() << ". Took "
+                                    << duration.count() << " seconds";
                         backend_->cache().setFull();
                     }
                     else
                     {
-                        BOOST_LOG_TRIVIAL(info)
-                            << "Finished a cursor. num remaining = "
-                            << *numRemaining << " start = " << cursorStr
-                            << " markers = " << *markers;
+                        log_.info() << "Finished a cursor. num remaining = "
+                                    << *numRemaining << " start = " << cursorStr
+                                    << " markers = " << *markers;
                     }
                 });
         }
@@ -1275,7 +1192,7 @@ ReportingETL::loadCacheFromDb(uint32_t seq)
 void
 ReportingETL::monitorReadOnly()
 {
-    BOOST_LOG_TRIVIAL(debug) << "Starting reporting in strict read only mode";
+    log_.debug() << "Starting reporting in strict read only mode";
     auto rng = backend_->hardFetchLedgerRangeNoThrow();
     uint32_t latestSequence;
     if (!rng)

--- a/src/etl/ReportingETL.h
+++ b/src/etl/ReportingETL.h
@@ -8,6 +8,7 @@
 #include <boost/beast/websocket.hpp>
 #include <backend/BackendInterface.h>
 #include <etl/ETLSource.h>
+#include <log/Logger.h>
 #include <subscriptions/SubscriptionManager.h>
 
 #include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
@@ -55,6 +56,8 @@ class SubscriptionManager;
 class ReportingETL
 {
 private:
+    clio::Logger log_{"ETL"};
+
     std::shared_ptr<BackendInterface> backend_;
     std::shared_ptr<SubscriptionManager> subscriptions_;
     std::shared_ptr<ETLLoadBalancer> loadBalancer_;
@@ -300,7 +303,7 @@ private:
     void
     run()
     {
-        BOOST_LOG_TRIVIAL(info) << "Starting reporting etl";
+        log_.info() << "Starting reporting etl";
         stopping_ = false;
 
         doWork();
@@ -337,8 +340,8 @@ public:
 
     ~ReportingETL()
     {
-        BOOST_LOG_TRIVIAL(info) << "onStop called";
-        BOOST_LOG_TRIVIAL(debug) << "Stopping Reporting ETL";
+        log_.info() << "onStop called";
+        log_.debug() << "Stopping Reporting ETL";
         stopping_ = true;
 
         if (worker_.joinable())
@@ -346,7 +349,7 @@ public:
         if (cacheDownloader_.joinable())
             cacheDownloader_.join();
 
-        BOOST_LOG_TRIVIAL(debug) << "Joined ReportingETL worker thread";
+        log_.debug() << "Joined ReportingETL worker thread";
     }
 
     boost::json::object

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -1,0 +1,191 @@
+#include <config/Config.h>
+#include <log/Logger.h>
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+
+namespace clio {
+
+Logger LogService::general_log_ = Logger{"General"};
+Logger LogService::alert_log_ = Logger{"Alert"};
+
+std::ostream&
+operator<<(std::ostream& stream, Severity sev)
+{
+    static constexpr std::array<const char*, 6> labels = {
+        "TRC",
+        "DBG",
+        "NFO",
+        "WRN",
+        "ERR",
+        "FTL",
+    };
+
+    return stream << labels.at(static_cast<int>(sev));
+}
+
+Severity
+tag_invoke(boost::json::value_to_tag<Severity>, boost::json::value const& value)
+{
+    if (not value.is_string())
+        throw std::runtime_error("`log_level` must be a string");
+    auto const& logLevel = value.as_string();
+
+    if (boost::iequals(logLevel, "trace"))
+        return Severity::TRACE;
+    else if (boost::iequals(logLevel, "debug"))
+        return Severity::DEBUG;
+    else if (boost::iequals(logLevel, "info"))
+        return Severity::INFO;
+    else if (
+        boost::iequals(logLevel, "warning") || boost::iequals(logLevel, "warn"))
+        return Severity::WARNING;
+    else if (boost::iequals(logLevel, "error"))
+        return Severity::ERROR;
+    else if (boost::iequals(logLevel, "fatal"))
+        return Severity::FATAL;
+    else
+        throw std::runtime_error(
+            "Could not parse `log_level`: expected `trace`, `debug`, `info`, "
+            "`warning`, `error` or `fatal`");
+}
+
+void
+LogService::init(Config const& config)
+{
+    namespace src = boost::log::sources;
+    namespace keywords = boost::log::keywords;
+    namespace sinks = boost::log::sinks;
+
+    boost::log::add_common_attributes();
+    boost::log::register_simple_formatter_factory<Severity, char>("Severity");
+    auto const defaultFormat =
+        "%TimeStamp% (%SourceLocation%) [%ThreadID%] %Channel%:%Severity% "
+        "%Message%";
+    std::string format =
+        config.valueOr<std::string>("log_format", defaultFormat);
+
+    if (config.valueOr("log_to_console", false))
+    {
+        boost::log::add_console_log(std::cout, keywords::format = format);
+    }
+
+    auto logDir = config.maybeValue<std::string>("log_directory");
+    if (logDir)
+    {
+        boost::filesystem::path dirPath{logDir.value()};
+        if (!boost::filesystem::exists(dirPath))
+            boost::filesystem::create_directories(dirPath);
+        auto const rotationSize =
+            config.valueOr<uint64_t>("log_rotation_size", 2048u) * 1024u *
+            1024u;
+        auto const rotationPeriod =
+            config.valueOr<uint32_t>("log_rotation_hour_interval", 12u);
+        auto const dirSize =
+            config.valueOr<uint64_t>("log_directory_max_size", 50u * 1024u) *
+            1024u * 1024u;
+        auto fileSink = boost::log::add_file_log(
+            keywords::file_name = dirPath / "clio.log",
+            keywords::target_file_name = dirPath / "clio_%Y-%m-%d_%H-%M-%S.log",
+            keywords::auto_flush = true,
+            keywords::format = format,
+            keywords::open_mode = std::ios_base::app,
+            keywords::rotation_size = rotationSize,
+            keywords::time_based_rotation =
+                sinks::file::rotation_at_time_interval(
+                    boost::posix_time::hours(rotationPeriod)));
+        fileSink->locked_backend()->set_file_collector(
+            sinks::file::make_collector(
+                keywords::target = dirPath, keywords::max_size = dirSize));
+        fileSink->locked_backend()->scan_for_files();
+    }
+
+    // get default severity, can be overridden per channel using
+    // the `log_channels` array
+    auto defaultSeverity =
+        config.valueOr<Severity>("log_level", Severity::INFO);
+    static constexpr std::array<const char*, 7> channels = {
+        "General",
+        "WebServer",
+        "Backend",
+        "RPC",
+        "ETL",
+        "Subscriptions",
+        "Performance",
+    };
+
+    auto core = boost::log::core::get();
+    auto min_severity = boost::log::expressions::channel_severity_filter(
+        log_channel, log_severity);
+
+    for (auto const& channel : channels)
+        min_severity[channel] = defaultSeverity;
+    min_severity["Alert"] =
+        Severity::WARNING;  // Channel for alerts, always warning severity
+
+    for (auto const overrides = config.arrayOr("log_channels", {});
+         auto const& cfg : overrides)
+    {
+        auto name = cfg.valueOrThrow<std::string>(
+            "channel", "Channel name is required");
+        if (not std::count(std::begin(channels), std::end(channels), name))
+            throw std::runtime_error(
+                "Can't override settings for log channel " + name +
+                ": invalid channel");
+
+        min_severity[name] =
+            cfg.valueOr<Severity>("log_level", defaultSeverity);
+    }
+
+    core->set_filter(min_severity);
+    LogService::info() << "Default log level = " << defaultSeverity;
+}
+
+Logger::Pump
+Logger::trace(source_location_t const loc) const
+{
+    return {logger_, Severity::TRACE, loc};
+};
+Logger::Pump
+Logger::debug(source_location_t const loc) const
+{
+    return {logger_, Severity::DEBUG, loc};
+};
+Logger::Pump
+Logger::info(source_location_t const loc) const
+{
+    return {logger_, Severity::INFO, loc};
+};
+Logger::Pump
+Logger::warn(source_location_t const loc) const
+{
+    return {logger_, Severity::WARNING, loc};
+};
+Logger::Pump
+Logger::error(source_location_t const loc) const
+{
+    return {logger_, Severity::ERROR, loc};
+};
+Logger::Pump
+Logger::fatal(source_location_t const loc) const
+{
+    return {logger_, Severity::FATAL, loc};
+};
+
+std::string
+Logger::Pump::pretty_path(source_location_t const& loc, size_t max_depth) const
+{
+    auto const file_path = std::string{loc.file_name()};
+    auto idx = file_path.size();
+    while (max_depth-- > 0)
+    {
+        idx = file_path.rfind('/', idx - 1);
+        if (idx == std::string::npos || idx == 0)
+            break;
+    }
+    return file_path.substr(idx == std::string::npos ? 0 : idx + 1) + ':' +
+        std::to_string(loc.line());
+}
+
+}  // namespace clio

--- a/src/log/Logger.h
+++ b/src/log/Logger.h
@@ -1,0 +1,257 @@
+#ifndef RIPPLE_UTIL_LOGGER_H
+#define RIPPLE_UTIL_LOGGER_H
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/json.hpp>
+#include <boost/log/core/core.hpp>
+#include <boost/log/expressions/predicates/channel_severity_filter.hpp>
+#include <boost/log/sinks/unlocked_frontend.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/sources/severity_feature.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <boost/log/utility/setup/formatter_parser.hpp>
+
+// Note: clang still does not provide non-experimental support, gcc does
+// TODO: start using <source_location> once clang catches up on c++20
+#include <experimental/source_location>
+
+#include <optional>
+#include <string>
+
+namespace clio {
+
+class Config;
+using source_location_t = std::experimental::source_location;
+
+/**
+ * @brief Custom severity levels for @ref Logger.
+ */
+enum class Severity {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL,
+};
+
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_severity, "Severity", Severity);
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_channel, "Channel", std::string);
+
+/**
+ * @brief Custom labels for @ref Severity in log output.
+ *
+ * @param stream std::ostream The output stream
+ * @param sev Severity The severity to output to the ostream
+ * @return std::ostream& The same ostream we were given
+ */
+std::ostream&
+operator<<(std::ostream& stream, Severity sev);
+
+/**
+ * @brief Custom JSON parser for @ref Severity.
+ *
+ * @param value The JSON string to parse
+ * @return Severity The parsed severity
+ * @throws std::runtime_error Thrown if severity is not in the right format
+ */
+Severity
+tag_invoke(
+    boost::json::value_to_tag<Severity>,
+    boost::json::value const& value);
+
+/**
+ * @brief A simple thread-safe logger for the channel specified
+ * in the constructor.
+ *
+ * This is cheap to copy and move. Designed to be used as a member variable or
+ * otherwise. See @ref LogService::init() for setup of the logging core and
+ * severity levels for each channel.
+ */
+class Logger final
+{
+    using logger_t =
+        boost::log::sources::severity_channel_logger_mt<Severity, std::string>;
+    mutable logger_t logger_;
+
+    friend class LogService;  // to expose the Pump interface
+
+    /**
+     * @brief Helper that pumps data into a log record via `operator<<`.
+     */
+    class Pump final
+    {
+        using pump_opt_t =
+            std::optional<boost::log::aux::record_pump<logger_t>>;
+
+        boost::log::record rec_;
+        pump_opt_t pump_ = std::nullopt;
+
+    public:
+        ~Pump() = default;
+        Pump(logger_t& logger, Severity sev, source_location_t const& loc)
+            : rec_{logger.open_record(boost::log::keywords::severity = sev)}
+        {
+            if (rec_)
+            {
+                pump_.emplace(boost::log::aux::make_record_pump(logger, rec_));
+                pump_->stream() << boost::log::add_value(
+                    "SourceLocation", pretty_path(loc));
+            }
+        }
+
+        Pump(Pump&&) = delete;
+        Pump(Pump const&) = delete;
+        Pump&
+        operator=(Pump const&) = delete;
+        Pump&
+        operator=(Pump&&) = delete;
+
+        /**
+         * @brief Perfectly forwards any incoming data into the underlying
+         * boost::log pump if the pump is available. nop otherwise.
+         *
+         * @tparam T Type of data to pump
+         * @param data The data to pump
+         * @return Pump& Reference to itself for chaining
+         */
+        template <typename T>
+        [[maybe_unused]] Pump&
+        operator<<(T&& data)
+        {
+            if (pump_)
+                pump_->stream() << std::forward<T>(data);
+            return *this;
+        }
+
+    private:
+        [[nodiscard]] std::string
+        pretty_path(source_location_t const& loc, size_t max_depth = 3) const;
+    };
+
+public:
+    ~Logger() = default;
+    /**
+     * @brief Construct a new Logger object that produces loglines for the
+     * specified channel.
+     *
+     * See @ref LogService::init() for general setup and configuration of
+     * severity levels per channel.
+     *
+     * @param channel The channel this logger will report into.
+     */
+    Logger(std::string channel)
+        : logger_{boost::log::keywords::channel = channel}
+    {
+    }
+    Logger(Logger const&) = default;
+    Logger(Logger&&) = default;
+    Logger&
+    operator=(Logger const&) = default;
+    Logger&
+    operator=(Logger&&) = default;
+
+    /*! Interface for logging at @ref Severity::TRACE severity */
+    [[nodiscard]] Pump
+    trace(source_location_t const loc = source_location_t::current()) const;
+
+    /*! Interface for logging at @ref Severity::DEBUG severity */
+    [[nodiscard]] Pump
+    debug(source_location_t const loc = source_location_t::current()) const;
+
+    /*! Interface for logging at @ref Severity::INFO severity */
+    [[nodiscard]] Pump
+    info(source_location_t const loc = source_location_t::current()) const;
+
+    /*! Interface for logging at @ref Severity::WARNING severity */
+    [[nodiscard]] Pump
+    warn(source_location_t const loc = source_location_t::current()) const;
+
+    /*! Interface for logging at @ref Severity::ERROR severity */
+    [[nodiscard]] Pump
+    error(source_location_t const loc = source_location_t::current()) const;
+
+    /*! Interface for logging at @ref Severity::FATAL severity */
+    [[nodiscard]] Pump
+    fatal(source_location_t const loc = source_location_t::current()) const;
+};
+
+/**
+ * @brief A global logging service.
+ *
+ * Used to initialize and setup the logging core as well as a globally available
+ * entrypoint for logging into the `General` channel as well as raising alerts.
+ */
+class LogService
+{
+    static Logger general_log_; /*! Global logger for General channel */
+    static Logger alert_log_;   /*! Global logger for Alerts channel */
+
+public:
+    LogService() = delete;
+
+    /**
+     * @brief Global log core initialization from a @ref Config
+     */
+    static void
+    init(Config const& config);
+
+    /*! Globally accesible General logger at @ref Severity::TRACE severity */
+    [[nodiscard]] static Logger::Pump
+    trace(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.trace(loc);
+    }
+
+    /*! Globally accesible General logger at @ref Severity::TRACE severity */
+    [[nodiscard]] static Logger::Pump
+    debug(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.debug(loc);
+    }
+
+    /*! Globally accesible General logger at @ref Severity::INFO severity */
+    [[nodiscard]] static Logger::Pump
+    info(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.info(loc);
+    }
+
+    /*! Globally accesible General logger at @ref Severity::WARNING severity */
+    [[nodiscard]] static Logger::Pump
+    warn(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.warn(loc);
+    }
+
+    /*! Globally accesible General logger at @ref Severity::ERROR severity */
+    [[nodiscard]] static Logger::Pump
+    error(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.error(loc);
+    }
+
+    /*! Globally accesible General logger at @ref Severity::FATAL severity */
+    [[nodiscard]] static Logger::Pump
+    fatal(source_location_t const loc = source_location_t::current())
+    {
+        return general_log_.fatal(loc);
+    }
+
+    /*! Globally accesible Alert logger */
+    [[nodiscard]] static Logger::Pump
+    alert(source_location_t const loc = source_location_t::current())
+    {
+        return alert_log_.warn(loc);
+    }
+};
+
+};  // namespace clio
+
+#endif  // RIPPLE_UTIL_LOGGER_H

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -6,26 +6,20 @@
 #undef GRPC_ASAN_ENABLED
 #endif
 
+#include <backend/BackendFactory.h>
+#include <config/Config.h>
+#include <etl/ReportingETL.h>
+#include <log/Logger.h>
+#include <webserver/Listener.h>
+
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/json.hpp>
-#include <boost/log/core.hpp>
-#include <boost/log/expressions.hpp>
-#include <boost/log/sinks/text_file_backend.hpp>
-#include <boost/log/sources/record_ostream.hpp>
-#include <boost/log/sources/severity_logger.hpp>
-#include <boost/log/support/date_time.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
-#include <boost/log/utility/setup/console.hpp>
-#include <boost/log/utility/setup/file.hpp>
+
 #include <algorithm>
-#include <backend/BackendFactory.h>
-#include <config/Config.h>
 #include <cstdlib>
-#include <etl/ReportingETL.h>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -35,7 +29,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <webserver/Listener.h>
 
 using namespace clio;
 
@@ -81,85 +74,6 @@ parse_certs(Config const& config)
 }
 
 void
-initLogging(Config const& config)
-{
-    namespace src = boost::log::sources;
-    namespace keywords = boost::log::keywords;
-    namespace sinks = boost::log::sinks;
-    namespace trivial = boost::log::trivial;
-    boost::log::add_common_attributes();
-    std::string format = "[%TimeStamp%] [%ThreadID%] [%Severity%] %Message%";
-    if (config.valueOr<bool>("log_to_console", true))
-    {
-        boost::log::add_console_log(std::cout, keywords::format = format);
-    }
-
-    if (auto logDir = config.maybeValue<std::string>("log_directory"); logDir)
-    {
-        boost::filesystem::path dirPath{*logDir};
-        if (!boost::filesystem::exists(dirPath))
-            boost::filesystem::create_directories(dirPath);
-        auto const rotationSize =
-            config.valueOr<int64_t>("log_rotation_size", 2 * 1024) * 1024 *
-            1024u;
-        if (rotationSize <= 0)
-            throw std::runtime_error(
-                "log rotation size must be greater than 0");
-        auto const rotationPeriod =
-            config.valueOr<int64_t>("log_rotation_hour_interval", 12u);
-        if (rotationPeriod <= 0)
-            throw std::runtime_error(
-                "log rotation time interval must be greater than 0");
-        auto const dirSize =
-            config.valueOr<int64_t>("log_directory_max_size", 50 * 1024) *
-            1024 * 1024u;
-        if (dirSize <= 0)
-            throw std::runtime_error(
-                "log rotation directory max size must be greater than 0");
-        auto fileSink = boost::log::add_file_log(
-            keywords::file_name = dirPath / "clio.log",
-            keywords::target_file_name = dirPath / "clio_%Y-%m-%d_%H-%M-%S.log",
-            keywords::auto_flush = true,
-            keywords::format = format,
-            keywords::open_mode = std::ios_base::app,
-            keywords::rotation_size = rotationSize,
-            keywords::time_based_rotation =
-                sinks::file::rotation_at_time_interval(
-                    boost::posix_time::hours(rotationPeriod)));
-        fileSink->locked_backend()->set_file_collector(
-            sinks::file::make_collector(
-                keywords::target = dirPath, keywords::max_size = dirSize));
-        fileSink->locked_backend()->scan_for_files();
-    }
-    auto const logLevel = config.valueOr<std::string>("log_level", "info");
-    if (boost::iequals(logLevel, "trace"))
-        boost::log::core::get()->set_filter(
-            trivial::severity >= trivial::trace);
-    else if (boost::iequals(logLevel, "debug"))
-        boost::log::core::get()->set_filter(
-            trivial::severity >= trivial::debug);
-    else if (boost::iequals(logLevel, "info"))
-        boost::log::core::get()->set_filter(trivial::severity >= trivial::info);
-    else if (
-        boost::iequals(logLevel, "warning") || boost::iequals(logLevel, "warn"))
-        boost::log::core::get()->set_filter(
-            trivial::severity >= trivial::warning);
-    else if (boost::iequals(logLevel, "error"))
-        boost::log::core::get()->set_filter(
-            trivial::severity >= trivial::error);
-    else if (boost::iequals(logLevel, "fatal"))
-        boost::log::core::get()->set_filter(
-            trivial::severity >= trivial::fatal);
-    else
-    {
-        BOOST_LOG_TRIVIAL(warning) << "Unrecognized log level: " << logLevel
-                                   << ". Setting log level to info";
-        boost::log::core::get()->set_filter(trivial::severity >= trivial::info);
-    }
-    BOOST_LOG_TRIVIAL(info) << "Log level = " << logLevel;
-}
-
-void
 start(boost::asio::io_context& ioc, std::uint32_t numThreads)
 {
     std::vector<std::thread> v;
@@ -172,6 +86,7 @@ start(boost::asio::io_context& ioc, std::uint32_t numThreads)
 
 int
 main(int argc, char* argv[])
+try
 {
     // Check command line arguments.
     if (argc != 2)
@@ -196,10 +111,8 @@ main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    initLogging(config);
-
-    BOOST_LOG_TRIVIAL(info)
-        << "Clio version: " << Build::getClioFullVersionString();
+    LogService::init(config);
+    LogService::info() << "Clio version: " << Build::getClioFullVersionString();
 
     auto ctx = parse_certs(config);
     auto ctxRef = ctx
@@ -209,10 +122,10 @@ main(int argc, char* argv[])
     auto const threads = config.valueOr("io_threads", 2);
     if (threads <= 0)
     {
-        BOOST_LOG_TRIVIAL(fatal) << "io_threads is less than 0";
+        LogService::fatal() << "io_threads is less than 0";
         return EXIT_FAILURE;
     }
-    BOOST_LOG_TRIVIAL(info) << "Number of io threads = " << threads;
+    LogService::info() << "Number of io threads = " << threads;
 
     // io context to handle all incoming requests, as well as other things
     // This is not the only io context in the application
@@ -257,4 +170,8 @@ main(int argc, char* argv[])
     start(ioc, threads);
 
     return EXIT_SUCCESS;
+}
+catch (std::exception const& e)
+{
+    LogService::fatal() << "Exit on exception: " << e.what();
 }

--- a/src/rpc/RPC.h
+++ b/src/rpc/RPC.h
@@ -1,14 +1,14 @@
 #ifndef REPORTING_RPC_H_INCLUDED
 #define REPORTING_RPC_H_INCLUDED
 
+#include <backend/BackendInterface.h>
+#include <log/Logger.h>
+#include <rpc/Counters.h>
 #include <rpc/Errors.h>
+#include <util/Taggable.h>
 
 #include <boost/asio/spawn.hpp>
 #include <boost/json.hpp>
-
-#include <backend/BackendInterface.h>
-#include <rpc/Counters.h>
-#include <util/Taggable.h>
 
 #include <optional>
 #include <string>
@@ -34,6 +34,7 @@ namespace RPC {
 
 struct Context : public util::Taggable
 {
+    clio::Logger perfLog_{"Performance"};
     boost::asio::yield_context& yield;
     std::string method;
     std::uint32_t version;
@@ -129,6 +130,7 @@ template <class T>
 void
 logDuration(Context const& ctx, T const& dur)
 {
+    static clio::Logger log{"RPC"};
     std::stringstream ss;
     ss << ctx.tag() << "Request processing duration = "
        << std::chrono::duration_cast<std::chrono::milliseconds>(dur).count()
@@ -136,11 +138,11 @@ logDuration(Context const& ctx, T const& dur)
     auto seconds =
         std::chrono::duration_cast<std::chrono::seconds>(dur).count();
     if (seconds > 10)
-        BOOST_LOG_TRIVIAL(error) << ss.str();
+        log.error() << ss.str();
     else if (seconds > 1)
-        BOOST_LOG_TRIVIAL(warning) << ss.str();
+        log.warn() << ss.str();
     else
-        BOOST_LOG_TRIVIAL(info) << ss.str();
+        log.info() << ss.str();
 }
 
 }  // namespace RPC

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -1,4 +1,12 @@
+#include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
+
+using namespace clio;
+
+// local to compilation unit loggers
+namespace {
+clio::Logger gLog{"RPC"};
+}  // namespace
 
 namespace RPC {
 
@@ -10,25 +18,27 @@ doAccountTx(Context const& context)
         return status;
 
     constexpr std::string_view outerFuncName = __func__;
-    auto const maybeResponse = traverseTransactions(
-        context,
-        [&accountID, &outerFuncName](
-            std::shared_ptr<Backend::BackendInterface const> const& backend,
-            std::uint32_t const limit,
-            bool const forward,
-            std::optional<Backend::TransactionsCursor> const& cursorIn,
-            boost::asio::yield_context& yield) {
-            auto const start = std::chrono::system_clock::now();
-            auto const txnsAndCursor = backend->fetchAccountTransactions(
-                accountID, limit, forward, cursorIn, yield);
-            BOOST_LOG_TRIVIAL(info)
-                << outerFuncName << " db fetch took "
-                << std::chrono::duration_cast<std::chrono::milliseconds>(
-                       std::chrono::system_clock::now() - start)
-                       .count()
-                << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
-            return txnsAndCursor;
-        });
+    auto const maybeResponse =
+        traverseTransactions(
+            context,
+            [&accountID, &outerFuncName](
+                std::shared_ptr<Backend::BackendInterface const> const& backend,
+                std::uint32_t const limit,
+                bool const forward,
+                std::optional<Backend::TransactionsCursor> const& cursorIn,
+                boost::asio::yield_context& yield) {
+                auto const start = std::chrono::system_clock::now();
+                auto const txnsAndCursor = backend->fetchAccountTransactions(
+                    accountID, limit, forward, cursorIn, yield);
+                gLog.info()
+                    << outerFuncName << " db fetch took "
+                    << std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::system_clock::now() - start)
+                           .count()
+                    << " milliseconds - num blobs = "
+                    << txnsAndCursor.txns.size();
+                return txnsAndCursor;
+            });
 
     if (auto const status = std::get_if<Status>(&maybeResponse); status)
         return *status;

--- a/src/rpc/handlers/BookOffers.cpp
+++ b/src/rpc/handlers/BookOffers.cpp
@@ -4,12 +4,21 @@
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/jss.h>
-#include <boost/json.hpp>
-#include <algorithm>
-#include <rpc/RPCHelpers.h>
-
 #include <backend/BackendInterface.h>
 #include <backend/DBHelpers.h>
+#include <log/Logger.h>
+#include <rpc/RPCHelpers.h>
+
+#include <boost/json.hpp>
+
+#include <algorithm>
+
+using namespace clio;
+
+// local to compilation unit loggers
+namespace {
+clio::Logger gLog{"RPC"};
+}  // namespace
 
 namespace RPC {
 
@@ -64,11 +73,11 @@ doBookOffers(Context const& context)
         bookBase, lgrInfo.seq, limit, marker, context.yield);
     auto end = std::chrono::system_clock::now();
 
-    BOOST_LOG_TRIVIAL(warning)
-        << "Time loading books: "
-        << std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
-               .count()
-        << " milliseconds - request = " << request;
+    gLog.warn() << "Time loading books: "
+                << std::chrono::duration_cast<std::chrono::milliseconds>(
+                       end - start)
+                       .count()
+                << " milliseconds - request = " << request;
 
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
     response[JS(ledger_index)] = lgrInfo.seq;
@@ -78,11 +87,11 @@ doBookOffers(Context const& context)
 
     auto end2 = std::chrono::system_clock::now();
 
-    BOOST_LOG_TRIVIAL(warning)
-        << "Time transforming to json: "
-        << std::chrono::duration_cast<std::chrono::milliseconds>(end2 - end)
-               .count()
-        << " milliseconds - request = " << request;
+    gLog.warn() << "Time transforming to json: "
+                << std::chrono::duration_cast<std::chrono::milliseconds>(
+                       end2 - end)
+                       .count()
+                << " milliseconds - request = " << request;
 
     if (retMarker)
         response["marker"] = ripple::strHex(*retMarker);

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -1,9 +1,11 @@
 #include <ripple/app/ledger/LedgerToJson.h>
 #include <ripple/protocol/STLedgerEntry.h>
+#include <backend/BackendInterface.h>
+#include <log/Logger.h>
+#include <rpc/RPCHelpers.h>
+
 #include <boost/json.hpp>
 
-#include <backend/BackendInterface.h>
-#include <rpc/RPCHelpers.h>
 // Get state nodes from a ledger
 //   Inputs:
 //     limit:        integer, maximum number of entries
@@ -17,6 +19,13 @@
 //     marker:       resume point, if any
 //
 //
+
+using namespace clio;
+
+// local to compilation unit loggers
+namespace {
+clio::Logger gLog{"RPC"};
+}  // namespace
 
 namespace RPC {
 
@@ -65,7 +74,7 @@ doLedgerData(Context const& context)
         }
         else
         {
-            BOOST_LOG_TRIVIAL(debug) << __func__ << " : parsing marker";
+            gLog.debug() << "Parsing marker";
 
             marker = ripple::uint256{};
             if (!marker->parseHex(request.at(JS(marker)).as_string().c_str()))
@@ -168,9 +177,8 @@ doLedgerData(Context const& context)
         std::chrono::duration_cast<std::chrono::microseconds>(end - start)
             .count();
 
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " number of results = " << results.size()
-        << " fetched in " << time << " microseconds";
+    gLog.debug() << "Number of results = " << results.size() << " fetched in "
+                 << time << " microseconds";
     boost::json::array objects;
     objects.reserve(results.size());
     for (auto const& [key, object] : results)
@@ -194,9 +202,8 @@ doLedgerData(Context const& context)
 
     time = std::chrono::duration_cast<std::chrono::microseconds>(end2 - end)
                .count();
-    BOOST_LOG_TRIVIAL(debug)
-        << __func__ << " number of results = " << results.size()
-        << " serialized in " << time << " microseconds";
+    gLog.debug() << "Number of results = " << results.size()
+                 << " serialized in " << time << " microseconds";
 
     return response;
 }

--- a/src/rpc/handlers/NFTHistory.cpp
+++ b/src/rpc/handlers/NFTHistory.cpp
@@ -1,4 +1,12 @@
+#include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
+
+using namespace clio;
+
+// local to compilation unit loggers
+namespace {
+clio::Logger gLog{"RPC"};
+}  // namespace
 
 namespace RPC {
 
@@ -11,26 +19,28 @@ doNFTHistory(Context const& context)
     auto const tokenID = std::get<ripple::uint256>(maybeTokenID);
 
     constexpr std::string_view outerFuncName = __func__;
-    auto const maybeResponse = traverseTransactions(
-        context,
-        [&tokenID, &outerFuncName](
-            std::shared_ptr<Backend::BackendInterface const> const& backend,
-            std::uint32_t const limit,
-            bool const forward,
-            std::optional<Backend::TransactionsCursor> const& cursorIn,
-            boost::asio::yield_context& yield)
-            -> Backend::TransactionsAndCursor {
-            auto const start = std::chrono::system_clock::now();
-            auto const txnsAndCursor = backend->fetchNFTTransactions(
-                tokenID, limit, forward, cursorIn, yield);
-            BOOST_LOG_TRIVIAL(info)
-                << outerFuncName << " db fetch took "
-                << std::chrono::duration_cast<std::chrono::milliseconds>(
-                       std::chrono::system_clock::now() - start)
-                       .count()
-                << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
-            return txnsAndCursor;
-        });
+    auto const maybeResponse =
+        traverseTransactions(
+            context,
+            [&tokenID, &outerFuncName](
+                std::shared_ptr<Backend::BackendInterface const> const& backend,
+                std::uint32_t const limit,
+                bool const forward,
+                std::optional<Backend::TransactionsCursor> const& cursorIn,
+                boost::asio::yield_context& yield)
+                -> Backend::TransactionsAndCursor {
+                auto const start = std::chrono::system_clock::now();
+                auto const txnsAndCursor = backend->fetchNFTTransactions(
+                    tokenID, limit, forward, cursorIn, yield);
+                gLog.info()
+                    << outerFuncName << " db fetch took "
+                    << std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::system_clock::now() - start)
+                           .count()
+                    << " milliseconds - num blobs = "
+                    << txnsAndCursor.txns.size();
+                return txnsAndCursor;
+            });
 
     if (auto const status = std::get_if<Status>(&maybeResponse); status)
         return *status;

--- a/src/rpc/handlers/NFTOffers.cpp
+++ b/src/rpc/handlers/NFTOffers.cpp
@@ -4,9 +4,11 @@
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/jss.h>
-#include <boost/json.hpp>
-#include <algorithm>
 #include <rpc/RPCHelpers.h>
+
+#include <boost/json.hpp>
+
+#include <algorithm>
 
 namespace json = boost::json;
 

--- a/src/subscriptions/SubscriptionManager.h
+++ b/src/subscriptions/SubscriptionManager.h
@@ -3,8 +3,10 @@
 
 #include <backend/BackendInterface.h>
 #include <config/Config.h>
-#include <memory>
+#include <log/Logger.h>
 #include <subscriptions/Message.h>
+
+#include <memory>
 
 class WsBase;
 
@@ -87,6 +89,7 @@ public:
 class SubscriptionManager
 {
     using session_ptr = std::shared_ptr<WsBase>;
+    clio::Logger log_{"Subscriptions"};
 
     std::vector<std::thread> workers_;
     boost::asio::io_context ioc_;
@@ -134,8 +137,8 @@ public:
         // We will eventually want to clamp this to be the number of strands,
         // since adding more threads than we have strands won't see any
         // performance benefits
-        BOOST_LOG_TRIVIAL(info) << "Starting subscription manager with "
-                                << numThreads << " workers";
+        log_.info() << "Starting subscription manager with " << numThreads
+                    << " workers";
 
         workers_.reserve(numThreads);
         for (auto i = numThreads; i > 0; --i)

--- a/src/util/Taggable.h
+++ b/src/util/Taggable.h
@@ -209,7 +209,8 @@ private:
     friend Type
     tag_invoke(boost::json::value_to_tag<Type>, boost::json::value const& value)
     {
-        assert(value.is_string());
+        if (not value.is_string())
+            throw std::runtime_error("`log_tag_style` must be a string");
         auto const& style = value.as_string();
 
         if (boost::iequals(style, "int") || boost::iequals(style, "uint"))

--- a/unittests/Config.cpp
+++ b/unittests/Config.cpp
@@ -1,9 +1,8 @@
 #include <config/Config.h>
+#include <util/Fixtures.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/json/parse.hpp>
-#include <boost/log/core.hpp>
-#include <gtest/gtest.h>
 
 #include <cstdio>
 #include <exception>
@@ -34,17 +33,10 @@ constexpr static auto JSONData = R"JSON(
     }
 )JSON";
 
-class ConfigTest : public ::testing::Test
+class ConfigTest : public NoLoggerFixture
 {
 protected:
     Config cfg{json::parse(JSONData)};
-
-    void
-    SetUp() override
-    {
-        // disable logging in test
-        core::get()->set_logging_enabled(false);
-    }
 };
 
 TEST_F(ConfigTest, SanityCheck)

--- a/unittests/Logger.cpp
+++ b/unittests/Logger.cpp
@@ -1,0 +1,49 @@
+#include <util/Fixtures.h>
+using namespace clio;
+
+// Used as a fixture for tests with enabled logging
+class LoggerTest : public LoggerFixture
+{
+};
+
+// Used as a fixture for tests with disabled logging
+class NoLoggerTest : public NoLoggerFixture
+{
+};
+
+TEST_F(LoggerTest, Basic)
+{
+    Logger log{"General"};
+    log.info() << "Info line logged";
+    checkEqual("General:NFO Info line logged");
+
+    LogService::debug() << "Debug line with numbers " << 12345;
+    checkEqual("General:DBG Debug line with numbers 12345");
+
+    LogService::warn() << "Warning is logged";
+    checkEqual("General:WRN Warning is logged");
+}
+
+TEST_F(LoggerTest, Filtering)
+{
+    Logger log{"General"};
+    log.trace() << "Should not be logged";
+    checkEmpty();
+
+    log.warn() << "Warning is logged";
+    checkEqual("General:WRN Warning is logged");
+
+    Logger tlog{"Trace"};
+    tlog.trace() << "Trace line logged for 'Trace' component";
+    checkEqual("Trace:TRC Trace line logged for 'Trace' component");
+}
+
+TEST_F(NoLoggerTest, Basic)
+{
+    Logger log{"Trace"};
+    log.trace() << "Nothing";
+    checkEmpty();
+
+    LogService::fatal() << "Still nothing";
+    checkEmpty();
+}

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -1,0 +1,93 @@
+#ifndef CLIO_UNITTEST_FIXTURES_H
+#define CLIO_UNITTEST_FIXTURES_H
+
+#include <ios>
+#include <mutex>
+
+#include <gtest/gtest.h>
+#include <log/Logger.h>
+
+/**
+ * @brief Fixture with LogService support.
+ */
+class LoggerFixture : public ::testing::Test
+{
+    /**
+     * @brief A simple string buffer that can be used to mock std::cout for
+     * console logging.
+     */
+    class FakeBuffer final : public std::stringbuf
+    {
+    public:
+        std::string
+        getStrAndReset()
+        {
+            auto value = str();
+            str("");
+            return value;
+        }
+    };
+
+    FakeBuffer buffer_;
+    std::ostream stream_ = std::ostream{&buffer_};
+
+protected:
+    // Simulates the `LogService::init(config)` call
+    void
+    SetUp() override
+    {
+        static std::once_flag once_;
+        std::call_once(once_, [] {
+            boost::log::add_common_attributes();
+            boost::log::register_simple_formatter_factory<clio::Severity, char>(
+                "Severity");
+        });
+
+        namespace src = boost::log::sources;
+        namespace keywords = boost::log::keywords;
+        namespace sinks = boost::log::sinks;
+        namespace expr = boost::log::expressions;
+        auto core = boost::log::core::get();
+
+        core->remove_all_sinks();
+        boost::log::add_console_log(
+            stream_, keywords::format = "%Channel%:%Severity% %Message%");
+        auto min_severity = expr::channel_severity_filter(
+            clio::log_channel, clio::log_severity);
+        min_severity["General"] = clio::Severity::DEBUG;
+        min_severity["Trace"] = clio::Severity::TRACE;
+        core->set_filter(min_severity);
+        core->set_logging_enabled(true);
+    }
+
+    void
+    checkEqual(std::string expected)
+    {
+        auto value = buffer_.getStrAndReset();
+        ASSERT_EQ(value, expected + '\n');
+    }
+
+    void
+    checkEmpty()
+    {
+        ASSERT_TRUE(buffer_.getStrAndReset().empty());
+    }
+};
+
+/**
+ * @brief Fixture with LogService support but completely disabled logging.
+ *
+ * This is meant to be used as a base for other fixtures.
+ */
+class NoLoggerFixture : public LoggerFixture
+{
+protected:
+    void
+    SetUp() override
+    {
+        LoggerFixture::SetUp();
+        boost::log::core::get()->set_logging_enabled(false);
+    }
+};
+
+#endif  // CLIO_UNITTEST_FIXTURES_H


### PR DESCRIPTION
Fixes #290 

This change does the following few things:
- Introduces an abstraction for logging within `clio` (helps with separation of concerns, testability, DI, etc.)
- Implements a logger for tracking `Performance` specific things - to be used by Sophia in performance testing
- Each `Logger` object will use their own `mutex` so that logs in one part of the app don't interlock with all others.
- Adds a globally available `LogService` that can be used to raise Alerts and push logs into the General channel.
- Adds unit tests for logging primitives

The intention is to help performance and battle the 40% performance decrease we have seen lately due to many new log lines (multiple on each rpc).