### PR TITLE
Use custom malformedAddress error in ledger_entry

### DIFF
--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -59,6 +59,9 @@ getErrorInfo(ClioError code)
          "malformedRequest",
          "Malformed request."},
         {ClioError::rpcMALFORMED_OWNER, "malformedOwner", "Malformed owner."},
+        {ClioError::rpcMALFORMED_ADDRESS,
+         "malformedAddress",
+         "Malformed address."},
     };
 
     auto matchByCode = [code](auto const& info) { return info.code == code; };

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -19,6 +19,7 @@ enum class ClioError {
     rpcMALFORMED_CURRENCY = 5000,
     rpcMALFORMED_REQUEST = 5001,
     rpcMALFORMED_OWNER = 5002,
+    rpcMALFORMED_ADDRESS = 5003,
 };
 
 /**

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -49,7 +49,7 @@ doLedgerEntry(Context const& context)
         auto const account = ripple::parseBase58<ripple::AccountID>(
             request.at(JS(account_root)).as_string().c_str());
         if (!account || account->isZero())
-            return Status{RippledError::rpcINVALID_PARAMS, "malformedAddress"};
+            return Status{ClioError::rpcMALFORMED_ADDRESS};
         else
             key = ripple::keylet::account(*account).key;
     }
@@ -175,8 +175,7 @@ doLedgerEntry(Context const& context)
 
                 if (!ownerID)
                 {
-                    return Status{
-                        RippledError::rpcINVALID_PARAMS, "malformedAddress"};
+                    return Status{ClioError::rpcMALFORMED_ADDRESS};
                 }
                 else
                 {
@@ -222,8 +221,7 @@ doLedgerEntry(Context const& context)
                                                            .c_str());
 
             if (!id)
-                return Status{
-                    RippledError::rpcINVALID_PARAMS, "malformedAddress"};
+                return Status{ClioError::rpcMALFORMED_ADDRESS};
             else
             {
                 std::uint32_t seq =
@@ -259,8 +257,7 @@ doLedgerEntry(Context const& context)
                 offer.at(JS(account)).as_string().c_str());
 
             if (!id)
-                return Status{
-                    RippledError::rpcINVALID_PARAMS, "malformedAddress"};
+                return Status{ClioError::rpcMALFORMED_ADDRESS};
             else
             {
                 std::uint32_t seq =
@@ -313,7 +310,7 @@ doLedgerEntry(Context const& context)
 
         if (!id1 || !id2)
             return Status{
-                RippledError::rpcINVALID_PARAMS, "malformedAddresses"};
+                ClioError::rpcMALFORMED_ADDRESS, "malformedAddresses"};
 
         else if (!ripple::to_currency(
                      currency, state.at(JS(currency)).as_string().c_str()))


### PR DESCRIPTION
Fixes #272 
- Add a custom error code for malformedAddress
- Use the new error in relevant places (except for `escrow` case where `account` should not be supported according to docs)