### PR TITLE
include searched_all in error response of tx

### DIFF
--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -132,10 +132,9 @@ makeError(Status const& status)
         status.code);
     if (status.extraInfo)
     {
-        for (auto it = status.extraInfo->begin(); it != status.extraInfo->end();
-             ++it)
+        for (auto& [key, value] : status.extraInfo.value())
         {
-            res[it->key()] = it->value();
+            res[key] = value;
         }
     }
     return res;

--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -106,7 +106,7 @@ makeError(Status const& status)
         return str.empty() ? nullopt : make_optional(str);
     };
 
-    return visit(
+    auto res = visit(
         overloadSet{
             [&status, &wrapOptional](RippledError err) {
                 if (err == ripple::rpcUNKNOWN)
@@ -130,6 +130,15 @@ makeError(Status const& status)
             },
         },
         status.code);
+    if (status.extraInfo)
+    {
+        for (auto it = status.extraInfo->begin(); it != status.extraInfo->end();
+             ++it)
+        {
+            res[it->key()] = it->value();
+        }
+    }
+    return res;
 }
 
 }  // namespace RPC

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -50,9 +50,12 @@ struct Status
     CombinedError code = RippledError::rpcSUCCESS;
     std::string error = "";
     std::string message = "";
+    std::optional<boost::json::object> extraInfo;
 
     Status() = default;
     /* implicit */ Status(CombinedError code) : code(code){};
+    Status(CombinedError code, boost::json::object const& extraInfo)
+        : code(code), extraInfo(extraInfo){};
 
     // HACK. Some rippled handlers explicitly specify errors.
     // This means that we have to be able to duplicate this

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -54,7 +54,7 @@ struct Status
 
     Status() = default;
     /* implicit */ Status(CombinedError code) : code(code){};
-    Status(CombinedError code, boost::json::object const& extraInfo)
+    Status(CombinedError code, boost::json::object&& extraInfo)
         : code(code), extraInfo(extraInfo){};
 
     // HACK. Some rippled handlers explicitly specify errors.

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -55,7 +55,7 @@ struct Status
     Status() = default;
     /* implicit */ Status(CombinedError code) : code(code){};
     Status(CombinedError code, boost::json::object&& extraInfo)
-        : code(code), extraInfo(extraInfo){};
+        : code(code), extraInfo(std::move(extraInfo)){};
 
     // HACK. Some rippled handlers explicitly specify errors.
     // This means that we have to be able to duplicate this


### PR DESCRIPTION
This PR fixes a couple of bugs. Fixes https://github.com/XRPLF/clio/issues/278. Also performs other checks on the ledger range supplied by the user in order to align with rippled. Also actually implements the `searched_all` functionality: https://xrpl.org/tx.html#not-found-response
Supersedes: https://github.com/XRPLF/clio/pull/359

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/407)
<!-- Reviewable:end -->
