### PR TITLE
Fix backend test fail

### DIFF
--- a/unittests/Backend.cpp
+++ b/unittests/Backend.cpp
@@ -802,19 +802,17 @@ TEST_F(BackendTest, Basic)
                 auto generateNextLedger = [seed](auto lgrInfo) {
                     ++lgrInfo.seq;
                     lgrInfo.parentHash = lgrInfo.hash;
-                    std::srand(std::time(nullptr));
+                    static auto randomEngine = std::default_random_engine(seed);
                     std::shuffle(
                         lgrInfo.txHash.begin(),
                         lgrInfo.txHash.end(),
-                        std::default_random_engine(seed));
+                        randomEngine);
                     std::shuffle(
                         lgrInfo.accountHash.begin(),
                         lgrInfo.accountHash.end(),
-                        std::default_random_engine(seed));
+                        randomEngine);
                     std::shuffle(
-                        lgrInfo.hash.begin(),
-                        lgrInfo.hash.end(),
-                        std::default_random_engine(seed));
+                        lgrInfo.hash.begin(), lgrInfo.hash.end(), randomEngine);
                     return lgrInfo;
                 };
                 auto writeLedger = [&](auto lgrInfo,
@@ -2213,19 +2211,17 @@ TEST_F(BackendTest, cacheIntegration)
                 auto generateNextLedger = [seed](auto lgrInfo) {
                     ++lgrInfo.seq;
                     lgrInfo.parentHash = lgrInfo.hash;
-                    std::srand(std::time(nullptr));
+                    static auto randomEngine = std::default_random_engine(seed);
                     std::shuffle(
                         lgrInfo.txHash.begin(),
                         lgrInfo.txHash.end(),
-                        std::default_random_engine(seed));
+                        randomEngine);
                     std::shuffle(
                         lgrInfo.accountHash.begin(),
                         lgrInfo.accountHash.end(),
-                        std::default_random_engine(seed));
+                        randomEngine);
                     std::shuffle(
-                        lgrInfo.hash.begin(),
-                        lgrInfo.hash.end(),
-                        std::default_random_engine(seed));
+                        lgrInfo.hash.begin(), lgrInfo.hash.end(), randomEngine);
                     return lgrInfo;
                 };
                 auto writeLedger = [&](auto lgrInfo, auto objs, auto state) {
@@ -2295,7 +2291,14 @@ TEST_F(BackendTest, cacheIntegration)
                     EXPECT_TRUE(retLgr);
                     EXPECT_EQ(
                         RPC::ledgerInfoToBlob(*retLgr),
-                        RPC::ledgerInfoToBlob(lgrInfo));
+                        RPC::ledgerInfoToBlob(lgrInfo))
+                        << "retLgr seq:" << retLgr->seq
+                        << "; lgrInfo seq:" << lgrInfo.seq
+                        << "; retLgr hash:" << retLgr->hash
+                        << "; lgrInfo hash:" << lgrInfo.hash
+                        << "; retLgr parentHash:" << retLgr->parentHash
+                        << "; lgr Info parentHash:" << lgrInfo.parentHash;
+
                     std::vector<ripple::uint256> keys;
                     for (auto [key, obj] : objs)
                     {


### PR DESCRIPTION
We found cacheIntegration fails occasionally. Like this one https://github.com/XRPLF/clio/actions/runs/4076284584/jobs/7024125391
The case fails when comparing the result of fetchLedgerBySequence and fetchLedgerByHash. fetchLedgerByHash is to search the 'ledger_hashes' by hash to get sequence, then call fetchLedgerBySequence inside.
The problem is we could get wrong seq from ledger_hashes table. Because the generateNextLedger could generate the same hash for different ledger seq. generateNextLedger shuffles the same hash multiple times to get hash for 20 test targets.
From the error message, we also can tell the mismatch happens at the sequence number. We saw the parentHash is the same as well, that can be explained: because the previous hash is same, so the next parentHash is the same.
I did an experiment (mimic our unittest steps, the hash is also from unittest)to show the probability. 
```
int main()
{
  std::set<std::string> x;
  const char *const delim = "";
  std::vector<std::string> v = {"DB", "65", "EF", "4C", "7C", "FD", "F8", "FA", "6A", "82", "D9", "80", "13", "CE", "CD", "A2", "5D", "96", "6E", "52", "AC", "48", "58", "37", "91", "41", "C2", "59", "5A", "FA", "E2", "4E"};
  unsigned seed =
      std::chrono::system_clock::now().time_since_epoch().count();
  int times = 1000;
  while (times-- != 0)
  {
    std::srand(std::time(nullptr));
    std::shuffle(v.begin(), v.end(), std::default_random_engine(seed));
    std::ostringstream s;
    std::copy(v.begin(), v.end(), std::ostream_iterator<std::string>(s, delim));
    x.insert(s.str());
    std::cout << s.str() << std::endl;
  }
  std::cout << x.size() << std::endl;
}
```


shuffle is called 1000 times, but only generate 50-300 different result.
This diff adds a function to generate unique hash. I also add more log, in case it fails again, we have more information.

