### PR TITLE
Add workaround for source_location for AppleClang 

### DIFF
--- a/CMake/deps/SourceLocation.cmake
+++ b/CMake/deps/SourceLocation.cmake
@@ -1,0 +1,11 @@
+include(CheckIncludeFileCXX)
+
+check_include_file_cxx("source_location" SOURCE_LOCATION_AVAILABLE)
+if(SOURCE_LOCATION_AVAILABLE) 
+    target_compile_definitions(clio PUBLIC "HAS_SOURCE_LOCATION")
+endif()
+
+check_include_file_cxx("experimental/source_location" EXPERIMENTAL_SOURCE_LOCATION_AVAILABLE)
+if(EXPERIMENTAL_SOURCE_LOCATION_AVAILABLE)     
+    target_compile_definitions(clio PUBLIC "HAS_EXPERIMENTAL_SOURCE_LOCATION")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ if(PACKAGING)
   add_definitions(-DPKG=1)
 endif()
 
-
 add_library(clio)
 target_compile_features(clio PUBLIC cxx_std_20)
 target_include_directories(clio PUBLIC src)
@@ -45,6 +44,7 @@ include(CMake/ClioVersion.cmake)
 include(CMake/deps/rippled.cmake)
 include(CMake/deps/Boost.cmake)
 include(CMake/deps/cassandra.cmake)
