### PR TITLE
Add limit to response only if next marker is available

### DIFF
--- a/src/rpc/handlers/AccountChannels.cpp
+++ b/src/rpc/handlers/AccountChannels.cpp
@@ -85,7 +85,6 @@ doAccountChannels(Context const& context)
 
     response[JS(account)] = ripple::to_string(accountID);
     response[JS(channels)] = boost::json::value(boost::json::array_kind);
-    response[JS(limit)] = limit;
     boost::json::array& jsonChannels = response.at(JS(channels)).as_array();
 
     auto const addToResponse = [&](ripple::SLE&& sle) {
@@ -118,7 +117,10 @@ doAccountChannels(Context const& context)
     auto nextMarker = std::get<RPC::AccountCursor>(next);
 
     if (nextMarker.isNonZero())
+    {
         response[JS(marker)] = nextMarker.toString();
+        response[JS(limit)] = limit;
+    }
 
     return response;
 }

--- a/src/rpc/handlers/AccountLines.cpp
+++ b/src/rpc/handlers/AccountLines.cpp
@@ -140,7 +140,6 @@ doAccountLines(Context const& context)
     response[JS(account)] = ripple::to_string(accountID);
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
     response[JS(ledger_index)] = lgrInfo.seq;
-    response[JS(limit)] = limit;
     response[JS(lines)] = boost::json::value(boost::json::array_kind);
     boost::json::array& jsonLines = response.at(JS(lines)).as_array();
 
@@ -181,7 +180,10 @@ doAccountLines(Context const& context)
     auto nextMarker = std::get<RPC::AccountCursor>(next);
 
     if (nextMarker.isNonZero())
+    {
         response[JS(marker)] = nextMarker.toString();
+        response[JS(limit)] = limit;
+    }
 
     return response;
 }

--- a/src/rpc/handlers/AccountOffers.cpp
+++ b/src/rpc/handlers/AccountOffers.cpp
@@ -100,7 +100,6 @@ doAccountOffers(Context const& context)
     }
 
     response[JS(account)] = ripple::to_string(accountID);
-    response[JS(limit)] = limit;
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
     response[JS(ledger_index)] = lgrInfo.seq;
     response[JS(offers)] = boost::json::value(boost::json::array_kind);
@@ -130,7 +129,10 @@ doAccountOffers(Context const& context)
     auto nextMarker = std::get<RPC::AccountCursor>(next);
 
     if (nextMarker.isNonZero())
+    {
         response[JS(marker)] = nextMarker.toString();
+        response[JS(limit)] = limit;
+    }
 
     return response;
 }


### PR DESCRIPTION
Fixes #221 

Fixing issues from the latest comments on #221:
- Add 'limit' to response only if a `marker` is also available (meaning there is more data) for
  - Account channels
  - Account lines
  - Account offers