### PR TITLE
Fix account ownership check

### DIFF
--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -81,6 +81,34 @@ struct Status
             return *err != RippledError::rpcSUCCESS;
         return true;
     }
+
+    /**
+     * @brief Returns true if the Status contains the desired @ref RippledError
+     *
+     * @param other The RippledError to match
+     * @return bool true if status matches given error; false otherwise
+     */
+    bool
+    operator==(RippledError other) const
+    {
+        if (auto err = std::get_if<RippledError>(&code))
+            return *err == other;
+        return false;
+    }
+
+    /**
+     * @brief Returns true if the Status contains the desired @ref ClioError
+     *
+     * @param other The RippledError to match
+     * @return bool true if status matches given error; false otherwise
+     */
+    bool
+    operator==(ClioError other) const
+    {
+        if (auto err = std::get_if<ClioError>(&code))
+            return *err == other;
+        return false;
+    }
 };
 
 /**

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -352,7 +352,7 @@ buildResponse(Context const& ctx)
         if (auto object = get_if<boost::json::object>(&v);
             object && not shouldSuppressValidatedFlag(ctx))
         {
-            (*object)["validated"] = true;
+            (*object)[JS(validated)] = true;
         }
 
         return v;

--- a/src/rpc/RPC.h
+++ b/src/rpc/RPC.h
@@ -73,13 +73,13 @@ struct AccountCursor
     std::uint32_t hint;
 
     std::string
-    toString()
+    toString() const
     {
         return ripple::strHex(index) + "," + std::to_string(hint);
     }
 
     bool
-    isNonZero()
+    isNonZero() const
     {
         return index.isNonZero() || hint != 0;
     }

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -36,7 +36,6 @@ parseAccountCursor(
     BackendInterface const& backend,
     std::uint32_t seq,
     std::optional<std::string> jsonCursor,
-    ripple::AccountID const& accountID,
     boost::asio::yield_context& yield);
 
 // TODO this function should probably be in a different file and namespace

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -202,8 +202,7 @@ doAccountObjects(Context const& context)
     if (auto status = std::get_if<RPC::Status>(&next))
         return *status;
 
-    auto nextMarker = std::get<RPC::AccountCursor>(next);
-
+    auto const& nextMarker = std::get<RPC::AccountCursor>(next);
     if (nextMarker.isNonZero())
         response[JS(marker)] = nextMarker.toString();
 

--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -442,8 +442,7 @@ doUnsubscribe(Context const& context)
     if (request.contains("books"))
         unsubscribeToBooks(books, context.session, *context.subscriptions);
 
-    boost::json::object response = {{"status", "success"}};
-    return response;
+    return boost::json::object{};
 }
 
 }  // namespace RPC


### PR DESCRIPTION
Fixes #222 

When recreating the cursor from a marker in `account_objects` we call out to 'isOwnedByAccount' which seems to be a safety net of sorts. 
If the marker happens to land on an entry where the `accountID` we check against is the `destination` the check will fail.
The fix just adds a check for this case. 

On a second thought tho, maybe we don't need this `isOwnedByAccount` check at all? 