### PR TITLE
Document dos_guard in example config. Log when client surpasses rate limit

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -21,7 +21,16 @@
     ],
     "dos_guard":
     {
-        "whitelist":["127.0.0.1"]
+        "whitelist":["127.0.0.1"], // comma-separated list of ips to exclude from rate limiting
+        /* The below values are the default values and are only specified here
+         * for documentation purposes. The rate limiter currently limits
+         * connections and bandwidth per ip. The rate limiter looks at the raw
+         * ip of a client connection, and so requests routed through a load
+         * balancer will all have the same ip and be treated as a single client
+         */
+        "max_fetches":100000000, // max bytes per ip per sweep interval
+        "max_connections":1, // max connections per ip
+        "sweep_interval": 10 // time in seconds before resetting bytes per ip count
     },
     "cache":
     {
@@ -29,7 +38,11 @@
     },
     "server":{
         "ip": "0.0.0.0",
-        "port": 51233
+        "port": 51233,
+        /* Max number of requests to queue up before rejecting further requests.
+        * Defaults to 0, which disables the limit
+        */
+        "max_queue_size":500
     },
     "log_channels": [
         {

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -36,6 +36,7 @@ class DOSGuard
     std::uint32_t const maxFetches_;
     std::uint32_t const sweepInterval_;
     std::uint32_t const maxConnCount_;
+    clio::Logger log_{"RPC"};
 
 public:
     DOSGuard(clio::Config const& config, boost::asio::io_context& ctx)
@@ -90,6 +91,8 @@ public:
                 connsOk = it->second <= maxConnCount_;
             }
         }
+        if (!fetchesOk || !connsOk)
+            log_.warn() << "Client surpassed the rate limit. ip = " << ip;
 
         return fetchesOk && connsOk;
     }


### PR DESCRIPTION
I also added a max size for the work queue in the example config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xrplf/clio/451)
<!-- Reviewable:end -->
