### PR TITLE
Update documentation and config with ssl_cert_file and ssl_key_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ server is running
 to the IP of your Clio server. This entry can take the form of a comma-separated list if
 you are running multiple Clio nodes.
 
+In addition, the parameters `ssl_cert_file` and `ssl_key_file` can also be added to the top level of precedence of our Clio config. `ssl_cert_file` specifies the filepath for your SSL cert while `ssl_key_file` specifies the filepath for your SSL key. It is up to you how to change ownership of these folders for your designated Clio user. Your options include:
+- Copying the two files as root somewhere that's accessible by the Clio user, then running `sudo chown` to your user
+- Changing the permissiosn directly so it's readable by your CLio user
+- Running Clio as root (strongly discouraged)
+
+An example of how to include `ssl_cert_file` and `ssl_key_file` in the Clio config are below:
+```sh
+{
+    "server":{
+        "ip": "0.0.0.0",
+        "port": 51233
+    },
+    "ssl_cert_file" : "/full/path/to/cert.file",
+    "ssl_key_file" : "/full/path/to/key.file"
+}
+```
+
 Once your config files are ready, start rippled and Clio. It doesn't matter which you
 start first, and it's fine to stop one or the other and restart at any given time.
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ you are running multiple Clio nodes.
 
 In addition, the parameters `ssl_cert_file` and `ssl_key_file` can also be added to the top level of precedence of our Clio config. `ssl_cert_file` specifies the filepath for your SSL cert while `ssl_key_file` specifies the filepath for your SSL key. It is up to you how to change ownership of these folders for your designated Clio user. Your options include:
 - Copying the two files as root somewhere that's accessible by the Clio user, then running `sudo chown` to your user
-- Changing the permissiosn directly so it's readable by your CLio user
+- Changing the permissions directly so it's readable by your Clio user
 - Running Clio as root (strongly discouraged)
 
 An example of how to include `ssl_cert_file` and `ssl_key_file` in the Clio config are below:
-```sh
+```json
 {
     "server":{
         "ip": "0.0.0.0",

--- a/example-config.json
+++ b/example-config.json
@@ -66,5 +66,7 @@
     "log_rotation_hour_interval": 12,
     "log_tag_style": "uint",
     "extractor_threads": 8,
-    "read_only": false
+    "read_only": false,
+    //"ssl_cert_file" : "/full/path/to/cert.file",
+    //"ssl_key_file" : "/full/path/to/key.file"
 }


### PR DESCRIPTION
**Issue** (#424): No documentation regarding ssl_cert_file and ssl_key_file in Clio config file
**Fix**: Update documentation regarding optional ssl_cert_file and ssl_key_file parameter