### PR TITLE
Add hotfix to old account_tx ledger index max out-of-bounds PR

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1597,9 +1597,7 @@ traverseTransactions(
         {
             if (context.range.maxSequence < *max ||
                 context.range.minSequence > *max)
-                return Status{
-                    RippledError::rpcLGR_IDX_MALFORMED,
-                    "ledgerSeqMaxOutOfRange"};
+                return Status{RippledError::rpcLGR_IDX_MALFORMED};
             else
                 maxIndex = static_cast<uint32_t>(*max);
         }


### PR DESCRIPTION
**Problem**: Upon Q&A, custom error message for [old issue](https://github.com/XRPLF/clio/issues/263) had mismatch with original rippled error message
**Fix**: Add hotfix to old account_tx ledger index max out-of-bounds PR