### PR TITLE
Fix ledger_entry API : can not get ticket entry

### DIFF
--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -340,6 +340,7 @@ doLedgerEntry(Context const& context)
     }
     else if (request.contains(JS(ticket)))
     {
+        // ticket object : account, ticket_seq
         if (!request.at(JS(ticket)).is_object())
         {
             if (!request.at(JS(ticket)).is_string())
@@ -351,8 +352,8 @@ doLedgerEntry(Context const& context)
                     ClioError::rpcMALFORMED_REQUEST, "malformedTicket"};
         }
         else if (
-            !request.at(JS(ticket)).as_object().contains(JS(owner)) ||
-            !request.at(JS(ticket)).as_object().at(JS(owner)).is_string())
+            !request.at(JS(ticket)).as_object().contains(JS(account)) ||
+            !request.at(JS(ticket)).as_object().at(JS(account)).is_string())
         {
             return Status{ClioError::rpcMALFORMED_REQUEST};
         }
@@ -368,7 +369,7 @@ doLedgerEntry(Context const& context)
             auto const id =
                 ripple::parseBase58<ripple::AccountID>(request.at(JS(ticket))
                                                            .as_object()
-                                                           .at(JS(owner))
+                                                           .at(JS(account))
                                                            .as_string()
                                                            .c_str());
 
@@ -376,7 +377,7 @@ doLedgerEntry(Context const& context)
                 return Status{ClioError::rpcMALFORMED_OWNER};
             else
             {
-                std::uint32_t seq = request.at(JS(offer))
+                std::uint32_t seq = request.at(JS(ticket))
                                         .as_object()
                                         .at(JS(ticket_seq))
                                         .as_int64();


### PR DESCRIPTION
ledger_entry API handle ticket object incorrectly.
For request:
{
   "method":"ledger_entry",
   "params":[
      {
         "ticket":{
            "account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
            "ticket_seq":389
         }
      }
   ]
}
<img width="1172" alt="Screenshot 2023-02-28 at 15 27 31" src="https://user-images.githubusercontent.com/120398799/221899611-64fc3250-65d0-4f48-ae53-dff6ca9293f3.png">

![Screenshot 2023-02-28 at 14 18 40](https://user-images.githubusercontent.com/120398799/221880694-8c3a827d-15f9-44b3-ad23-0be4398105d4.png)

clio return: malformedRequest error. While rippled can return correct value.

After fix:
![Screenshot 2023-02-28 at 14 21 56](https://user-images.githubusercontent.com/120398799/221881588-7543899b-cbce-4590-a47a-9e364338efe9.png)

https://xrpl.org/ledger_entry.html#get-ticket-object

