### PR TITLE
Unit-tests for slightly modified DOSGuard

### DIFF
--- a/CMake/deps/gtest.cmake
+++ b/CMake/deps/gtest.cmake
@@ -10,7 +10,7 @@ if(NOT googletest_POPULATED)
   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-target_link_libraries(clio_tests PUBLIC clio gtest_main)
+target_link_libraries(clio_tests PUBLIC clio gmock_main)
 target_include_directories(clio_tests PRIVATE unittests)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,8 @@ if(BUILD_TESTS)
     unittests/RPCErrors.cpp
     unittests/Backend.cpp
     unittests/Logger.cpp
-    unittests/Config.cpp)
+    unittests/Config.cpp
+    unittests/DOSGuard.cpp)
   include(CMake/deps/gtest.cmake)
 endif()
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -362,7 +362,7 @@ private:
         }
         else if constexpr (std::is_same_v<Return, double>)
         {
-            if (not value.is_double())
+            if (not value.is_number())
                 has_error = true;
         }
         else if constexpr (

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -201,20 +201,19 @@ try
     boost::asio::io_context ioc{threads};
 
     // Rate limiter, to prevent abuse
-    DOSGuard dosGuard{config, ioc};
+    auto sweepHandler = IntervalSweepHandler{config, ioc};
+    auto dosGuard = DOSGuard{config, sweepHandler};
 
     // Interface to the database
-    std::shared_ptr<BackendInterface> backend{
-        Backend::make_Backend(ioc, config)};
+    auto backend = Backend::make_Backend(ioc, config);
 
     // Manages clients subscribed to streams
-    std::shared_ptr<SubscriptionManager> subscriptions{
-        SubscriptionManager::make_SubscriptionManager(config, backend)};
+    auto subscriptions =
+        SubscriptionManager::make_SubscriptionManager(config, backend);
 
     // Tracks which ledgers have been validated by the
     // network
-    std::shared_ptr<NetworkValidatedLedgers> ledgers{
-        NetworkValidatedLedgers::make_ValidatedLedgers()};
+    auto ledgers = NetworkValidatedLedgers::make_ValidatedLedgers();
 
     // Handles the connection to one or more rippled nodes.
     // ETL uses the balancer to extract data.

--- a/src/webserver/HttpBase.h
+++ b/src/webserver/HttpBase.h
@@ -115,7 +115,7 @@ class HttpBase : public util::Taggable
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory const& tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     RPC::Counters& counters_;
     WorkQueue& workQueue_;
     send_lambda lambda_;
@@ -172,7 +172,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer buffer)
@@ -197,7 +197,7 @@ public:
         perfLog_.debug() << tag() << "http session closed";
     }
 
-    DOSGuard&
+    clio::DOSGuard&
     dosGuard()
     {
         return dosGuard_;
@@ -348,7 +348,7 @@ handle_request(
     std::shared_ptr<ETLLoadBalancer> balancer,
     std::shared_ptr<ReportingETL const> etl,
     util::TagDecoratorFactory const& tagFactory,
-    DOSGuard& dosGuard,
+    clio::DOSGuard& dosGuard,
     RPC::Counters& counters,
     std::string const& ip,
     std::shared_ptr<Session> http,

--- a/src/webserver/HttpSession.h
+++ b/src/webserver/HttpSession.h
@@ -43,7 +43,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer buffer)

--- a/src/webserver/Listener.h
+++ b/src/webserver/Listener.h
@@ -51,7 +51,7 @@ class Detector
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory const& tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     RPC::Counters& counters_;
     WorkQueue& queue_;
     boost::beast::flat_buffer buffer_;
@@ -66,7 +66,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue)
         : ioc_(ioc)
