### PR TITLE
Remove branch name from version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,8 @@ if(NOT GIT_COMMIT_HASH)
   if(Git_FOUND)
       execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
           OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE git-ref)
-      execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-          OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE branch)
       if(git-ref)
-          set(BUILD "${branch}-${git-ref}")
+          set(BUILD "${git-ref}")
           message(STATUS "Build version: ${BUILD}")
           add_definitions(-DCLIO_BUILD="${BUILD}")
       endif()


### PR DESCRIPTION
It is possible to have a branch name end up in the version string that will cause a runtime exception from the [beast semantic version checker](https://thejohnfreeman.github.io/rippled/classbeast_1_1SemanticVersion.html).
```
[2022-12-06 19:34:17.448982] [0x0000000107c1b600] [info]    Exit on exception: 1.0.3+bad/named/-version-string-41ee3d1: Bad server version string
```