### PR TITLE
Add support for IP Ranges in DOSGuard Whitelist

### DIFF
--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -29,6 +29,10 @@
 
 #include <config/Config.h>
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 namespace clio {
 
 class BaseDOSGuard
@@ -70,6 +74,333 @@ class BasicDOSGuard : public BaseDOSGuard
 
 public:
     /**
+     * @brief Checks if raw IPv4 address is valid
+     *
+     * @param ip Raw IPv4 address to check
+     */
+    [[nodiscard]] bool
+    checkParsedIPv4Address(std::string const& ip) const
+    {
+        try
+        {
+            boost::asio::ip::address_v4::from_string(ip);
+            return true;
+        }
+
+        catch (const std::exception& e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Checks if raw IPv6 address is valid
+     *
+     * @param ip Raw IPv6 address to check
+     */
+    [[nodiscard]] bool
+    checkParsedIPv6Address(std::string const& ip) const
+    {
+        try
+        {
+            boost::asio::ip::address_v6::from_string(ip);
+            return true;
+        }
+
+        catch (const std::exception& e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Checks if IPv4 address has a valid CIDR notation
+     *
+     * @param ip The IP address (IPv4)
+     */
+    [[nodiscard]] bool
+    checkCIDRIPv4(std::string const& ip) const
+    {
+        if (ip.find("/") != std::string::npos)
+        {
+            std::string rawSubstring = ip.substr(ip.find("/"));
+            // Check if there is an element at the end of the CIDR
+            if (rawSubstring.length() > 1 && rawSubstring.length() <= 3)
+            {
+                int parsedCIDRNumber =
+                    stoi(rawSubstring.substr(rawSubstring.find("/") + 1));
+
+                if (parsedCIDRNumber >= 0 && parsedCIDRNumber <= 32)
+                {
+                    return true;
+                }
+
+                else
+                {
+                    return false;
+                }
+            }
+
+            else
+            {
+                return false;
+            }
+        }
+
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Checks if parsed byte has a valid CIDR notation
+     *
+     * @param ip The IP address (IPv6)
+     */
+    [[nodiscard]] bool
+    checkCIDRIPv6(std::string const& ip) const
+    {
+        if (ip.find("/") != std::string::npos)
+        {
+            std::string rawSubstring = ip.substr(ip.find("/"));
+            // Check if there is an element at the end of the CIDR
+            if (rawSubstring.length() > 1 && rawSubstring.length() <= 4)
+            {
+                int parsedCIDRNumber =
+                    stoi(rawSubstring.substr(rawSubstring.find("/") + 1));
+
+                if (parsedCIDRNumber >= 0 && parsedCIDRNumber <= 128)
+                {
+                    return true;
+                }
+
+                else
+                {
+                    return false;
+                }
+            }
+
+            else
+            {
+                return false;
+            }
+        }
+
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Checks if IPv4 address belongs in specified subnet
+     *
+     * @param ip The ip being checked to see if it belongs in the subnet
+     * @param subnetIPwCIDR The IPv4 subnet with attached CIDR
+     */
+    [[nodiscard]] bool
+    isIPv4AddressInSubnet(
+        std::string const& ip,
+        std::string const& subnetIPwCIDR) const
+    {
+        // ip being checked does not have CIDR
+        if (subnetIPwCIDR.find("/") != std::string::npos &&
+            checkParsedIPv4Address(ip) == true)
+        {
+            boost::system::error_code subnetError;
+            boost::asio::ip::network_v4 subnet =
+                boost::asio::ip::make_network_v4(subnetIPwCIDR, subnetError);
+            boost::asio::ip::address_v4_range subnetRangeHosts = subnet.hosts();
+
+            if (subnetError)
+            {
+                throw std::invalid_argument(subnetError.message());
+                return false;
+            }
+
+            boost::system::error_code error_code;
+            boost::asio::ip::address addr =
+                boost::asio::ip::make_address(ip, error_code);
+
+            if (error_code)
+            {
+                throw std::invalid_argument(error_code.message());
+                return false;
+            }
+
+            // Check if the address is in one of the hosts of subnet
+            if (subnetRangeHosts.find(addr.to_v4()) != subnetRangeHosts.end())
+            {
+                return true;
+            }
+        }
+
+        // Catch-All for incorrect cases
+        return false;
+    }
+
+    /**
+     * @brief Checks if IPv6 address belongs in specified subnet
+     *
+     * @param ip The ip being checked to see if it belongs in the subnet
+     * @param subnetIPwCIDR The IPv6 subnet with attached CIDR
+     */
+    [[nodiscard]] bool
+    isIPv6AddressInSubnet(
+        std::string const& ip,
+        std::string const& subnetIPwCIDR) const
+    {
+        // ip being checked does not have CIDR
+        if (subnetIPwCIDR.find("/") != std::string::npos &&
+            checkParsedIPv6Address(ip) == true)
+        {
+            boost::system::error_code subnetError;
+            boost::asio::ip::network_v6 subnet =
+                boost::asio::ip::make_network_v6(subnetIPwCIDR, subnetError);
+            boost::asio::ip::address_v6_range subnetRangeHosts = subnet.hosts();
+
+            if (subnetError)
+            {
+                throw std::invalid_argument(subnetError.message());
+                return false;
+            }
+
+            boost::system::error_code error_code;
+            boost::asio::ip::address addr =
+                boost::asio::ip::make_address(ip, error_code);
+
+            if (error_code)
+            {
+                throw std::invalid_argument(error_code.message());
+                return false;
+            }
+
+            // Check if the address is in one of the hosts of subnet
+            if (subnetRangeHosts.find(addr.to_v6()) != subnetRangeHosts.end())
+            {
+                return true;
+            }
+        }
+
+        // Catch-All for incorrect cases
+        return false;
+    }
+
+    /**
+     * @brief Helper method that checks if an IP address is valid IPv4
+     *
+     * @param ip The IP address (explicit IPv4)
+     */
+    [[nodiscard]] bool
+    isValidIPv4(std::string const& ip) const
+    {
+        // CASE #1: Checks specific to detection of CIDR for IPv4
+        if (ip.find("/") != std::string::npos &&
+            checkParsedIPv4Address(ip.substr(0, ip.find("/"))) == true &&
+            checkCIDRIPv4(ip) == true)
+        {
+            return true;
+        }
+
+        // CASE #2: No CIDR, can check ip valid IP
+        else if (ip.find("/") == std::string::npos)
+        {
+            return checkParsedIPv4Address(ip);
+        }
+
+        // Catch-All for incorrect cases
+        return false;
+    }
+
+    /**
+     * @brief Helper method checks if an IP address is a valid IPv6 address
+     *
+     * @param ip The IP address (explicit IPv6), with/without a CIDR
+     */
+    [[nodiscard]] bool
+    isValidIPv6(std::string const& ip) const
+    {
+        // CASE #1: Checks specific to detection of CIDR for IPv6
+        if (ip.find("/") != std::string::npos &&
+            checkParsedIPv6Address(ip.substr(0, ip.find("/"))) == true &&
+            checkCIDRIPv6(ip) == true)
+        {
+            return true;
+        }
+
+        // CASE #2: General check to determine if valid IPv6 if no CIDR
+        else if (ip.find("/") == std::string::npos)
+        {
+            return checkParsedIPv6Address(ip);
+        }
+
+        // Catch-All for incorrect cases
+        return false;
+    }
+
+    /**
+     * @brief Wrapper method to check mixed bag of IP addresses and determine
+     * validity of IPv4 or IPv6
+     *
+     * @param ip The IP address to check, type unknown
+     */
+    [[nodiscard]] bool
+    checkValidityOfWhitelist(std::string const& ip) const
+    {
+        if (ip.find(".") != std::string::npos)
+        {
+            return isValidIPv4(ip);
+        }
+
+        else if (
+            ip.find(":") != std::string::npos ||
+            ip.find("::") != std::string::npos)
+        {
+            return isValidIPv6(ip);
+        }
+
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @brief Wrapper method to check mixed bag of IPv4 and IPv6 subnets
+     * and determine if an IP already fills a subnet
+     *
+     * @param ip The IP address to check, type unknown
+     * @param subnetIP The subnet IP address to check, type unknown
+     */
+    [[nodiscard]] bool
+    checkIfInSubnetMixed(std::string const& ip, std::string const& subnetIP)
+        const
+    {
+        // Check that both addresses are IPv4
+        if (ip.find(".") != std::string::npos &&
+            subnetIP.find(".") != std::string::npos)
+        {
+            return isIPv4AddressInSubnet(ip, subnetIP);
+        }
+
+        // Check that both addresses are IPv6
+        else if (
+            (ip.find(":") != std::string::npos ||
+             ip.find("::") != std::string::npos) &&
+            (subnetIP.find(":") != std::string::npos ||
+             subnetIP.find("::") != std::string::npos))
+        {
+            return isIPv6AddressInSubnet(ip, subnetIP);
+        }
+
+        else
+        {
+            return false;
+        }
+    }
+
+    /**
      * @brief Constructs a new DOS guard.
      *
      * @param config Clio config
@@ -87,14 +418,54 @@ public:
     /**
      * @brief Check whether an ip address is in the whitelist or not
      *
-     * @param ip The ip address to check
+     * @param ip The ip address to check (raw IP, NO CIDR)
      * @return true
-     * @return false
+     * @return falseconvertedIPsToStrings
      */
     [[nodiscard]] bool
     isWhiteListed(std::string const& ip) const noexcept
     {
-        return whitelist_.contains(ip);
+        // CASE #1: Check if IP is CIDR. Treat as malformed input
+        if (ip.find("/") != std::string::npos)
+        {
+            return false;
+        }
+
+        // CASE #2: Check if IP has malformed input.
+        boost::system::error_code error_code;
+        boost::asio::ip::address addr =
+            boost::asio::ip::make_address(ip, error_code);
+
+        // Neither a valid IPv4 nor a valid IPv6 address
+        if (error_code)
+        {
+            // throw std::invalid_argument(error_code.message());
+            return false;
+        }
+
+        // // CASE #3: O(1) | Check if IP has exact raw copy in whitelist
+        // if (whitelist_.find(ip)!= whitelist_.end()) {
+        //     return true;
+        // }
+
+        // CASE #4: If valid IP, O(N) run through vector
+        for (auto const& ipInWhitelist : whitelist_)
+        {
+            // Raw match
+            if (ip == ipInWhitelist)
+            {
+                return true;
+            }
+
+            // CIDR subnet match
+            else if (checkIfInSubnetMixed(ip, ipInWhitelist) == true)
+            {
+                return true;
+            }
+        }
+
+        // Only return false if there are no entries in the whitelist.
+        return false;
     }
 
     /**
@@ -236,14 +607,67 @@ private:
     [[nodiscard]] std::unordered_set<std::string> const
     getWhitelist(clio::Config const& config) const
     {
-        using T = std::unordered_set<std::string> const;
-        auto whitelist = config.arrayOr("dos_guard.whitelist", {});
+        // Data structures: string cast elements, complement, anwswer
+        std::unordered_set<std::string> convertedIPsToStrings;
+        std::unordered_set<std::string> subnetInstances;
+        std::unordered_set<std::string> resultsSet;
+
+        // Lambda function to cast to string
         auto const transform = [](auto const& elem) {
             return elem.template value<std::string>();
         };
-        return T{
-            boost::transform_iterator(std::begin(whitelist), transform),
-            boost::transform_iterator(std::end(whitelist), transform)};
+
+        // Convert the RANGE of outputs to raw strings if not already
+        auto preConversionList = config.arrayOr("dos_guard.whitelist", {});
+        std::transform(
+            std::begin(preConversionList),
+            std::end(preConversionList),
+            std::inserter(
+                convertedIPsToStrings, std::end(convertedIPsToStrings)),
+            transform);
+
+        // O(N) | Parse the subnet instances in mixed bag BEFORE you compare all
+        // the elements
+        for (auto const& subnetIPIterator : convertedIPsToStrings)
+        {
+            // Push IPv4 or IPv6 subnets IPs if applicable
+            if (subnetIPIterator.find("/") != std::string::npos &&
+                checkValidityOfWhitelist(subnetIPIterator) == true)
+            {
+                // Insert to own data structure, make complement of set, insert
+                // to result
+                subnetInstances.insert(subnetIPIterator);
+                resultsSet.insert(subnetIPIterator);
+                convertedIPsToStrings.erase(subnetIPIterator);
+            }
+        }
+
+        // O(N^2) | Automatic filtering of IPs that don't meet rules
+        // NOTE: This is the COMPLEMENT SET of subnet
+        for (auto const& candidateIPs : convertedIPsToStrings)
+        {
+            // Boolean values reset for every iteration
+            bool inSubnet = false;
+
+            // O(N) | Pass to check if the IP is in the subnet. If so, do NOT
+            // add it bc subnet notation is sufficient anyways
+            for (auto const& subnetInstance : subnetInstances)
+            {
+                if (checkIfInSubnetMixed(candidateIPs, subnetInstance) == true)
+                {
+                    inSubnet = true;
+                }
+            }
+
+            // Only add IP iff not in a subnet AND it is a valid IPv4 or IPv6
+            if (checkValidityOfWhitelist(candidateIPs) == true &&
+                inSubnet == false)
+            {
+                resultsSet.insert(candidateIPs);
+            }
+        }
+
+        return resultsSet;
     }
 };
 

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -416,6 +416,25 @@ public:
     }
 
     /**
+     * @brief Checks if IP address is malformed
+     *
+     * @param ip IP address to check
+     */
+    [[nodiscard]] bool
+    isValidIPMixed(std::string const& ip) const
+    {
+        try
+        {
+            boost::asio::ip::address::from_string(ip);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            return false;
+        }
+    }
+
+    /**
      * @brief Check whether an ip address is in the whitelist or not
      *
      * @param ip The ip address to check (raw IP, NO CIDR)
@@ -432,21 +451,10 @@ public:
         }
 
         // CASE #2: Check if IP has malformed input.
-        boost::system::error_code error_code;
-        boost::asio::ip::address addr =
-            boost::asio::ip::make_address(ip, error_code);
-
-        // Neither a valid IPv4 nor a valid IPv6 address
-        if (error_code)
+        if (!isValidIPMixed(ip))
         {
-            // throw std::invalid_argument(error_code.message());
             return false;
         }
-
-        // // CASE #3: O(1) | Check if IP has exact raw copy in whitelist
-        // if (whitelist_.find(ip)!= whitelist_.end()) {
-        //     return true;
-        // }
 
         // CASE #4: If valid IP, O(N) run through vector
         for (auto const& ipInWhitelist : whitelist_)

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -204,6 +204,7 @@ public:
         std::string const& ip,
         std::string const& subnetIPwCIDR) const
     {
+        // [!!!] TODO: Check and see if restoring condition helps
         // ip being checked does not have CIDR
         if (subnetIPwCIDR.find("/") != std::string::npos &&
             checkParsedIPv4Address(ip) == true)
@@ -251,6 +252,7 @@ public:
         std::string const& ip,
         std::string const& subnetIPwCIDR) const
     {
+        // [!!!] TODO: Check and see if restoring condition helps
         // ip being checked does not have CIDR
         if (subnetIPwCIDR.find("/") != std::string::npos &&
             checkParsedIPv6Address(ip) == true)
@@ -377,19 +379,18 @@ public:
     checkIfInSubnetMixed(std::string const& ip, std::string const& subnetIP)
         const
     {
+        // [!!!] TODO: Restore extra checks for subnetIP
         // Check that both addresses are IPv4
-        if (ip.find(".") != std::string::npos &&
-            subnetIP.find(".") != std::string::npos)
+        if (ip.find(".") != std::string::npos)
         {
             return isIPv4AddressInSubnet(ip, subnetIP);
         }
 
+        // [!!!] TODO: Restore extra checks for subnetIP
         // Check that both addresses are IPv6
         else if (
-            (ip.find(":") != std::string::npos ||
-             ip.find("::") != std::string::npos) &&
-            (subnetIP.find(":") != std::string::npos ||
-             subnetIP.find("::") != std::string::npos))
+            ip.find(":") != std::string::npos ||
+            ip.find("::") != std::string::npos)
         {
             return isIPv6AddressInSubnet(ip, subnetIP);
         }
@@ -416,6 +417,24 @@ public:
     }
 
     /**
+     * @brief Checks if IP address is malformed
+     *
+     */
+    [[nodiscard]] bool
+    isValidIPMixed(std::string const& ip) const
+    {
+        try
+        {
+            boost::asio::ip::address::from_string(ip);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            return false;
+        }
+    }
+
+    /**
      * @brief Check whether an ip address is in the whitelist or not
      *
      * @param ip The ip address to check (raw IP, NO CIDR)
@@ -432,14 +451,8 @@ public:
         }
 
         // CASE #2: Check if IP has malformed input.
-        boost::system::error_code error_code;
-        boost::asio::ip::address addr =
-            boost::asio::ip::make_address(ip, error_code);
-
-        // Neither a valid IPv4 nor a valid IPv6 address
-        if (error_code)
+        if (!isValidIPMixed(ip))
         {
-            // throw std::invalid_argument(error_code.message());
             return false;
         }
 

--- a/src/webserver/DOSGuard.h
+++ b/src/webserver/DOSGuard.h
@@ -619,6 +619,7 @@ private:
         std::unordered_set<std::string> convertedIPsToStrings;
         std::unordered_set<std::string> subnetInstances;
         std::unordered_set<std::string> resultsSet;
+        std::unordered_set<std::string> nonCIDRSet;
 
         // Lambda function to cast to string
         auto const transform = [](auto const& elem) {
@@ -646,13 +647,20 @@ private:
                 // to result
                 subnetInstances.insert(subnetIPIterator);
                 resultsSet.insert(subnetIPIterator);
-                convertedIPsToStrings.erase(subnetIPIterator);
+            }
+
+            // Push IP to separate data structure for nonCIDR
+            else if (
+                subnetIPIterator.find("/") == std::string::npos &&
+                checkValidityOfWhitelist(subnetIPIterator) == true)
+            {
+                nonCIDRSet.insert(subnetIPIterator);
             }
         }
 
         // O(N^2) | Automatic filtering of IPs that don't meet rules
         // NOTE: This is the COMPLEMENT SET of subnet
-        for (auto const& candidateIPs : convertedIPsToStrings)
+        for (auto const& candidateIPs : nonCIDRSet)
         {
             // Boolean values reset for every iteration
             bool inSubnet = false;


### PR DESCRIPTION
**Problem (#244):** Clio DOSGuard only takes in explicit IP addresses in whitelist, does not support ranges
**Fix**: Add parsing functionality to generate IP addresses for ranges delimited by [number1-number2] in any byte