### PR TITLE
Add Unittests Coverage

### DIFF
--- a/CMake/coverage.cmake
+++ b/CMake/coverage.cmake
@@ -1,0 +1,42 @@
+#call add_converage(module_name) to add coverage targets for the given module
+function(add_converage module)
+    if("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+        message("[Coverage] Building with llvm Code Coverage Tools")
+        # Using llvm gcov ; llvm install by xcode
+        set(LLVM_COV_PATH /Library/Developer/CommandLineTools/usr/bin)
+        if(NOT EXISTS ${LLVM_COV_PATH}/llvm-cov)
+            message(FATAL_ERROR "llvm-cov not found! Aborting.")
+        endif()
+
+        # set Flags
+        target_compile_options(${module} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+        target_link_options(${module} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+
+        # llvm-cov
+        add_custom_target(${module}-ccov-preprocessing
+            COMMAND LLVM_PROFILE_FILE=${module}.profraw $<TARGET_FILE:${module}>
+            COMMAND ${LLVM_COV_PATH}/llvm-profdata merge -sparse ${module}.profraw -o ${module}.profdata
+            DEPENDS ${module})
+
+        add_custom_target(${module}-ccov-show
+            COMMAND ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -show-line-counts-or-regions
+            DEPENDS ${module}-ccov-preprocessing)
+
+        # add summary for CI parse
+        add_custom_target(${module}-ccov-report
+            COMMAND ${LLVM_COV_PATH}/llvm-cov report $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -ignore-filename-regex=".*_makefiles|.*unittests" -show-region-summary=false
+            DEPENDS ${module}-ccov-preprocessing)
+
+        # exclude libs and unittests self
+        add_custom_target(${module}-ccov
+            COMMAND ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -show-line-counts-or-regions -output-dir=${module}-llvm-cov -format="html" -ignore-filename-regex=".*_makefiles|.*unittests" > /dev/null 2>&1
+            DEPENDS ${module}-ccov-preprocessing)
+
+        add_custom_command(TARGET ${module}-ccov POST_BUILD
+            COMMENT "Open ${module}-llvm-cov/index.html in your browser to view the coverage report."
+        )
+    else()
+        # gcc WIP
+        message(FATAL_ERROR "Complier not support yet")
+    endif()
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,14 +95,21 @@ add_executable(clio_server src/main/main.cpp)
 target_link_libraries(clio_server PUBLIC clio)
 
 if(BUILD_TESTS)
-  add_executable(clio_tests
-    unittests/RPCErrors.cpp
-    unittests/Backend.cpp
-    unittests/Logger.cpp
-    unittests/Config.cpp
-    unittests/ProfilerTest.cpp
-    unittests/DOSGuard.cpp)
+  set(TEST_TARGET clio_tests)
+  add_executable(${TEST_TARGET}
+  unittests/RPCErrors.cpp
+  unittests/Backend.cpp
+  unittests/Logger.cpp
+  unittests/Config.cpp
+  unittests/ProfilerTest.cpp
+  unittests/DOSGuard.cpp)
   include(CMake/deps/gtest.cmake)
+
+  # if CODE_COVERAGE enable, add clio_test-ccov
+  if(CODE_COVERAGE)
+    include(CMake/coverage.cmake)
+    add_converage(${TEST_TARGET})
+  endif()
 endif()
 
 include(CMake/install/install.cmake)


### PR DESCRIPTION
This change added 3 targets in CMake to support code coverage. Currently only support clang compiler.
1 make clio_tests-ccov-show : this target will show coverage details via console. Allow developers check the coverage quickly:
›
![Screenshot 2023-01-16 at 09 14 57](https://user-images.githubusercontent.com/120398799/212641152-a7b2b5ca-3be9-4764-8841-70492a4b89bf.png)


2 make clio_tests_ccov-report: this target will show summary via console, it will be used in CI to parse the output
![Screenshot 2023-01-16 at 09 16 23](https://user-images.githubusercontent.com/120398799/212641469-3ba5517c-38e7-43e9-934e-e832ae9f719c.png)


3 make clio_tests_ccov : this target will generate report under ./clio_tests_ccov folder.
![Screenshot 2023-01-16 at 09 19 16](https://user-images.githubusercontent.com/120398799/212642081-d8108b1c-6a8b-4de7-9777-d0ddd1a67ebf.png)
![Screenshot 2023-01-16 at 09 19 47](https://user-images.githubusercontent.com/120398799/212642170-93826f8c-254c-45de-a149-55f4847cb44c.png)

