### PR TITLE
Build Clio on macOS and Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build Clio
 on:
   push:
-    branches:  [master, release, develop, develop-next]
+    branches:  [master, release/*, develop, develop-next]
   pull_request:
-    branches:  [master, release, develop, develop-next]
+    branches:  [master, release/*, develop, develop-next]
   workflow_dispatch:
 
 jobs:
@@ -29,6 +29,7 @@ jobs:
           - suffix: rpm
             image: rippleci/clio-rpm-builder:2022-09-17
             script: rpm
+
     container:
       image: ${{ matrix.type.image }}
 
@@ -66,6 +67,64 @@ jobs:
         with:
           name: clio_tests-${{ matrix.type.suffix }}
           path: ${{ github.workspace }}/clio_tests
+
+  build_dev:
+    name: ${{ matrix.os.name }} test
+    needs: lint
+    continue-on-error: ${{ matrix.os.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: ubuntu-22.04
+            experimental: true
+          - name: macos-11
+            experimental: true
+          - name: macos-12
+            experimental: false
+    runs-on: ${{ matrix.os.name }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: clio
+
+    - name: Check Boost cache
+      id: boost
+      uses: actions/cache@v3
+      with:
+        path: boost
+        key: ${{ runner.os }}-boost
+
+    - name: Build boost
+      if: steps.boost.outputs.cache-hit != 'true'
+      run: |
+        curl -s -OJL "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz"
+        tar zxf boost_1_77_0.tar.gz
+        mv boost_1_77_0 boost
+        cd boost
+        ./bootstrap.sh
+        if [[ ${{ matrix.os.name }} =~ mac ]];then
+          mac_flags='cxxflags="-std=c++14"'
+        fi
+        ./b2 ${mac_flags}
+
+    - name: install deps
+      run: |
+        if [[ ${{ matrix.os.name }} =~ mac ]];then
+            brew install pkg-config protobuf openssl ninja cassandra-cpp-driver bison
+        elif [[ ${{matrix.os.name }} =~ ubuntu ]];then
+            sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen bison flex autoconf clang-format
+        fi
+
+    - name: Build clio
+      run: |
+        export BOOST_ROOT=$(pwd)/boost
+        cd clio
+        cmake -B build
+        if ! cmake --build build -j$(nproc); then
+          echo '# 🔥${{ matrix.os.name }}🔥 failed!💥' >> $GITHUB_STEP_SUMMARY
+        fi
 
   test_clio:
     name: Test Clio


### PR DESCRIPTION
We should be building/testing on the preferred development environment and the next Linux version we're going to support.