### PR TITLE
remove accountFromSeed

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -348,20 +348,6 @@ canHaveDeliveredAmount(
 }
 
 std::optional<ripple::AccountID>
-accountFromSeed(std::string const& account)
-{
-    auto const seed = ripple::parseGenericSeed(account);
-
-    if (!seed)
-        return {};
-
-    auto const keypair =
-        ripple::generateKeyPair(ripple::KeyType::secp256k1, *seed);
-
-    return ripple::calcAccountID(keypair.first);
-}
-
-std::optional<ripple::AccountID>
 accountFromStringStrict(std::string const& account)
 {
     auto blob = ripple::strUnHex(account);

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -25,9 +25,6 @@ namespace RPC {
 std::optional<ripple::AccountID>
 accountFromStringStrict(std::string const& account);
 
-std::optional<ripple::AccountID>
-accountFromSeed(std::string const& account);
-
 bool
 isOwnedByAccount(ripple::SLE const& sle, ripple::AccountID const& accountID);
 


### PR DESCRIPTION
Addresses https://github.com/XRPLF/clio/issues/330

This results in no change in API behavior, but is rather a decision to intentionally deviate from the rippled API. Allowing clients to send seeds in place of accounts is a security risk, because then someone's secret seed is being transmitted over the network as well as being written to the logs. This is very bad practice from a security standpoint.

Now, it is expected that passing an arbitrary string in place of an account in the API will return `actMalformed` as opposed to `actNotFound`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/399)
<!-- Reviewable:end -->
