### PR TITLE
Add rpcBAD_ISSUER to subscribe

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1461,7 +1461,7 @@ parseTaker(boost::json::value const& taker)
     takerID = accountFromStringStrict(taker.as_string().c_str());
 
     if (!takerID)
-        return Status{Error::rpcINVALID_PARAMS, "invalidTakerAccount"};
+        return Status{Error::rpcBAD_ISSUER, "invalidTakerAccount"};
     return *takerID;
 }
 bool


### PR DESCRIPTION
**Issue (#352):** subscribe API call to order books with empty taker returns "invalidParams" instead of "badIssuer"
**Fix:** Add rpcBAD_ISSUER Error Code 