### PR TITLE
Fix clio-server link issue

### DIFF
--- a/CMake/coverage.cmake
+++ b/CMake/coverage.cmake
@@ -12,12 +12,12 @@ function(add_converage module)
     # set Flags
     target_compile_options(${module} PRIVATE -fprofile-instr-generate
                                              -fcoverage-mapping)
-    target_link_options(${module} PRIVATE -fprofile-instr-generate
+    target_link_options(${module} PUBLIC -fprofile-instr-generate
                         -fcoverage-mapping)
 
     target_compile_options(clio PRIVATE -fprofile-instr-generate
                                         -fcoverage-mapping)
-    target_link_options(clio PRIVATE -fprofile-instr-generate
+    target_link_options(clio PUBLIC -fprofile-instr-generate
                         -fcoverage-mapping)
 
     # llvm-cov


### PR DESCRIPTION
When enable CODE_COVERAGE, we build and link clio lib and clio_tests with coverage dependency. Building clio_server will get a linker issue. We dont really need clio_server run with coverage dependency, but just avoid the error message,
I am changing the link option from private->public .