+include(CMake/deps/SourceLocation.cmake)
 
 target_sources(clio PRIVATE
   ## Main

--- a/src/log/Logger.cpp
+++ b/src/log/Logger.cpp
@@ -33,18 +33,18 @@ tag_invoke(boost::json::value_to_tag<Severity>, boost::json::value const& value)
     auto const& logLevel = value.as_string();
 
     if (boost::iequals(logLevel, "trace"))
-        return Severity::TRACE;
+        return Severity::TRC;
     else if (boost::iequals(logLevel, "debug"))
-        return Severity::DEBUG;
+        return Severity::DBG;
     else if (boost::iequals(logLevel, "info"))
-        return Severity::INFO;
+        return Severity::NFO;
     else if (
         boost::iequals(logLevel, "warning") || boost::iequals(logLevel, "warn"))
-        return Severity::WARNING;
+        return Severity::WRN;
     else if (boost::iequals(logLevel, "error"))
-        return Severity::ERROR;
+        return Severity::ERR;
     else if (boost::iequals(logLevel, "fatal"))
-        return Severity::FATAL;
+        return Severity::FTL;
     else
         throw std::runtime_error(
             "Could not parse `log_level`: expected `trace`, `debug`, `info`, "
@@ -103,8 +103,7 @@ LogService::init(Config const& config)
 
     // get default severity, can be overridden per channel using
     // the `log_channels` array
-    auto defaultSeverity =
-        config.valueOr<Severity>("log_level", Severity::INFO);
+    auto defaultSeverity = config.valueOr<Severity>("log_level", Severity::NFO);
     static constexpr std::array<const char*, 7> channels = {
         "General",
         "WebServer",
@@ -122,7 +121,7 @@ LogService::init(Config const& config)
     for (auto const& channel : channels)
         min_severity[channel] = defaultSeverity;
     min_severity["Alert"] =
-        Severity::WARNING;  // Channel for alerts, always warning severity
+        Severity::WRN;  // Channel for alerts, always warning severity
 
     for (auto const overrides = config.arrayOr("log_channels", {});
          auto const& cfg : overrides)
@@ -143,34 +142,34 @@ LogService::init(Config const& config)
 }
 
 Logger::Pump
-Logger::trace(source_location_t const loc) const
+Logger::trace(source_location_t const& loc) const
 {
-    return {logger_, Severity::TRACE, loc};
+    return {logger_, Severity::TRC, loc};
 };
 Logger::Pump
-Logger::debug(source_location_t const loc) const
+Logger::debug(source_location_t const& loc) const
 {
-    return {logger_, Severity::DEBUG, loc};
+    return {logger_, Severity::DBG, loc};
 };
 Logger::Pump
-Logger::info(source_location_t const loc) const
+Logger::info(source_location_t const& loc) const
 {
-    return {logger_, Severity::INFO, loc};
+    return {logger_, Severity::NFO, loc};
 };
 Logger::Pump
-Logger::warn(source_location_t const loc) const
+Logger::warn(source_location_t const& loc) const
 {
-    return {logger_, Severity::WARNING, loc};
+    return {logger_, Severity::WRN, loc};
 };
 Logger::Pump
-Logger::error(source_location_t const loc) const
+Logger::error(source_location_t const& loc) const
 {
-    return {logger_, Severity::ERROR, loc};
+    return {logger_, Severity::ERR, loc};
 };
 Logger::Pump
-Logger::fatal(source_location_t const loc) const
+Logger::fatal(source_location_t const& loc) const
 {
-    return {logger_, Severity::FATAL, loc};
+    return {logger_, Severity::FTL, loc};
 };
 
 std::string

--- a/src/log/Logger.h
+++ b/src/log/Logger.h
@@ -16,9 +16,15 @@
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/log/utility/setup/formatter_parser.hpp>
 
-// Note: clang still does not provide non-experimental support, gcc does
-// TODO: start using <source_location> once clang catches up on c++20
+#if defined(HAS_SOURCE_LOCATION) && __has_builtin(__builtin_source_location)
+// this is used by fully compatible compilers like gcc
+#include <source_location>
+
+#elif defined(HAS_EXPERIMENTAL_SOURCE_LOCATION)
+// this is used by clang on linux where source_location is still not out of
+// experimental headers
 #include <experimental/source_location>
+#endif
 
 #include <optional>
 #include <string>
@@ -26,18 +32,53 @@
 namespace clio {
 
 class Config;
+#if defined(HAS_SOURCE_LOCATION) && __has_builtin(__builtin_source_location)
+using source_location_t = std::source_location;
+#define CURRENT_SRC_LOCATION source_location_t::current()
+
+#elif defined(HAS_EXPERIMENTAL_SOURCE_LOCATION)
 using source_location_t = std::experimental::source_location;
+#define CURRENT_SRC_LOCATION source_location_t::current()
+
+#else
+// A workaround for AppleClang that is lacking source_location atm.
+// TODO: remove this workaround when all compilers catch up to c++20
+class SourceLocation
+{
+    std::string_view file_;
+    std::size_t line_;
+
+public:
+    SourceLocation(std::string_view file, std::size_t line)
+        : file_{file}, line_{line}
+    {
+    }
+    std::string_view
+    file_name() const
+    {
+        return file_;
+    }
+    std::size_t
+    line() const
+    {
+        return line_;
+    }
+};
+using source_location_t = SourceLocation;
+#define CURRENT_SRC_LOCATION \
+    source_location_t(__builtin_FILE(), __builtin_LINE())
+#endif
 
 /**
  * @brief Custom severity levels for @ref Logger.
  */
 enum class Severity {
-    TRACE,
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR,
-    FATAL,
+    TRC,
+    DBG,
+    NFO,
+    WRN,
+    ERR,
+    FTL,
 };
 
 BOOST_LOG_ATTRIBUTE_KEYWORD(log_severity, "Severity", Severity);
@@ -156,29 +197,29 @@ public:
     Logger&
     operator=(Logger&&) = default;
 
-    /*! Interface for logging at @ref Severity::TRACE severity */
+    /*! Interface for logging at @ref Severity::TRC severity */
     [[nodiscard]] Pump
-    trace(source_location_t const loc = source_location_t::current()) const;
+    trace(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 
-    /*! Interface for logging at @ref Severity::DEBUG severity */
+    /*! Interface for logging at @ref Severity::DBG severity */
     [[nodiscard]] Pump
-    debug(source_location_t const loc = source_location_t::current()) const;
+    debug(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 
     /*! Interface for logging at @ref Severity::INFO severity */
     [[nodiscard]] Pump
-    info(source_location_t const loc = source_location_t::current()) const;
+    info(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 
-    /*! Interface for logging at @ref Severity::WARNING severity */
+    /*! Interface for logging at @ref Severity::WRN severity */
     [[nodiscard]] Pump
-    warn(source_location_t const loc = source_location_t::current()) const;
+    warn(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 
-    /*! Interface for logging at @ref Severity::ERROR severity */
+    /*! Interface for logging at @ref Severity::ERR severity */
     [[nodiscard]] Pump
-    error(source_location_t const loc = source_location_t::current()) const;
+    error(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 
-    /*! Interface for logging at @ref Severity::FATAL severity */
+    /*! Interface for logging at @ref Severity::FTL severity */
     [[nodiscard]] Pump
-    fatal(source_location_t const loc = source_location_t::current()) const;
+    fatal(source_location_t const& loc = CURRENT_SRC_LOCATION) const;
 };
 
 /**
@@ -201,51 +242,51 @@ public:
     static void
     init(Config const& config);
 
-    /*! Globally accesible General logger at @ref Severity::TRACE severity */
+    /*! Globally accesible General logger at @ref Severity::TRC severity */
     [[nodiscard]] static Logger::Pump
-    trace(source_location_t const loc = source_location_t::current())
+    trace(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.trace(loc);
     }
 
-    /*! Globally accesible General logger at @ref Severity::TRACE severity */
+    /*! Globally accesible General logger at @ref Severity::DBG severity */
     [[nodiscard]] static Logger::Pump
-    debug(source_location_t const loc = source_location_t::current())
+    debug(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.debug(loc);
     }
 
-    /*! Globally accesible General logger at @ref Severity::INFO severity */
+    /*! Globally accesible General logger at @ref Severity::NFO severity */
     [[nodiscard]] static Logger::Pump
-    info(source_location_t const loc = source_location_t::current())
+    info(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.info(loc);
     }
 
-    /*! Globally accesible General logger at @ref Severity::WARNING severity */
+    /*! Globally accesible General logger at @ref Severity::WRN severity */
     [[nodiscard]] static Logger::Pump
-    warn(source_location_t const loc = source_location_t::current())
+    warn(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.warn(loc);
     }
 
-    /*! Globally accesible General logger at @ref Severity::ERROR severity */
+    /*! Globally accesible General logger at @ref Severity::ERR severity */
     [[nodiscard]] static Logger::Pump
-    error(source_location_t const loc = source_location_t::current())
+    error(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.error(loc);
     }
 
-    /*! Globally accesible General logger at @ref Severity::FATAL severity */
+    /*! Globally accesible General logger at @ref Severity::FTL severity */
     [[nodiscard]] static Logger::Pump
-    fatal(source_location_t const loc = source_location_t::current())
+    fatal(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return general_log_.fatal(loc);
     }
 
     /*! Globally accesible Alert logger */
     [[nodiscard]] static Logger::Pump
-    alert(source_location_t const loc = source_location_t::current())
+    alert(source_location_t const& loc = CURRENT_SRC_LOCATION)
     {
         return alert_log_.warn(loc);
     }

--- a/unittests/Backend.cpp
+++ b/unittests/Backend.cpp
@@ -27,7 +27,7 @@ TEST_F(BackendTest, Basic)
     boost::asio::spawn(
         ioc, [&done, &work, &ioc](boost::asio::yield_context yield) {
             boost::log::core::get()->set_filter(
-                clio::log_severity >= clio::Severity::WARNING);
+                clio::log_severity >= clio::Severity::WRN);
             std::string keyspace = "clio_test_" +
                 std::to_string(std::chrono::system_clock::now()
                                    .time_since_epoch()
@@ -1161,7 +1161,7 @@ TEST_F(BackendTest, cache)
 {
     using namespace Backend;
     boost::log::core::get()->set_filter(
-        clio::log_severity >= clio::Severity::WARNING);
+        clio::log_severity >= clio::Severity::WRN);
     SimpleCache cache;
     ASSERT_FALSE(cache.isFull());
     cache.setFull();
@@ -1403,7 +1403,7 @@ TEST_F(BackendTest, cacheBackground)
 {
     using namespace Backend;
     boost::log::core::get()->set_filter(
-        clio::log_severity >= clio::Severity::WARNING);
+        clio::log_severity >= clio::Severity::WRN);
     SimpleCache cache;
     ASSERT_FALSE(cache.isFull());
     ASSERT_EQ(cache.size(), 0);
@@ -1813,7 +1813,7 @@ TEST_F(BackendTest, cacheIntegration)
     boost::asio::spawn(
         ioc, [&ioc, &done, &work](boost::asio::yield_context yield) {
             boost::log::core::get()->set_filter(
-                clio::log_severity >= clio::Severity::WARNING);
+                clio::log_severity >= clio::Severity::WRN);
             std::string keyspace = "clio_test_" +
                 std::to_string(std::chrono::system_clock::now()
                                    .time_since_epoch()

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -53,8 +53,8 @@ protected:
             stream_, keywords::format = "%Channel%:%Severity% %Message%");
         auto min_severity = expr::channel_severity_filter(
             clio::log_channel, clio::log_severity);
-        min_severity["General"] = clio::Severity::DEBUG;
-        min_severity["Trace"] = clio::Severity::TRACE;
+        min_severity["General"] = clio::Severity::DBG;
+        min_severity["Trace"] = clio::Severity::TRC;
         core->set_filter(min_severity);
         core->set_logging_enabled(true);
     }


### PR DESCRIPTION
Fixes #428 

Introduces a small custom `source_location` clone that is used for compilers without direct support for `std::source_location` nor `std::experimental::source_location`.