### PR TITLE
add code coverage job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
           cmake --build clio-packages/build --parallel $(nproc)
           cp ./clio-packages/build/clio-prefix/src/clio-build/clio_tests .
           mv ./clio-packages/build/*.${{ matrix.type.suffix }} .
-
       - name: Artifact packages
         uses: actions/upload-artifact@v3
         with:
@@ -78,8 +77,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: ubuntu-22.04
-            experimental: true
           - name: macos-11
             experimental: true
           - name: macos-12
@@ -110,7 +107,6 @@ jobs:
           mac_flags='cxxflags="-std=c++14"'
         fi
         ./b2 ${mac_flags}
-
     - name: install deps
       run: |
         if [[ ${{ matrix.os.name }} =~ mac ]];then
@@ -118,7 +114,6 @@ jobs:
         elif [[ ${{matrix.os.name }} =~ ubuntu ]];then
             sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen bison flex autoconf clang-format
         fi
-
     - name: Build clio
       run: |
         export BOOST_ROOT=$(pwd)/boost
@@ -127,7 +122,7 @@ jobs:
         if ! cmake --build build -j$(nproc); then
           echo '# 🔥${{ matrix.os.name }}🔥 failed!💥' >> $GITHUB_STEP_SUMMARY
         fi
-
+        
   test_clio:
     name: Test Clio
     runs-on: [self-hosted, Linux]
@@ -147,3 +142,65 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         uses: ./.github/actions/test
+
+  code_coverage:
+    name: Build on Linux and code coverage
+    needs: lint
+    continue-on-error: false
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: clio
+
+    - name: Check Boost cache
+      id: boost
+      uses: actions/cache@v3
+      with:
+        path: boost
+        key: ${{ runner.os }}-boost
+
+    - name: Build boost
+      if: steps.boost.outputs.cache-hit != 'true'
+      run: |
+        curl -s -OJL "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz"
+        tar zxf boost_1_77_0.tar.gz
+        mv boost_1_77_0 boost
+        cd boost
+        ./bootstrap.sh
+        ./b2
+
+    - name: install deps
+      run: |
+          sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential doxygen bison flex autoconf clang-format gcovr
+
+    - name: Build clio
+      run: |
+        export BOOST_ROOT=$(pwd)/boost
+        cd clio
+        cmake -B build -DCODE_COVERAGE=on -DTEST_PARAMETER='--gtest_filter="-Backend*"'
+        if ! cmake --build build -j$(nproc); then
+          echo '# 🔥Ubuntu build🔥 failed!💥' >> $GITHUB_STEP_SUMMARY
+        fi
+        cd build
+        make clio_tests-ccov
+
+    - name: Code Coverage Summary Report
+      uses: irongut/CodeCoverageSummary@v1.2.0
+      with:
+        filename: clio/build/clio_tests-gcc-cov/out.xml
+        badge: true
+        output: both
+        format: markdown
+
+    - name: Save PR number and ccov report
+      run: |
+          mkdir -p ./UnitTestCoverage
+          echo ${{ github.event.number }} > ./UnitTestCoverage/NR
+          cp clio/build/clio_tests-gcc-cov/report.html ./UnitTestCoverage/report.html
+          cp code-coverage-results.md ./UnitTestCoverage/out.md
+    - uses: actions/upload-artifact@v2
+      with:
+        name: UnitTestCoverage
+        path: UnitTestCoverage/

--- a/CMake/coverage.cmake
+++ b/CMake/coverage.cmake
@@ -1,42 +1,126 @@
-#call add_converage(module_name) to add coverage targets for the given module
+# call add_converage(module_name) to add coverage targets for the given module
 function(add_converage module)
-    if("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
-        message("[Coverage] Building with llvm Code Coverage Tools")
-        # Using llvm gcov ; llvm install by xcode
-        set(LLVM_COV_PATH /Library/Developer/CommandLineTools/usr/bin)
-        if(NOT EXISTS ${LLVM_COV_PATH}/llvm-cov)
-            message(FATAL_ERROR "llvm-cov not found! Aborting.")
-        endif()
-
-        # set Flags
-        target_compile_options(${module} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-        target_link_options(${module} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
-
-        # llvm-cov
-        add_custom_target(${module}-ccov-preprocessing
-            COMMAND LLVM_PROFILE_FILE=${module}.profraw $<TARGET_FILE:${module}>
-            COMMAND ${LLVM_COV_PATH}/llvm-profdata merge -sparse ${module}.profraw -o ${module}.profdata
-            DEPENDS ${module})
-
-        add_custom_target(${module}-ccov-show
-            COMMAND ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -show-line-counts-or-regions
-            DEPENDS ${module}-ccov-preprocessing)
-
-        # add summary for CI parse
-        add_custom_target(${module}-ccov-report
-            COMMAND ${LLVM_COV_PATH}/llvm-cov report $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -ignore-filename-regex=".*_makefiles|.*unittests" -show-region-summary=false
-            DEPENDS ${module}-ccov-preprocessing)
-
-        # exclude libs and unittests self
-        add_custom_target(${module}-ccov
-            COMMAND ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}> -instr-profile=${module}.profdata -show-line-counts-or-regions -output-dir=${module}-llvm-cov -format="html" -ignore-filename-regex=".*_makefiles|.*unittests" > /dev/null 2>&1
-            DEPENDS ${module}-ccov-preprocessing)
-
-        add_custom_command(TARGET ${module}-ccov POST_BUILD
-            COMMENT "Open ${module}-llvm-cov/index.html in your browser to view the coverage report."
-        )
-    else()
-        # gcc WIP
-        message(FATAL_ERROR "Complier not support yet")
+  if("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang"
+     OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    message("[Coverage] Building with llvm Code Coverage Tools")
+    # Using llvm gcov ; llvm install by xcode
+    set(LLVM_COV_PATH /Library/Developer/CommandLineTools/usr/bin)
+    if(NOT EXISTS ${LLVM_COV_PATH}/llvm-cov)
+      message(FATAL_ERROR "llvm-cov not found! Aborting.")
     endif()
+
+    # set Flags
+    target_compile_options(${module} PRIVATE -fprofile-instr-generate
+                                             -fcoverage-mapping)
+    target_link_options(${module} PRIVATE -fprofile-instr-generate
+                        -fcoverage-mapping)
+
+    target_compile_options(clio PRIVATE -fprofile-instr-generate
+                                        -fcoverage-mapping)
+    target_link_options(clio PRIVATE -fprofile-instr-generate
+                        -fcoverage-mapping)
+
+    # llvm-cov
+    add_custom_target(
+      ${module}-ccov-preprocessing
+      COMMAND LLVM_PROFILE_FILE=${module}.profraw $<TARGET_FILE:${module}>
+      COMMAND ${LLVM_COV_PATH}/llvm-profdata merge -sparse ${module}.profraw -o
+              ${module}.profdata
+      DEPENDS ${module})
+
+    add_custom_target(
+      ${module}-ccov-show
+      COMMAND ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}>
+              -instr-profile=${module}.profdata -show-line-counts-or-regions
+      DEPENDS ${module}-ccov-preprocessing)
+
+    # add summary for CI parse
+    add_custom_target(
+      ${module}-ccov-report
+      COMMAND
+        ${LLVM_COV_PATH}/llvm-cov report $<TARGET_FILE:${module}>
+        -instr-profile=${module}.profdata
+        -ignore-filename-regex=".*_makefiles|.*unittests"
+        -show-region-summary=false
+      DEPENDS ${module}-ccov-preprocessing)
+
+    # exclude libs and unittests self
+    add_custom_target(
+      ${module}-ccov
+      COMMAND
+        ${LLVM_COV_PATH}/llvm-cov show $<TARGET_FILE:${module}>
+        -instr-profile=${module}.profdata -show-line-counts-or-regions
+        -output-dir=${module}-llvm-cov -format="html"
+        -ignore-filename-regex=".*_makefiles|.*unittests" > /dev/null 2>&1
+      DEPENDS ${module}-ccov-preprocessing)
+
+    add_custom_command(
+      TARGET ${module}-ccov
+      POST_BUILD
+      COMMENT
+        "Open ${module}-llvm-cov/index.html in your browser to view the coverage report."
+    )
+  elseif("${CMAKE_C_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}"
+                                                   MATCHES "GNU")
+    message("[Coverage] Building with Gcc Code Coverage Tools")
+
+    find_program(GCOV_PATH gcov)
+    if(NOT GCOV_PATH)
+      message(FATAL_ERROR "gcov not found! Aborting...")
+    endif() # NOT GCOV_PATH
+    find_program(GCOVR_PATH gcovr)
+    if(NOT GCOVR_PATH)
+      message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    set(COV_OUTPUT_PATH ${module}-gcc-cov)
+    target_compile_options(${module} PRIVATE -fprofile-arcs -ftest-coverage
+                                             -fPIC)
+    target_link_libraries(${module} PRIVATE gcov)
+
+    target_compile_options(clio PRIVATE -fprofile-arcs -ftest-coverage
+                                             -fPIC)
+    target_link_libraries(clio PRIVATE gcov)
+    # this target is used for CI as well generate the summary out.xml will send
+    # to github action to generate markdown, we can paste it to comments or
+    # readme
+    add_custom_target(
+      ${module}-ccov
+      COMMAND ${module} ${TEST_PARAMETER}
+      COMMAND rm -rf ${COV_OUTPUT_PATH}
+      COMMAND mkdir ${COV_OUTPUT_PATH}
+      COMMAND
+        gcovr -r ${CMAKE_SOURCE_DIR} --object-directory=${PROJECT_BINARY_DIR} -x
+        ${COV_OUTPUT_PATH}/out.xml --exclude='${CMAKE_SOURCE_DIR}/unittests/'
+        --exclude='${PROJECT_BINARY_DIR}/'
+      COMMAND
+        gcovr -r ${CMAKE_SOURCE_DIR} --object-directory=${PROJECT_BINARY_DIR}
+        --html ${COV_OUTPUT_PATH}/report.html
+        --exclude='${CMAKE_SOURCE_DIR}/unittests/'
+        --exclude='${PROJECT_BINARY_DIR}/'
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      COMMENT "Running gcovr to produce Cobertura code coverage report.")
+
+    # generate the detail report
+    add_custom_target(
+      ${module}-ccov-report
+      COMMAND ${module} ${TEST_PARAMETER}
+      COMMAND rm -rf ${COV_OUTPUT_PATH}
+      COMMAND mkdir ${COV_OUTPUT_PATH}
+      COMMAND
+        gcovr -r ${CMAKE_SOURCE_DIR} --object-directory=${PROJECT_BINARY_DIR}
+        --html-details ${COV_OUTPUT_PATH}/index.html
+        --exclude='${CMAKE_SOURCE_DIR}/unittests/'
+        --exclude='${PROJECT_BINARY_DIR}/'
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      COMMENT "Running gcovr to produce Cobertura code coverage report.")
+    add_custom_command(
+      TARGET ${module}-ccov-report
+      POST_BUILD
+      COMMENT
+        "Open ${COV_OUTPUT_PATH}/index.html in your browser to view the coverage report."
+    )
+  else()
+    message(FATAL_ERROR "Complier not support yet")
+  endif()
 endfunction()


### PR DESCRIPTION
This PR adds 
1 code coverage for gcc compiler
2 enable code coverage on CI  
     *show code coverage report markdown in log
  like:
                Package | Line Rate | Branch Rate | Complexity | Health
                -------- | --------- | ----------- | ---------- | ------
                src.backend | 0% | 0% | 0 | ❌
                src.config | 95% | 59% | 0 | ✔
                src.etl | 0% | 0% | 0 | ❌
                src.log | 90% | 32% | 0 | ✔
                src.rpc | 78% | 33% | 0 | ✔
                src.subscriptions | 0% | 0% | 0 | ❌
                src.util | 100% | 0% | 0 | ✔
                src.webserver | 100% | 55% | 0 | ✔
                **Summary** | **37%** (164 / 447) | **15%** (174 / 1173) | **0** | ❌
    *upload report to CI
Ideally, we can add coverage summary in PR comments. But github does not allow GITHUB_TOKEN to write PR https://docs.github.com/en/actions/security-guides/automatic-token-authentication. To add the coverage summary to comment, we need another workflow triggered by "build.yml". see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