@@ -164,7 +164,7 @@ make_websocket_session(
     std::shared_ptr<ETLLoadBalancer> balancer,
     std::shared_ptr<ReportingETL const> etl,
     util::TagDecoratorFactory const& tagFactory,
-    DOSGuard& dosGuard,
+    clio::DOSGuard& dosGuard,
     RPC::Counters& counters,
     WorkQueue& queue)
 {
@@ -197,7 +197,7 @@ make_websocket_session(
     std::shared_ptr<ETLLoadBalancer> balancer,
     std::shared_ptr<ReportingETL const> etl,
     util::TagDecoratorFactory const& tagFactory,
-    DOSGuard& dosGuard,
+    clio::DOSGuard& dosGuard,
     RPC::Counters& counters,
     WorkQueue& queue)
 {
@@ -234,7 +234,7 @@ class Listener
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     WorkQueue queue_;
     RPC::Counters counters_;
 
@@ -250,7 +250,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory tagFactory,
-        DOSGuard& dosGuard)
+        clio::DOSGuard& dosGuard)
         : ioc_(ioc)
         , ctx_(ctx)
         , acceptor_(net::make_strand(ioc))
@@ -356,7 +356,7 @@ make_HttpServer(
     std::shared_ptr<SubscriptionManager> subscriptions,
     std::shared_ptr<ETLLoadBalancer> balancer,
     std::shared_ptr<ReportingETL const> etl,
-    DOSGuard& dosGuard)
+    clio::DOSGuard& dosGuard)
 {
     static clio::Logger log{"WebServer"};
     if (!config.contains("server"))

--- a/src/webserver/PlainWsSession.h
+++ b/src/webserver/PlainWsSession.h
@@ -56,7 +56,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& buffer)
@@ -102,7 +102,7 @@ class WsUpgrader : public std::enable_shared_from_this<WsUpgrader>
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory const& tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     RPC::Counters& counters_;
     WorkQueue& queue_;
     http::request<http::string_body> req_;
@@ -118,7 +118,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& b)
@@ -145,7 +145,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& b,

--- a/src/webserver/SslHttpSession.h
+++ b/src/webserver/SslHttpSession.h
@@ -44,7 +44,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer buffer)

--- a/src/webserver/SslWsSession.h
+++ b/src/webserver/SslWsSession.h
@@ -54,7 +54,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& b)
@@ -99,7 +99,7 @@ class SslWsUpgrader : public std::enable_shared_from_this<SslWsUpgrader>
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory const& tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     RPC::Counters& counters_;
     WorkQueue& queue_;
     http::request<http::string_body> req_;
@@ -115,7 +115,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& b)
@@ -142,7 +142,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& b,

--- a/src/webserver/WsBase.h
+++ b/src/webserver/WsBase.h
@@ -121,7 +121,7 @@ class WsSession : public WsBase,
     std::shared_ptr<ETLLoadBalancer> balancer_;
     std::shared_ptr<ReportingETL const> etl_;
     util::TagDecoratorFactory const& tagFactory_;
-    DOSGuard& dosGuard_;
+    clio::DOSGuard& dosGuard_;
     RPC::Counters& counters_;
     WorkQueue& queue_;
     std::mutex mtx_;
@@ -155,7 +155,7 @@ public:
         std::shared_ptr<ETLLoadBalancer> balancer,
         std::shared_ptr<ReportingETL const> etl,
         util::TagDecoratorFactory const& tagFactory,
-        DOSGuard& dosGuard,
+        clio::DOSGuard& dosGuard,
         RPC::Counters& counters,
         WorkQueue& queue,
         boost::beast::flat_buffer&& buffer)

