### PR TITLE
helper function for subscribe to ensure cleanup

### DIFF
--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -479,7 +479,7 @@ SubscriptionManager::subscribeHelper(
 {
     subs.subscribe(session);
     std::unique_lock lk(cleanupMtx_);
-    cleanupFuncs_[session].emplace_back(func);
+    cleanupFuncs_[session].push_back(std::move(func));
 }
 template <typename Key>
 void

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -491,7 +491,7 @@ SubscriptionManager::subscribeHelper(
 {
     subs.subscribe(session, k);
     std::unique_lock lk(cleanupMtx_);
-    cleanupFuncs_[session].emplace_back(func);
+    cleanupFuncs_[session].push_back(std::move(func));
 }
 
 void

--- a/src/subscriptions/SubscriptionManager.h
+++ b/src/subscriptions/SubscriptionManager.h
@@ -262,13 +262,28 @@ private:
     void
     sendAll(std::string const& pubMsg, std::unordered_set<session_ptr>& subs);
 
+    using CleanupFunction = std::function<void(session_ptr)>;
+
+    void
+    subscribeHelper(
+        std::shared_ptr<WsBase>& session,
+        Subscription& subs,
+        CleanupFunction&& func);
+
+    template <typename Key>
+    void
+    subscribeHelper(
+        std::shared_ptr<WsBase>& session,
+        Key const& k,
+        SubscriptionMap<Key>& subs,
+        CleanupFunction&& func);
+
     /**
      * This is how we chose to cleanup subscriptions that have been closed.
      * Each time we add a subscriber, we add the opposite lambda that
      * unsubscribes that subscriber when cleanup is called with the session that
      * closed.
      */
-    using CleanupFunction = std::function<void(session_ptr)>;
     std::mutex cleanupMtx_;
     std::unordered_map<session_ptr, std::vector<CleanupFunction>>
         cleanupFuncs_ = {};


### PR DESCRIPTION
There was a memory leak where some subscriptions were not being cleaned up. This commit fixes that, and makes it easier to ensure this mistake doesn't happen again in the future

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/402)
<!-- Reviewable:end -->
