### PR TITLE
Eliminate extraneous bypass in ETLSource.cpp

### DIFF
--- a/src/etl/ETLSource.cpp
+++ b/src/etl/ETLSource.cpp
@@ -1159,7 +1159,11 @@ ETLLoadBalancer::execute(Func f, uint32_t ledgerSequence)
 
         log_.debug() << "Attempting to execute func. ledger sequence = "
                      << ledgerSequence << " - source = " << source->toString();
-        if (source->hasLedger(ledgerSequence) || true)
+        // Originally, it was (source->hasLedger(ledgerSequence) || true)
+        /* Sometimes rippled has ledger but doesn't actually know. However,
+        but this does NOT happen in the normal case and is safe to remove
+        This || true is only needed when loading full history standalone */
+        if (source->hasLedger(ledgerSequence))
         {
             bool res = f(source);
             if (res)


### PR DESCRIPTION
**Problem (#298):** Persistent leftover bypass in ETLSource.cpp that automatically disables proper check if source has proper ledgerSequence
**Fix:** Remove bypass