### PR TITLE
Fix malformed output format over ws rpc

### DIFF
--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -321,9 +321,6 @@ buildResponse(Context const& ctx)
         if (!res)
             return Status{RippledError::rpcFAILED_TO_FORWARD};
 
-        if (res->contains("result") && res->at("result").is_object())
-            return res->at("result").as_object();
-
         return *res;
     }
 

--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -50,29 +50,18 @@ doAccountInfo(Context const& context)
     if (!accountID)
         return Status{RippledError::rpcACT_MALFORMED};
 
-    assert(accountID.has_value());
-
     auto key = ripple::keylet::account(accountID.value());
-
     std::optional<std::vector<unsigned char>> dbResponse =
         context.backend->fetchLedgerObject(key.key, lgrInfo.seq, context.yield);
 
     if (!dbResponse)
-    {
         return Status{RippledError::rpcACT_NOT_FOUND};
-    }
 
     ripple::STLedgerEntry sle{
         ripple::SerialIter{dbResponse->data(), dbResponse->size()}, key.key};
 
     if (!key.check(sle))
         return Status{RippledError::rpcDB_DESERIALIZATION};
-
-    // if (!binary)
-    //     response[JS(account_data)] = getJson(sle);
-    // else
-    //     response[JS(account_data)] = ripple::strHex(*dbResponse);
-    // response[JS(db_time)] = time;
 
     response[JS(account_data)] = toJson(sle);
     response[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);


### PR DESCRIPTION
Fixes #405 

When accessing `clio` thru ws rpc a forwarded rpc result is no longer wrapped in extra `result` object.
All fields are copied from the original `rippled` response when forwarding. 