### PR TITLE
add connection counting

### DIFF
--- a/src/webserver/HttpSession.h
+++ b/src/webserver/HttpSession.h
@@ -13,6 +13,7 @@ class HttpSession : public HttpBase<HttpSession>,
                     public std::enable_shared_from_this<HttpSession>
 {
     boost::beast::tcp_stream stream_;
+    std::optional<std::string> ip_;
 
 public:
     // Take ownership of the socket
@@ -41,6 +42,21 @@ public:
               std::move(buffer))
         , stream_(std::move(socket))
     {
+        try
+        {
+            ip_ = stream_.socket().remote_endpoint().address().to_string();
+        }
+        catch (std::exception const&)
+        {
+        }
+        if (ip_)
+            HttpBase::dosGuard().increment(*ip_);
+    }
+
+    ~HttpSession()
+    {
+        if (ip_ and not upgraded_)
+            HttpBase::dosGuard().decrement(*ip_);
     }
 
     boost::beast::tcp_stream&
@@ -57,14 +73,7 @@ public:
     std::optional<std::string>
     ip()
     {
-        try
-        {
-            return stream_.socket().remote_endpoint().address().to_string();
-        }
-        catch (std::exception const&)
-        {
-            return {};
-        }
+        return ip_;
     }
 
     // Start the asynchronous operation

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -138,6 +138,7 @@ void
 make_websocket_session(
     boost::asio::io_context& ioc,
     boost::beast::tcp_stream stream,
+    std::optional<std::string> const& ip,
     http::request<http::string_body> req,
     boost::beast::flat_buffer buffer,
     std::shared_ptr<BackendInterface const> backend,
@@ -152,6 +153,7 @@ make_websocket_session(
     std::make_shared<WsUpgrader>(
         ioc,
         std::move(stream),
+        ip,
         backend,
         subscriptions,
         balancer,
@@ -169,6 +171,7 @@ void
 make_websocket_session(
     boost::asio::io_context& ioc,
     boost::beast::ssl_stream<boost::beast::tcp_stream> stream,
+    std::optional<std::string> const& ip,
     http::request<http::string_body> req,
     boost::beast::flat_buffer buffer,
     std::shared_ptr<BackendInterface const> backend,
@@ -183,6 +186,7 @@ make_websocket_session(
     std::make_shared<SslWsUpgrader>(
         ioc,
         std::move(stream),
+        ip,
         backend,
         subscriptions,
         balancer,

--- a/src/webserver/PlainWsSession.h
+++ b/src/webserver/PlainWsSession.h
@@ -32,6 +32,7 @@ public:
     explicit PlainWsSession(
         boost::asio::io_context& ioc,
         boost::asio::ip::tcp::socket&& socket,
+        std::optional<std::string> ip,
         std::shared_ptr<BackendInterface const> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<ETLLoadBalancer> balancer,
@@ -43,6 +44,7 @@ public:
         boost::beast::flat_buffer&& buffer)
         : WsSession(
               ioc,
+              ip,
               backend,
               subscriptions,
               balancer,
@@ -65,19 +67,7 @@ public:
     std::optional<std::string>
     ip()
     {
-        try
-        {
-            return ws()
-                .next_layer()
-                .socket()
-                .remote_endpoint()
-                .address()
-                .to_string();
-        }
-        catch (std::exception const&)
-        {
-            return {};
-        }
+        return ip_;
     }
 
     ~PlainWsSession() = default;
@@ -98,11 +88,13 @@ class WsUpgrader : public std::enable_shared_from_this<WsUpgrader>
     RPC::Counters& counters_;
     WorkQueue& queue_;
     http::request<http::string_body> req_;
+    std::optional<std::string> ip_;
 
 public:
     WsUpgrader(
         boost::asio::io_context& ioc,
         boost::asio::ip::tcp::socket&& socket,
+        std::optional<std::string> ip,
         std::shared_ptr<BackendInterface const> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<ETLLoadBalancer> balancer,
@@ -123,11 +115,13 @@ public:
         , dosGuard_(dosGuard)
         , counters_(counters)
         , queue_(queue)
+        , ip_(ip)
     {
     }
     WsUpgrader(
         boost::asio::io_context& ioc,
         boost::beast::tcp_stream&& stream,
+        std::optional<std::string> ip,
         std::shared_ptr<BackendInterface const> backend,
         std::shared_ptr<SubscriptionManager> subscriptions,
         std::shared_ptr<ETLLoadBalancer> balancer,
@@ -150,6 +144,7 @@ public:
         , counters_(counters)
         , queue_(queue)
         , req_(std::move(req))
+        , ip_(ip)
     {
     }
 
@@ -198,6 +193,7 @@ private:
         std::make_shared<PlainWsSession>(
             ioc_,
             http_.release_socket(),
+            ip_,
             backend_,
             subscriptions_,
             balancer_,

--- a/src/webserver/SslHttpSession.h
+++ b/src/webserver/SslHttpSession.h
@@ -13,6 +13,7 @@ class SslHttpSession : public HttpBase<SslHttpSession>,
                        public std::enable_shared_from_this<SslHttpSession>
 {
     boost::beast::ssl_stream<boost::beast::tcp_stream> stream_;
+    std::optional<std::string> ip_;
 
 public:
     // Take ownership of the socket
@@ -42,6 +43,25 @@ public:
               std::move(buffer))
         , stream_(std::move(socket), ctx)
     {
+        try
+        {
+            ip_ = stream_.next_layer()
+                      .socket()
+                      .remote_endpoint()
+                      .address()
+                      .to_string();
+        }
+        catch (std::exception const&)
+        {
+        }
+        if (ip_)
+            HttpBase::dosGuard().increment(*ip_);
+    }
+
+    ~SslHttpSession()
+    {
+        if (ip_ and not upgraded_)
+            HttpBase::dosGuard().decrement(*ip_);
     }
 
     boost::beast::ssl_stream<boost::beast::tcp_stream>&
@@ -58,18 +78,7 @@ public:
     std::optional<std::string>
     ip()
     {
-        try
-        {
-            return stream_.next_layer()
-                .socket()
-                .remote_endpoint()
-                .address()
-                .to_string();
-        }
-        catch (std::exception const&)
-        {
-            return {};
-        }
+        return ip_;
     }
 
     // Start the asynchronous operation


### PR DESCRIPTION
Limit the number of concurrent connections the server allows from a specific ip. Defaults to 1. This will apply to open subscriptions as well. Also raises the default max fetches value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/433)
<!-- Reviewable:end -->
