### PR TITLE
Implement a simple check to suppress 'validated' flag output

### DIFF
--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -305,6 +305,13 @@ isClioOnly(std::string const& method)
     return handlerTable.isClioOnly(method);
 }
 
+bool
+shouldSuppressValidatedFlag(RPC::Context const& context)
+{
+    return boost::iequals(context.method, "subscribe") ||
+        boost::iequals(context.method, "unsubscribe");
+}
+
 Status
 getLimit(RPC::Context const& context, std::uint32_t& limit)
 {
@@ -403,8 +410,11 @@ buildResponse(Context const& ctx)
             << ctx.tag() << __func__ << " finish executing rpc `" << ctx.method
             << '`';
 
-        if (auto object = std::get_if<boost::json::object>(&v))
+        if (auto object = std::get_if<boost::json::object>(&v);
+            object && not shouldSuppressValidatedFlag(ctx))
+        {
             (*object)["validated"] = true;
+        }
 
         return v;
     }


### PR DESCRIPTION
Fixes #354 

We decided to leave `status` output as is. 
However, `validated` flag is now suppressed for both `subscribe` and `unsubscribe` commands.