### PR TITLE
Remove checks for a valid subscription in subscribe/unsubscribe rpc

### DIFF
--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -297,12 +297,6 @@ doSubscribe(Context const& context)
 {
     auto request = context.params;
 
-    if (!request.contains(JS(streams)) && !request.contains(JS(accounts)) &&
-        !request.contains(JS(accounts_proposed)) &&
-        !request.contains(JS(books)))
-        return Status{
-            Error::rpcINVALID_PARAMS, "does not contain valid subscription"};
-
     if (request.contains(JS(streams)))
     {
         if (!request.at(JS(streams)).is_array())
@@ -378,12 +372,6 @@ Result
 doUnsubscribe(Context const& context)
 {
     auto request = context.params;
-
-    if (!request.contains(JS(streams)) && !request.contains(JS(accounts)) &&
-        !request.contains(JS(accounts_proposed)) &&
-        !request.contains(JS(books)))
-        return Status{
-            Error::rpcINVALID_PARAMS, "does not contain valid subscription"};
 
     if (request.contains(JS(streams)))
     {


### PR DESCRIPTION
Fixes #348 

Removes the checks to match rippled behaviour.