### PR TITLE
Increase file descriptor limit

### DIFF
--- a/CMake/install/clio.service.in
+++ b/CMake/install/clio.service.in
@@ -11,6 +11,7 @@ ExecStart=@CLIO_INSTALL_DIR@/bin/clio_server @CLIO_INSTALL_DIR@/etc/config.json
 Restart=on-failure
 User=clio
 Group=clio
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
System ran out of file descriptors. 
Default limit is 1024 and can be hit with many connections open.