### PR TITLE
Always add git ref to version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,13 @@ if(NOT GIT_COMMIT_HASH)
   find_package(Git)
   if(Git_FOUND)
       execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-          OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE gch)
-      if(gch)
-          set(GIT_COMMIT_HASH "${gch}")
-          message(STATUS "Git commit: ${GIT_COMMIT_HASH}")
-          add_definitions(-DCLIO_GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+          OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE git-ref)
+      execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+          OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE branch)
+      if(git-ref)
+          set(BUILD "${branch}-${git-ref}")
+          message(STATUS "Build version: ${BUILD}")
+          add_definitions(-DCLIO_BUILD="${BUILD}")
       endif()
   endif()
 endif() #git
@@ -109,8 +111,8 @@ add_executable(clio_server src/main/main.cpp)
 target_link_libraries(clio_server PUBLIC clio)
 
 if(BUILD_TESTS)
-  add_executable(clio_tests 
-    unittests/RPCErrors.cpp 
+  add_executable(clio_tests
+    unittests/RPCErrors.cpp
     unittests/Backend.cpp
     unittests/Logger.cpp
     unittests/Config.cpp)

--- a/src/main/impl/Build.cpp
+++ b/src/main/impl/Build.cpp
@@ -13,16 +13,14 @@ namespace Build {
 //------------------------------------------------------------------------------
 // clang-format off
 char const* const versionString = "1.0.3"
-// clang-format on
+    // clang-format on
 
-#if defined(DEBUG) || defined(SANITIZER)
     "+"
-#ifdef CLIO_GIT_COMMIT_HASH
-    CLIO_GIT_COMMIT_HASH
-    "."
+#ifdef CLIO_BUILD
+    CLIO_BUILD
 #endif
 #ifdef DEBUG
-    "DEBUG"
+    ".DEBUG"
 #ifdef SANITIZER
     "."
 #endif
@@ -31,7 +29,7 @@ char const* const versionString = "1.0.3"
 #ifdef SANITIZER
     BOOST_PP_STRINGIZE(SANITIZER)
 #endif
-#endif
+
 #ifdef PKG
         "-release"
 #endif


### PR DESCRIPTION
The `${branch}-${git-ref}` will be in the version string regardless of build type/branch/time of day.

Looks like:
`clio-1.0.3+docker-compose-94385e6`
Addresses: #427 