### PR TITLE
Fix LGR_IDXS_INVALID error code mismatch

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1597,7 +1597,7 @@ traverseTransactions(
         {
             if (context.range.maxSequence < *max ||
                 context.range.minSequence > *max)
-                return Status{RippledError::rpcLGR_IDX_MALFORMED};
+                return Status{RippledError::rpcLGR_IDXS_INVALID};
             else
                 maxIndex = static_cast<uint32_t>(*max);
         }


### PR DESCRIPTION
**Problem**: Upon Q&A, error code for https://github.com/XRPLF/clio/issues/263 had mismatch with  rippled error message (misconstrued for lgr_idxs_malformed)
**Fix**: Add correct error message hotfix to old account_tx ledger index max out-of-bounds PR