--- a/unittests/DOSGuard.cpp
+++ b/unittests/DOSGuard.cpp
@@ -1,0 +1,152 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2022, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <util/Fixtures.h>
+
+#include <config/Config.h>
+#include <webserver/DOSGuard.h>
+
+#include <boost/json/parse.hpp>
+#include <gmock/gmock.h>
+
+using namespace testing;
+using namespace clio;
+using namespace std;
+namespace json = boost::json;
+
+namespace {
+constexpr static auto JSONData = R"JSON(
+    {
+        "dos_guard": {
+            "max_fetches": 100,
+            "sweep_interval": 1,
+            "max_connections": 2,
+            "whitelist": ["127.0.0.1"]
+        }
+    }
+)JSON";
+
+constexpr static auto JSONData2 = R"JSON(
+    {
+        "dos_guard": {
+            "max_fetches": 100,
+            "sweep_interval": 0.1,
+            "max_connections": 2,
+            "whitelist": ["127.0.0.1"]
+        }
+    }
+)JSON";
+
+constexpr static auto IP = "127.0.0.2";
+
+class FakeSweepHandler
+{
+private:
+    using guard_type = BasicDOSGuard<FakeSweepHandler>;
+    guard_type* dosGuard_;
+
+public:
+    void
+    setup(guard_type* guard)
+    {
+        dosGuard_ = guard;
+    }
+
+    void
+    sweep()
+    {
+        dosGuard_->clear();
+    }
+};
+};  // namespace
+
+class DOSGuardTest : public NoLoggerFixture
+{
+protected:
+    Config cfg{json::parse(JSONData)};
+    FakeSweepHandler sweepHandler;
+    BasicDOSGuard<FakeSweepHandler> guard{cfg, sweepHandler};
+};
+
+TEST_F(DOSGuardTest, Whitelisting)
+{
+    EXPECT_TRUE(guard.isWhiteListed("127.0.0.1"));
+    EXPECT_FALSE(guard.isWhiteListed(IP));
+}
+
+TEST_F(DOSGuardTest, ConnectionCount)
+{
+    EXPECT_TRUE(guard.isOk(IP));
+    guard.increment(IP);  // one connection
+    EXPECT_TRUE(guard.isOk(IP));
+    guard.increment(IP);  // two connections
+    EXPECT_TRUE(guard.isOk(IP));
+    guard.increment(IP);  // > two connections, can't connect more
+    EXPECT_FALSE(guard.isOk(IP));
+
+    guard.decrement(IP);
+    EXPECT_TRUE(guard.isOk(IP));  // can connect again
+}
+
+TEST_F(DOSGuardTest, FetchCount)
+{
+    EXPECT_TRUE(guard.add(IP, 50));  // half of allowence
+    EXPECT_TRUE(guard.add(IP, 50));  // now fully charged
+    EXPECT_FALSE(guard.add(IP, 1));  // can't add even 1 anymore
+    EXPECT_FALSE(guard.isOk(IP));
+
+    guard.clear();                // force clear the above fetch count
+    EXPECT_TRUE(guard.isOk(IP));  // can fetch again
+}
+
+TEST_F(DOSGuardTest, ClearFetchCountOnTimer)
+{
+    EXPECT_TRUE(guard.add(IP, 50));  // half of allowence
+    EXPECT_TRUE(guard.add(IP, 50));  // now fully charged
+    EXPECT_FALSE(guard.add(IP, 1));  // can't add even 1 anymore
+    EXPECT_FALSE(guard.isOk(IP));
+
+    sweepHandler.sweep();         // pretend sweep called from timer
+    EXPECT_TRUE(guard.isOk(IP));  // can fetch again
+}
+
+template <typename SweepHandler>
+struct BasicDOSGuardMock : public BaseDOSGuard
+{
+    BasicDOSGuardMock(SweepHandler& handler)
+    {
+        handler.setup(this);
+    }
+
+    MOCK_METHOD(void, clear, (), (noexcept, override));
+};
+
+class DOSGuardIntervalSweepHandlerTest : public SyncAsioContextTest
+{
+protected:
+    Config cfg{json::parse(JSONData2)};
+    IntervalSweepHandler sweepHandler{cfg, ctx};
+    BasicDOSGuardMock<IntervalSweepHandler> guard{sweepHandler};
+};
+
+TEST_F(DOSGuardIntervalSweepHandlerTest, SweepAfterInterval)
+{
+    EXPECT_CALL(guard, clear()).Times(Exactly(2));
+    ctx.run_for(std::chrono::milliseconds(210));
+}


### PR DESCRIPTION
Fixes #452 

This is one way to approach unit-testing something that requires `boost::asio::io_context` without trying to mock or proxy it somehow. Instead we just inject a strategy (handler) that will do whatever it needs to and call out to the DOSGuard itself when needed (e.g. to reset some counter via `clear`).

I'm open to other ideas how to test this.
I have also implemented a fixture that wraps and runs a real `boost::asio::io_context` in a `std::jthread`. We can make use of it when we absolutely have no choice but to test with a real context. For the `DOSGuard` however doing that would mean to actually wait for a timer and sync that with the test thread. This obviously introduces longer running tests - not ideal.

I'm now also thinking that we need to test the strategy itself. For this we must call `setup` with a mock/fake somehow so the strategy might also have to become a template.