### PR TITLE
Update documentation and config with start_sequence 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,23 @@ server is running
 to the IP of your Clio server. This entry can take the form of a comma-separated list if
 you are running multiple Clio nodes.
 
-In addition, the parameters `ssl_cert_file` and `ssl_key_file` can also be added to the top level of precedence of our Clio config. `ssl_cert_file` specifies the filepath for your SSL cert while `ssl_key_file` specifies the filepath for your SSL key. It is up to you how to change ownership of these folders for your designated Clio user. Your options include:
+
+In addition, the parameter `start_sequence` can be included and configured within the top level of the config file. This parameter specifies the sequence of first ledger to extract if the database is empty. Note that ETL extracts ledgers in order and that no backfilling functionality currently exists, meaning Clio will not retroactively learn ledgers older than the one you specify. Choosing to specify this or not will yield the following behavior:
+- If this setting is absent and the database is empty, ETL will start with the next ledger validated by the network. 
+- If this setting is present and the database is not empty, an exception is thrown.
+
+In addition, the optional parameter `finish_sequence` can be added to the json file as well, specifying where the ledger can stop.
+
+To add `start_sequence` and/or `finish_sequence` to the config.json file appropriately, they will be on the same top level of precedence as other parameters (such as database, etl_sources, read_only, etc.) and be specified with an integer. Here is an example below, added at the end of the config.json:
+
+```json
+    ...
+    "read_only": false,
+    "start_sequence": [integer] the ledger index to start from
+    "finish_sequence": [integer] the ledger index to finish at
+```
+
+The parameters `ssl_cert_file` and `ssl_key_file` can also be added to the top level of precedence of our Clio config. `ssl_cert_file` specifies the filepath for your SSL cert while `ssl_key_file` specifies the filepath for your SSL key. It is up to you how to change ownership of these folders for your designated Clio user. Your options include:
 - Copying the two files as root somewhere that's accessible by the Clio user, then running `sudo chown` to your user
 - Changing the permissions directly so it's readable by your Clio user
 - Running Clio as root (strongly discouraged)

--- a/example-config.json
+++ b/example-config.json
@@ -67,6 +67,8 @@
     "log_tag_style": "uint",
     "extractor_threads": 8,
     "read_only": false,
+    //"start_sequence": [integer] the ledger index to start from,
+    //"finish_sequence": [integer] the ledger index to finish at,
     //"ssl_cert_file" : "/full/path/to/cert.file",
     //"ssl_key_file" : "/full/path/to/key.file"
 }


### PR DESCRIPTION
**Issue (#250)**: No documentation regarding start_sequence in Clio config file
**Fix**: Update documentation regarding optional start_sequence parameter 