### PR TITLE
Return account malformed error for invalid accounts

### DIFF
--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -103,11 +103,8 @@ validateAccounts(boost::json::array const& accounts)
         if (!account.is_string())
             return Status{Error::rpcINVALID_PARAMS, "accountNotString"};
 
-        std::string s = account.as_string().c_str();
-        auto id = accountFromStringStrict(s);
-
-        if (!id)
-            return Status{Error::rpcINVALID_PARAMS, "invalidAccount" + s};
+        if (!accountFromStringStrict(account.as_string().c_str()))
+            return Status{Error::rpcACT_MALFORMED, "Account malformed."};
     }
 
     return OK;


### PR DESCRIPTION
Fixes #349

Affects `subscribe` and `unsubscribe` for `accounts` and `accounts_proposed`.