### PR TITLE
Update gitignore and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *clio*.log
-build/
+build*/
 .vscode
 .python-version
 config.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Use these instructions to build a Clio executable from the source. These instruc
 ```sh
 # Install dependencies
   sudo apt-get -y install git pkg-config protobuf-compiler libprotobuf-dev libssl-dev wget build-essential bison flex autoconf cmake clang-format
+# Install gcovr to run code coverage
+  sudo apt-get -y install gcovr
 
 # Compile Boost
   wget -O $HOME/boost_1_75_0.tar.gz https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz


### PR DESCRIPTION
sometimes we need two sets of makefiles on the same machine, 
we shall ignore build_clang / build_gcc/ build_ccov_enable such.

update readme , adding gcovr dep