### PR TITLE
Add clang-format git hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+exec 1>&2
+
+# format all relevant sources
+find src unittests -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format -i
+
+# check how many lines differ
+lines=$(git diff | wc -l)
+
+# check if there is any updated files
+if [ "$lines" != "0" ]; then
+    cat <<\EOF
+
+                                   WARNING 
+-----------------------------------------------------------------------------
+  Automatically re-formatted code with `clang-format` - commit was aborted.
+  Please manually add any updated files and commit again.
+-----------------------------------------------------------------------------
+
+EOF
+    exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,13 @@ To contribute, please:
 
 > **Note:** Please make sure you read the [Style guide](#style-guide).
 
+## Install git hooks
+Please make sure to run the following command in order to use git hooks that are helpful for `clio` development.
+
+``` bash
+git config --local core.hooksPath .githooks
+```
+
 ## Git commands
 This sections offers a detailed look at the git commands you will need to use to get your PR submitted. 
 Please note that there are more than one way to do this and these commands are only  provided for your convenience.
@@ -117,7 +124,10 @@ Existing maintainers can resign, or be subject to a vote for removal at the behe
 ## Existing Maintainers
 
 * [cjcobb23](https://github.com/cjcobb23) (Ripple)
-* [natenichols](https://github.com/natenichols) (Ripple)
 * [legleux](https://github.com/legleux) (Ripple)
 * [undertome](https://github.com/undertome) (Ripple)
 * [godexsoft](https://github.com/godexsoft) (Ripple)
+
+## Honorable ex-Maintainers
+
+* [natenichols](https://github.com/natenichols) (ex-Ripple)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use these instructions to build a Clio executable from the source. These instruc
 
 ```sh
 # Install dependencies
-  sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential bison flex autoconf cmake
+  sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential bison flex autoconf cmake clang-format
 
 # Compile Boost
   wget -O $HOME/boost_1_75_0.tar.gz https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz


### PR DESCRIPTION
Fixes #392 

- Add a pre-commit hook which uses `clang-format` to correct any style issues and aborts the ongoing commit in case some files had to be changed during the pre-commit hook. 
- Add git hooks installation howto to `CONTRIBUTING.md`