### PR TITLE
Custom error validator

### DIFF
--- a/src/rpc/common/Validators.h
+++ b/src/rpc/common/Validators.h
@@ -392,8 +392,8 @@ public:
      * @brief Constructs a validator that calls the given validator "req" and
      * return customized error "err"
      */
-    WithCustomError(Requirement const& req, RPC::Status const& err)
-        : requirement{req}, error{err}
+    WithCustomError(Requirement req, RPC::Status err)
+        : requirement{std::move(req)}, error{err}
     {
     }
 

--- a/src/rpc/common/Validators.h
+++ b/src/rpc/common/Validators.h
@@ -378,6 +378,36 @@ private:
 };
 
 /**
+ * @brief A meta-validator that wrapp other validator to send the customized
+ * error
+ */
+template <typename Requirement>
+class WithCustomError final
+{
+    Requirement requirement;
+    RPC::Status error;
+
+public:
+    /**
+     * @brief Constructs a validator that calls the given validator "req" and
+     * return customized error "err"
+     */
+    WithCustomError(Requirement const& req, RPC::Status const& err)
+        : requirement{req}, error{err}
+    {
+    }
+
+    [[nodiscard]] MaybeError
+    verify(boost::json::value const& value, std::string_view key) const
+    {
+        if (auto const res = requirement.verify(value, key); not res)
+            return Error{error};
+
+        return {};
+    }
+};
+
+/**
  * @brief A meta-validator that allows to specify a custom validation function
  */
 class CustomValidator final


### PR DESCRIPTION
For the same validator, the error message might be different according to the field location, eg https://xrpl.org/book_offers.html#possible-errors
Add this validator to send out a custom error when validation fails.