### PR TITLE
Implement book_offers in new RPC framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(clio PRIVATE
   src/rpc/ngHandlers/Tx.cpp
   src/rpc/ngHandlers/GatewayBalances.cpp
   src/rpc/ngHandlers/LedgerEntry.cpp
+  src/rpc/ngHandlers/BookOffers.cpp
   ## RPC Methods
   # Account
   src/rpc/handlers/AccountChannels.cpp
@@ -126,7 +127,8 @@ if(BUILD_TESTS)
     unittests/rpc/handlers/AccountChannelsTest.cpp
     unittests/rpc/handlers/TxTest.cpp
     unittests/rpc/handlers/GatewayBalancesTest.cpp
-    unittests/rpc/handlers/LedgerEntryTest.cpp)
+    unittests/rpc/handlers/LedgerEntryTest.cpp
+    unittests/rpc/handlers/BookOffersTest.cpp)
   include(CMake/deps/gtest.cmake)
 
   # if CODE_COVERAGE enable, add clio_test-ccov

--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -173,7 +173,6 @@ BackendInterface::fetchBookOffers(
     ripple::uint256 const& book,
     std::uint32_t const ledgerSequence,
     std::uint32_t const limit,
-    std::optional<ripple::uint256> const& cursor,
     boost::asio::yield_context& yield) const
 {
     // TODO try to speed this up. This can take a few seconds. The goal is

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -479,7 +479,6 @@ public:
         ripple::uint256 const& book,
         std::uint32_t const ledgerSequence,
         std::uint32_t const limit,
-        std::optional<ripple::uint256> const& cursor,
         boost::asio::yield_context& yield) const;
 
     /**

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -217,6 +217,13 @@ postProcessOrderBook(
     boost::asio::yield_context& yield);
 
 std::variant<Status, ripple::Book>
+parseBook(
+    ripple::Currency pays,
+    ripple::AccountID payIssuer,
+    ripple::Currency gets,
+    ripple::AccountID getIssuer);
+
+std::variant<Status, ripple::Book>
 parseBook(boost::json::object const& request);
 
 std::variant<Status, ripple::AccountID>

--- a/src/rpc/common/Validators.cpp
+++ b/src/rpc/common/Validators.cpp
@@ -22,6 +22,7 @@
 #include <rpc/common/Validators.h>
 
 #include <boost/json/value.hpp>
+#include <fmt/core.h>
 
 #include <charconv>
 #include <string_view>
@@ -197,6 +198,29 @@ CustomValidator CurrencyValidator = CustomValidator{
         if (!ripple::to_currency(currency, value.as_string().c_str()))
             return Error{RPC::Status{
                 RPC::ClioError::rpcMALFORMED_CURRENCY, "malformedCurrency"}};
+        return MaybeError{};
+    }};
+
+CustomValidator IssuerValidator = CustomValidator{
+    [](boost::json::value const& value, std::string_view key) -> MaybeError {
+        if (!value.is_string())
+            return Error{RPC::Status{
+                RPC::RippledError::rpcINVALID_PARAMS,
+                std::string(key) + "NotString"}};
+        ripple::AccountID issuer;
+        if (!ripple::to_issuer(issuer, value.as_string().c_str()))
+            return Error{RPC::Status{
+                // TODO: need to align with the error
+                RPC::RippledError::rpcINVALID_PARAMS,
+                fmt::format("Invalid field '{}', bad issuer.", key)}};
+
+        if (issuer == ripple::noAccount())
+            return Error{RPC::Status{
+                RPC::RippledError::rpcINVALID_PARAMS,
+                fmt::format(
+                    "Invalid field '{}', bad issuer account "
+                    "one.",
+                    key)}};
         return MaybeError{};
     }};
 

--- a/src/rpc/common/Validators.h
+++ b/src/rpc/common/Validators.h
@@ -485,4 +485,10 @@ extern CustomValidator Uint256HexStringValidator;
  */
 extern CustomValidator CurrencyValidator;
 
+/**
+ * @brief Provide a common used validator for issuer type
+ * It must be a hex string or base58 string
+ */
+extern CustomValidator IssuerValidator;
+
 }  // namespace RPCng::validation

--- a/src/rpc/handlers/BookOffers.cpp
+++ b/src/rpc/handlers/BookOffers.cpp
@@ -83,13 +83,9 @@ doBookOffers(Context const& context)
     if (auto const status = getTaker(request, takerID); status)
         return status;
 
-    ripple::uint256 marker = beast::zero;
-    if (auto const status = getHexMarker(request, marker); status)
-        return status;
-
     auto start = std::chrono::system_clock::now();
-    auto [offers, retMarker] = context.backend->fetchBookOffers(
-        bookBase, lgrInfo.seq, limit, marker, context.yield);
+    auto [offers, _] = context.backend->fetchBookOffers(
+        bookBase, lgrInfo.seq, limit, context.yield);
     auto end = std::chrono::system_clock::now();
 
     gLog.warn() << "Time loading books: "
@@ -111,10 +107,6 @@ doBookOffers(Context const& context)
                        end2 - end)
                        .count()
                 << " milliseconds - request = " << request;
-
-    if (retMarker)
-        response["marker"] = ripple::strHex(*retMarker);
-
     return response;
 }
 

--- a/src/rpc/handlers/Subscribe.cpp
+++ b/src/rpc/handlers/Subscribe.cpp
@@ -263,8 +263,8 @@ validateAndGetBooks(
                                     auto book,
                                     boost::asio::yield_context& yield) {
                 auto bookBase = getBookBase(book);
-                auto [offers, retMarker] = backend->fetchBookOffers(
-                    bookBase, rng->maxSequence, 200, {}, yield);
+                auto [offers, _] = backend->fetchBookOffers(
+                    bookBase, rng->maxSequence, 200, yield);
 
                 auto orderBook = postProcessOrderBook(
                     offers, book, takerID, *backend, rng->maxSequence, yield);

--- a/src/rpc/ngHandlers/BookOffers.cpp
+++ b/src/rpc/ngHandlers/BookOffers.cpp
@@ -1,0 +1,133 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <rpc/RPCHelpers.h>
+#include <rpc/ngHandlers/BookOffers.h>
+
+namespace RPCng {
+
+BookOffersHandler::Result
+BookOffersHandler::process(Input input, boost::asio::yield_context& yield) const
+{
+    auto bookMaybe = RPC::parseBook(
+        input.paysCurrency, input.paysID, input.getsCurrency, input.getsID);
+    if (auto status = std::get_if<RPC::Status>(&bookMaybe))
+        return Error{*status};
+
+    // check ledger
+    auto const range = sharedPtrBackend_->fetchLedgerRange();
+    auto const lgrInfoOrStatus = RPC::getLedgerInfoFromHashOrSeq(
+        *sharedPtrBackend_,
+        yield,
+        input.ledgerHash,
+        input.ledgerIndex,
+        range->maxSequence);
+
+    if (auto const status = std::get_if<RPC::Status>(&lgrInfoOrStatus))
+        return Error{*status};
+    auto const lgrInfo = std::get<ripple::LedgerInfo>(lgrInfoOrStatus);
+
+    auto const book = std::get<ripple::Book>(bookMaybe);
+    auto const bookKey = getBookBase(book);
+    BookOffersHandler::Output output;
+    // TODO: Add perfomance metrics if needed in future
+    auto [offers, _] = sharedPtrBackend_->fetchBookOffers(
+        bookKey, lgrInfo.seq, input.limit, yield);
+
+    output.ledgerHash = ripple::strHex(lgrInfo.hash);
+    output.ledgerIndex = lgrInfo.seq;
+    output.offers = RPC::postProcessOrderBook(
+        offers,
+        book,
+        input.taker ? *(input.taker) : beast::zero,
+        *sharedPtrBackend_,
+        lgrInfo.seq,
+        yield);
+
+    return output;
+}
+
+void
+tag_invoke(
+    boost::json::value_from_tag,
+    boost::json::value& jv,
+    BookOffersHandler::Output const& output)
+{
+    jv = boost::json::object{
+        {"ledger_hash", output.ledgerHash},
+        {"ledger_index", output.ledgerIndex},
+        {"offers", output.offers},
+    };
+}
+
+BookOffersHandler::Input
+tag_invoke(
+    boost::json::value_to_tag<BookOffersHandler::Input>,
+    boost::json::value const& jv)
+{
+    BookOffersHandler::Input input;
+    auto const& jsonObject = jv.as_object();
+    ripple::to_currency(
+        input.getsCurrency,
+        jv.at("taker_gets").as_object().at("currency").as_string().c_str());
+    ripple::to_currency(
+        input.paysCurrency,
+        jv.at("taker_pays").as_object().at("currency").as_string().c_str());
+    if (jv.at("taker_gets").as_object().contains("issuer"))
+    {
+        ripple::to_issuer(
+            input.getsID,
+            jv.at("taker_gets").as_object().at("issuer").as_string().c_str());
+    }
+    if (jv.at("taker_pays").as_object().contains("issuer"))
+    {
+        ripple::to_issuer(
+            input.paysID,
+            jv.at("taker_pays").as_object().at("issuer").as_string().c_str());
+    }
+    if (jsonObject.contains("ledger_hash"))
+    {
+        input.ledgerHash = jv.at("ledger_hash").as_string().c_str();
+    }
+    if (jsonObject.contains("ledger_index"))
+    {
+        if (!jsonObject.at("ledger_index").is_string())
+        {
+            input.ledgerIndex = jv.at("ledger_index").as_int64();
+        }
+        else if (jsonObject.at("ledger_index").as_string() != "validated")
+        {
+            input.ledgerIndex =
+                std::stoi(jv.at("ledger_index").as_string().c_str());
+        }
+    }
+    if (jsonObject.contains("taker"))
+    {
+        input.taker =
+            RPC::accountFromStringStrict(jv.at("taker").as_string().c_str());
+    }
+    if (jsonObject.contains("limit"))
+    {
+        input.limit = jv.at("limit").as_int64();
+    }
+
+    return input;
+}
+
+}  // namespace RPCng

--- a/src/rpc/ngHandlers/BookOffers.h
+++ b/src/rpc/ngHandlers/BookOffers.h
@@ -1,0 +1,108 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <backend/BackendInterface.h>
+#include <rpc/common/Types.h>
+#include <rpc/common/Validators.h>
+
+#include <boost/asio/spawn.hpp>
+
+namespace RPCng {
+class BookOffersHandler
+{
+    std::shared_ptr<BackendInterface> sharedPtrBackend_;
+
+public:
+    struct Output
+    {
+        std::string ledgerHash;
+        uint32_t ledgerIndex;
+        boost::json::array offers;
+        bool validated = true;
+    };
+
+    // the taker is not really used in both clio and rippled, both of them
+    // return all the offers regardless the funding status
+    struct Input
+    {
+        std::optional<std::string> ledgerHash;
+        std::optional<uint32_t> ledgerIndex;
+        uint32_t limit = 50;
+        std::optional<ripple::AccountID> taker;
+        ripple::Currency paysCurrency;
+        ripple::Currency getsCurrency;
+        // accountID will be filled by input converter, if no issuer is given,
+        // will use XRP issuer
+        ripple::AccountID paysID = ripple::xrpAccount();
+        ripple::AccountID getsID = ripple::xrpAccount();
+    };
+
+    using Result = RPCng::HandlerReturnType<Output>;
+
+    BookOffersHandler(std::shared_ptr<BackendInterface> const& sharedPtrBackend)
+        : sharedPtrBackend_(sharedPtrBackend)
+    {
+    }
+
+    RpcSpecConstRef
+    spec() const
+    {
+        static const RpcSpec rpcSpec = {
+            {"taker_gets",
+             validation::Required{},
+             validation::Type<boost::json::object>{},
+             validation::Section{
+                 {"currency",
+                  validation::Required{},
+                  validation::CurrencyValidator},
+                 {"issuer", validation::IssuerValidator}}},
+            {"taker_pays",
+             validation::Required{},
+             validation::Type<boost::json::object>{},
+             validation::Section{
+                 {"currency",
+                  validation::Required{},
+                  validation::CurrencyValidator},
+                 {"issuer", validation::IssuerValidator}}},
+            {"taker", validation::AccountValidator},
+            {"limit",
+             validation::Type<uint32_t>{},
+             validation::Between{1, 100}},
+            {"ledger_hash", validation::Uint256HexStringValidator},
+            {"ledger_index", validation::LedgerIndexValidator}};
+        return rpcSpec;
+    }
+
+    Result
+    process(Input input, boost::asio::yield_context& yield) const;
+};
+
+void
+tag_invoke(
+    boost::json::value_from_tag,
+    boost::json::value& jv,
+    BookOffersHandler::Output const& output);
+
+BookOffersHandler::Input
+tag_invoke(
+    boost::json::value_to_tag<BookOffersHandler::Input>,
+    boost::json::value const& jv);
+}  // namespace RPCng

--- a/src/rpc/ngHandlers/BookOffers.h
+++ b/src/rpc/ngHandlers/BookOffers.h
@@ -72,16 +72,26 @@ public:
              validation::Section{
                  {"currency",
                   validation::Required{},
-                  validation::CurrencyValidator},
-                 {"issuer", validation::IssuerValidator}}},
+                  validation::WithCustomError{
+                      validation::CurrencyValidator,
+                      RPC::Status(RPC::RippledError::rpcDST_AMT_MALFORMED)}},
+                 {"issuer",
+                  validation::WithCustomError{
+                      validation::IssuerValidator,
+                      RPC::Status(RPC::RippledError::rpcDST_ISR_MALFORMED)}}}},
             {"taker_pays",
              validation::Required{},
              validation::Type<boost::json::object>{},
              validation::Section{
                  {"currency",
                   validation::Required{},
-                  validation::CurrencyValidator},
-                 {"issuer", validation::IssuerValidator}}},
+                  validation::WithCustomError{
+                      validation::CurrencyValidator,
+                      RPC::Status(RPC::RippledError::rpcSRC_CUR_MALFORMED)}},
+                 {"issuer",
+                  validation::WithCustomError{
+                      validation::IssuerValidator,
+                      RPC::Status(RPC::RippledError::rpcSRC_ISR_MALFORMED)}}}},
             {"taker", validation::AccountValidator},
             {"limit",
              validation::Type<uint32_t>{},

--- a/unittests/rpc/handlers/AccountCurrenciesTest.cpp
+++ b/unittests/rpc/handlers/AccountCurrenciesTest.cpp
@@ -171,15 +171,15 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
     // ACCOUNT can receive USD 10 from ACCOUNT2 and send USD 20 to ACCOUNT2, now
     // the balance is 100, ACCOUNT can only send USD to ACCOUNT2
     auto const line1 = CreateRippleStateLedgerObject(
-        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123);
+        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     // ACCOUNT2 can receive JPY 10 from ACCOUNT and send JPY 20 to ACCOUNT, now
     // the balance is 100, ACCOUNT2 can only send JPY to ACCOUNT
     auto const line2 = CreateRippleStateLedgerObject(
-        ACCOUNT, "JPY", ISSUER, 100, ACCOUNT2, 10, ACCOUNT, 20, TXNID, 123);
+        ACCOUNT, "JPY", ISSUER, 100, ACCOUNT2, 10, ACCOUNT, 20, TXNID, 123, 0);
     // ACCOUNT can receive EUR 10 from ACCOUNT and send EUR 20 to ACCOUNT2, now
     // the balance is 8, ACCOUNT can receive/send EUR to/from ACCOUNT2
     auto const line3 = CreateRippleStateLedgerObject(
-        ACCOUNT, "EUR", ISSUER, 8, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123);
+        ACCOUNT, "EUR", ISSUER, 8, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     std::vector<Blob> bbs;
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(line2.getSerializer().peekData());
@@ -226,7 +226,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
     EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject(
-        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123);
+        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
     ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
@@ -272,7 +272,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderSeq)
     EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject(
-        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123);
+        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
     ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));

--- a/unittests/rpc/handlers/BookOffersTest.cpp
+++ b/unittests/rpc/handlers/BookOffersTest.cpp
@@ -1,0 +1,1327 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <rpc/RPCHelpers.h>
+#include <rpc/common/AnyHandler.h>
+#include <rpc/ngHandlers/BookOffers.h>
+#include <util/Fixtures.h>
+#include <util/TestObject.h>
+
+#include <fmt/core.h>
+
+constexpr static auto ACCOUNT = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn";
+constexpr static auto ACCOUNT2 = "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun";
+
+constexpr static auto LEDGERHASH =
+    "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652";
+constexpr static auto INDEX1 =
+    "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC";
+constexpr static auto INDEX2 =
+    "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
+// 20 USD : 10 XRP
+constexpr static auto PAYS20USDGETS10XRPBOOKDIR =
+    "43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000";
+// 20 XRP : 10 USD
+constexpr static auto PAYS20XRPGETS10USDBOOKDIR =
+    "7B1767D41DBCE79D9585CF9D0262A5FEC45E5206FF524F8B55071AFD498D0000";
+// transfer rate x2
+constexpr static auto TRANSFERRATEX2 = 2000000000;
+
+using namespace RPCng;
+namespace json = boost::json;
+using namespace testing;
+
+class RPCBookOffersHandlerTest : public HandlerBaseTest
+{
+};
+
+struct ParameterTestBundle
+{
+    std::string testName;
+    std::string testJson;
+    std::string expectedError;
+    std::string expectedErrorMessage;
+};
+
+struct RPCBookOffersParameterTest
+    : public RPCBookOffersHandlerTest,
+      public WithParamInterface<ParameterTestBundle>
+{
+    struct NameGenerator
+    {
+        template <class ParamType>
+        std::string
+        operator()(const testing::TestParamInfo<ParamType>& info) const
+        {
+            auto bundle = static_cast<ParameterTestBundle>(info.param);
+            return bundle.testName;
+        }
+    };
+};
+
+TEST_P(RPCBookOffersParameterTest, CheckError)
+{
+    auto bundle = GetParam();
+    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const output =
+            handler.process(json::parse(bundle.testJson), yield);
+        ASSERT_FALSE(output);
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), bundle.expectedError);
+        EXPECT_EQ(
+            err.at("error_message").as_string(), bundle.expectedErrorMessage);
+    });
+}
+
+auto
+generateParameterBookOffersTestBundles()
+{
+    return std::vector<ParameterTestBundle>{
+        ParameterTestBundle{
+            "MissingTakerGets",
+            R"({
+                "taker_pays" : {
+                    "currency" : "USD",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    }
+            })",
+            "invalidParams",
+            "Required field 'taker_gets' missing"},
+        ParameterTestBundle{
+            "MissingTakerPays",
+            R"({
+                "taker_gets" : {
+                    "currency" : "USD",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    }
+            })",
+            "invalidParams",
+            "Required field 'taker_pays' missing"},
+        ParameterTestBundle{
+            "WrongTypeTakerPays",
+            R"({
+                "taker_pays" : "wrong",
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "WrongTypeTakerGets",
+            R"({
+                "taker_gets" : "wrong",
+                "taker_pays" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "TakerPaysMissingCurrency",
+            R"({
+                "taker_pays" : {},
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Required field 'currency' missing"},
+        ParameterTestBundle{
+            "TakerGetsMissingCurrency",
+            R"({
+                "taker_gets" : {},
+                "taker_pays" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Required field 'currency' missing"},
+        ParameterTestBundle{
+            "TakerGetsWrongCurrency",
+            R"({
+                "taker_gets" : {
+                    "currency" : "CNYY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_pays" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "malformedCurrency",
+            "malformedCurrency"},
+        ParameterTestBundle{
+            "TakerPaysWrongCurrency",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNYY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "malformedCurrency",
+            "malformedCurrency"},
+        ParameterTestBundle{
+            "TakerGetsCurrencyNotString",
+            R"({
+                "taker_gets" : {
+                    "currency" : 123,
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_pays" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "currencyNotString"},
+        ParameterTestBundle{
+            "TakerPaysCurrencyNotString",
+            R"({
+                "taker_pays" : {
+                    "currency" : 123,
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "currencyNotString"},
+        ParameterTestBundle{
+            "TakerGetsWrongIssuer",
+            R"({
+                "taker_gets" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs5"
+                    },
+                "taker_pays" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Invalid field 'issuer', bad issuer."},
+        ParameterTestBundle{
+            "TakerPaysWrongIssuer",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs5"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    }
+            })",
+            "invalidParams",
+            "Invalid field 'issuer', bad issuer."},
+        ParameterTestBundle{
+            "InvalidTaker",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "taker": "123"
+            })",
+            "invalidParams",
+            "takerMalformed"},
+        ParameterTestBundle{
+            "TakerNotString",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "taker": 123
+            })",
+            "invalidParams",
+            "takerNotString"},
+        ParameterTestBundle{
+            "LimitNotInt",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "limit": "123"
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "LimitLargerThanMax",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "limit": 101
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "LimitSmallerThanMin",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "limit": 0
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "LedgerIndexInvalid",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "ledger_index": "xxx"
+            })",
+            "invalidParams",
+            "ledgerIndexMalformed"},
+        ParameterTestBundle{
+            "LedgerHashInvalid",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "ledger_hash": "xxx"
+            })",
+            "invalidParams",
+            "ledger_hashMalformed"},
+        ParameterTestBundle{
+            "LedgerHashNotString",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP"
+                    },
+                "ledger_hash": 123
+            })",
+            "invalidParams",
+            "ledger_hashNotString"},
+        ParameterTestBundle{
+            "GetsPaysXRPWithIssuer",
+            R"({
+                "taker_pays" : {
+                    "currency" : "XRP",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                "taker_gets" : {
+                    "currency" : "CNY",
+                    "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+                    }
+            })",
+            "srcIsrMalformed",
+            "Unneeded field 'taker_pays.issuer' for XRP currency "
+            "specification."},
+        ParameterTestBundle{
+            "PaysCurrencyWithXRPIssuer",
+            R"({
+                "taker_pays" : {
+                    "currency" : "JPY"                    },
+                "taker_gets" : {
+                    "currency" : "CNY",
+                    "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+                    }
+            })",
+            "srcIsrMalformed",
+            "Invalid field 'taker_pays.issuer', expected non-XRP issuer."},
+        ParameterTestBundle{
+            "GetsCurrencyWithXRPIssuer",
+            R"({
+                "taker_pays" : {
+                    "currency" : "XRP"                    
+                    },
+                "taker_gets" : {
+                    "currency" : "CNY"                    
+                    }            
+            })",
+            "dstIsrMalformed",
+            "Invalid field 'taker_gets.issuer', expected non-XRP issuer."},
+        ParameterTestBundle{
+            "GetsXRPWithIssuer",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
+                    },
+                "taker_gets" : {
+                    "currency" : "XRP",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
+                    }            
+            })",
+            "dstIsrMalformed",
+            "Unneeded field 'taker_gets.issuer' for XRP currency "
+            "specification."},
+        ParameterTestBundle{
+            "BadMarket",
+            R"({
+                "taker_pays" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
+                    },
+                "taker_gets" : {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                   
+                    }            
+            })",
+            "badMarket",
+            "badMarket"}};
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RPCBookOffersHandler,
+    RPCBookOffersParameterTest,
+    testing::ValuesIn(generateParameterBookOffersTestBundles()),
+    RPCBookOffersParameterTest::NameGenerator());
+
+struct BookOffersNormalTestBundle
+{
+    std::string testName;
+    std::string inputJson;
+    std::map<ripple::uint256, std::optional<ripple::uint256>> mockedSuccessors;
+    std::map<ripple::uint256, Blob> mockedLedgerObjects;
+    uint32_t ledgerObjectCalls;
+    std::vector<ripple::STObject> mockedOffers;
+    std::string expectedJson;
+};
+
+struct RPCBookOffersNormalPathTest
+    : public RPCBookOffersHandlerTest,
+      public WithParamInterface<BookOffersNormalTestBundle>
+{
+    struct NameGenerator
+    {
+        template <class ParamType>
+        std::string
+        operator()(const testing::TestParamInfo<ParamType>& info) const
+        {
+            auto bundle = static_cast<BookOffersNormalTestBundle>(info.param);
+            return bundle.testName;
+        }
+    };
+};
+
+TEST_P(RPCBookOffersNormalPathTest, CheckOutput)
+{
+    auto const& bundle = GetParam();
+    auto const seq = 300;
+    auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    mockBackendPtr->updateRange(10);   // min
+    mockBackendPtr->updateRange(seq);  // max
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    // return valid ledgerinfo
+    auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, seq);
+    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(seq, _))
+        .WillByDefault(Return(ledgerinfo));
+
+    // return valid book dir
+    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey)
+        .Times(bundle.mockedSuccessors.size());
+    for (auto const& [key, value] : bundle.mockedSuccessors)
+    {
+        ON_CALL(*rawBackendPtr, doFetchSuccessorKey(key, seq, _))
+            .WillByDefault(Return(value));
+    }
+
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject)
+        .Times(bundle.ledgerObjectCalls);
+
+    for (auto const& [key, value] : bundle.mockedLedgerObjects)
+    {
+        ON_CALL(*rawBackendPtr, doFetchLedgerObject(key, seq, _))
+            .WillByDefault(Return(value));
+    }
+
+    std::vector<Blob> bbs;
+    std::transform(
+        bundle.mockedOffers.begin(),
+        bundle.mockedOffers.end(),
+        std::back_inserter(bbs),
+        [](auto const& obj) { return obj.getSerializer().peekData(); });
+    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+
+    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const output =
+            handler.process(json::parse(bundle.inputJson), yield);
+        ASSERT_TRUE(output);
+        EXPECT_EQ(output.value(), json::parse(bundle.expectedJson));
+    });
+}
+
+auto
+generateNormalPathBookOffersTestBundles()
+{
+    auto const account = GetAccountIDWithString(ACCOUNT);
+    auto const account2 = GetAccountIDWithString(ACCOUNT2);
+
+    auto const frozenTrustLine = CreateRippleStateLedgerObject(
+        ACCOUNT2,
+        "USD",
+        ACCOUNT,
+        -8,
+        ACCOUNT2,
+        1000,
+        ACCOUNT,
+        2000,
+        INDEX1,
+        2,
+        ripple::lsfLowFreeze);
+
+    auto const gets10USDPays20XRPOffer = CreateOfferLedgerObject(
+        ACCOUNT2,
+        10,
+        20,
+        ripple::to_string(ripple::to_currency("USD")),
+        ripple::to_string(ripple::xrpCurrency()),
+        ACCOUNT,
+        toBase58(ripple::xrpAccount()),
+        PAYS20XRPGETS10USDBOOKDIR);
+
+    auto const gets10USDPays20XRPOwnerOffer = CreateOfferLedgerObject(
+        ACCOUNT,
+        10,
+        20,
+        ripple::to_string(ripple::to_currency("USD")),
+        ripple::to_string(ripple::xrpCurrency()),
+        ACCOUNT,
+        toBase58(ripple::xrpAccount()),
+        PAYS20XRPGETS10USDBOOKDIR);
+
+    auto const gets10XRPPays20USDOffer = CreateOfferLedgerObject(
+        ACCOUNT2,
+        10,
+        20,
+        ripple::to_string(ripple::xrpCurrency()),
+        ripple::to_string(ripple::to_currency("USD")),
+        toBase58(ripple::xrpAccount()),
+        ACCOUNT,
+        PAYS20USDGETS10XRPBOOKDIR);
+
+    auto const getsXRPPaysUSDBook =
+        getBookBase(std::get<ripple::Book>(RPC::parseBook(
+            ripple::to_currency("USD"),
+            account,
+            ripple::xrpCurrency(),
+            ripple::xrpAccount())));
+    auto const getsUSDPaysXRPBook =
+        getBookBase(std::get<ripple::Book>(RPC::parseBook(
+            ripple::xrpCurrency(),
+            ripple::xrpAccount(),
+            ripple::to_currency("USD"),
+            account)));
+
+    auto const getsXRPPaysUSDInputJson = fmt::format(
+        R"({{
+            "taker_gets": {{
+                "currency": "XRP"
+            }},
+            "taker_pays": {{
+                "currency": "USD",
+                "issuer": "{}"
+            }}
+        }})",
+        ACCOUNT);
+
+    auto const paysXRPGetsUSDInputJson = fmt::format(
+        R"({{
+            "taker_pays": {{
+                "currency": "XRP"
+            }},
+            "taker_gets": {{
+                "currency": "USD",
+                "issuer": "{}"
+            }}
+        }})",
+        ACCOUNT);
+
+    auto const feeLedgerObject = CreateFeeSettingBlob(1, 2, 3, 4, 0);
+
+    auto const trustline30Balance = CreateRippleStateLedgerObject(
+        ACCOUNT2,
+        "USD",
+        ACCOUNT,
+        -30,
+        ACCOUNT2,
+        1000,
+        ACCOUNT,
+        2000,
+        INDEX1,
+        2,
+        0);
+
+    auto const trustline8Balance = CreateRippleStateLedgerObject(
+        ACCOUNT2,
+        "USD",
+        ACCOUNT,
+        -8,
+        ACCOUNT2,
+        1000,
+        ACCOUNT,
+        2000,
+        INDEX1,
+        2,
+        0);
+
+    return std::vector<BookOffersNormalTestBundle>{
+        BookOffersNormalTestBundle{
+            "PaysUSDGetsXRPNoFrozenOwnerFundEnough",
+            getsXRPPaysUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsXRPPaysUSDBook,
+                 ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}},
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // pays issuer account object
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2)
+                     .getSerializer()
+                     .peekData()},
+                // owner account object
+                {ripple::keylet::account(account2).key,
+                 CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX1, 2)
+                     .getSerializer()
+                     .peekData()},
+                // fee settings: base ->3 inc->2, account2 has 2 objects ,total
+                // reserve ->7
+                // owner_funds should be 193
+                {ripple::keylet::fees().key, feeLedgerObject}},
+            5,
+            std::vector<ripple::STObject>{gets10XRPPays20USDOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerGets":"10",
+                            "TakerPays":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"20"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}"
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                193,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysUSDGetsXRPNoFrozenOwnerFundNotEnough",
+            getsXRPPaysUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsXRPPaysUSDBook,
+                 ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}},
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // pays issuer account object
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2)
+                     .getSerializer()
+                     .peekData()},
+                // owner account object, hold
+                {ripple::keylet::account(account2).key,
+                 CreateAccountRootObject(ACCOUNT2, 0, 2, 5 + 7, 2, INDEX1, 2)
+                     .getSerializer()
+                     .peekData()},
+                // fee settings: base ->3 inc->2, account2 has 2 objects
+                // ,total
+                // reserve ->7
+                {ripple::keylet::fees().key, feeLedgerObject}},
+            5,
+            std::vector<ripple::STObject>{gets10XRPPays20USDOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerGets":"10",
+                            "TakerPays":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"20"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}",
+                            "taker_gets_funded":"5",
+                            "taker_pays_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }}
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                5,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysUSDGetsXRPFrozen",
+            getsXRPPaysUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsXRPPaysUSDBook,
+                 ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}},
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20USDGETS10XRPBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // pays issuer account object
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT, ripple::lsfGlobalFreeze, 2, 200, 2, INDEX1, 2)
+                     .getSerializer()
+                     .peekData()}},
+            3,
+            std::vector<ripple::STObject>{gets10XRPPays20USDOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerGets":"10",
+                            "TakerPays":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"20"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}",
+                            "taker_gets_funded":"0",
+                            "taker_pays_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"0"
+                            }}
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                0,
+                2)},
+        BookOffersNormalTestBundle{
+            "GetsUSDPaysXRPFrozen",
+            paysXRPGetsUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsUSDPaysXRPBook,
+                 ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}},
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // gets issuer account object
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT,
+                     ripple::lsfGlobalFreeze,
+                     2,
+                     200,
+                     2,
+                     INDEX1,
+                     2,
+                     TRANSFERRATEX2)
+                     .getSerializer()
+                     .peekData()}},
+            3,
+            std::vector<ripple::STObject>{gets10USDPays20XRPOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}",
+                            "taker_pays_funded":"0",
+                            "taker_gets_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"0"
+                            }}
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                PAYS20XRPGETS10USDBOOKDIR,
+                0,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysXRPGetsUSDWithTransferFee",
+            paysXRPGetsUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsUSDPaysXRPBook,
+                 ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}},
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // gets issuer account object, rate is 1/2
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2)
+                     .getSerializer()
+                     .peekData()},
+                // trust line between gets issuer and owner,owner has 8 USD
+                {ripple::keylet::line(
+                     account2, account, ripple::to_currency("USD"))
+                     .key,
+                 trustline8Balance.getSerializer().peekData()},
+            },
+            6,
+            std::vector<ripple::STObject>{gets10USDPays20XRPOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}",
+                            "taker_gets_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"4"
+                            }},
+                            "taker_pays_funded":"8"
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                PAYS20XRPGETS10USDBOOKDIR,
+                8,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysXRPGetsUSDWithMultipleOffers",
+            paysXRPGetsUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsUSDPaysXRPBook,
+                 ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}},
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 CreateOwnerDirLedgerObject(
+                     {ripple::uint256{INDEX2}, ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // gets issuer account object
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2)
+                     .getSerializer()
+                     .peekData()},
+                // trust line between gets issuer and owner,owner has 30 USD
+                {ripple::keylet::line(
+                     account2, account, ripple::to_currency("USD"))
+                     .key,
+                 trustline30Balance.getSerializer().peekData()},
+            },
+            6,
+            std::vector<ripple::STObject>{
+                // After offer1, balance is 30 - 2*10 = 10
+                gets10USDPays20XRPOffer,
+                // offer2 not fully funded, balance is 10, rate is 2, so only
+                // gets 5
+                gets10USDPays20XRPOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}"
+                        }},
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "taker_gets_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"5"
+                            }},
+                            "taker_pays_funded":"10",
+                            "quality":"{}"
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                PAYS20XRPGETS10USDBOOKDIR,
+                30,
+                2,
+                ACCOUNT2,
+                PAYS20XRPGETS10USDBOOKDIR,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysXRPGetsUSDSellingOwnCurrency",
+            paysXRPGetsUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsUSDPaysXRPBook,
+                 ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}},
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // gets issuer account object, rate is 1/2
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2)
+                     .getSerializer()
+                     .peekData()},
+            },
+            3,
+            std::vector<ripple::STObject>{gets10USDPays20XRPOwnerOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}"
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT,
+                PAYS20XRPGETS10USDBOOKDIR,
+                10,
+                2)},
+        BookOffersNormalTestBundle{
+            "PaysXRPGetsUSDTrustLineFrozen",
+            paysXRPGetsUSDInputJson,
+            // prepare offer dir index
+            std::map<ripple::uint256, std::optional<ripple::uint256>>{
+                {getsUSDPaysXRPBook,
+                 ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}},
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 std::optional<ripple::uint256>{}}},
+            std::map<ripple::uint256, ripple::Blob>{
+                // book dir object
+                {ripple::uint256{PAYS20XRPGETS10USDBOOKDIR},
+                 CreateOwnerDirLedgerObject({ripple::uint256{INDEX2}}, INDEX1)
+                     .getSerializer()
+                     .peekData()},
+                // gets issuer account object, rate is 1/2
+                {ripple::keylet::account(account).key,
+                 CreateAccountRootObject(
+                     ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2)
+                     .getSerializer()
+                     .peekData()},
+                // trust line between gets issuer and owner,owner has 8 USD
+                {ripple::keylet::line(
+                     account2, account, ripple::to_currency("USD"))
+                     .key,
+                 frozenTrustLine.getSerializer().peekData()},
+            },
+            6,
+            std::vector<ripple::STObject>{gets10USDPays20XRPOffer},
+            fmt::format(
+                R"({{
+                    "ledger_hash":"{}",
+                    "ledger_index":300,
+                    "offers":[
+                        {{
+                            "Account":"{}",
+                            "BookDirectory":"{}",
+                            "BookNode":"0",
+                            "Flags":0,
+                            "LedgerEntryType":"Offer",
+                            "OwnerNode":"0",
+                            "PreviousTxnID":"0000000000000000000000000000000000000000000000000000000000000000",
+                            "PreviousTxnLgrSeq":0,
+                            "Sequence":0,
+                            "TakerPays":"20",
+                            "TakerGets":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"10"
+                            }},
+                            "index":"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321",
+                            "owner_funds":"{}",
+                            "quality":"{}",
+                            "taker_gets_funded":{{
+                                "currency":"USD",
+                                "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "value":"0"
+                            }},
+                            "taker_pays_funded":"0"
+                        }}
+                    ]
+                }})",
+                LEDGERHASH,
+                ACCOUNT2,
+                PAYS20XRPGETS10USDBOOKDIR,
+                0,
+                2)},
+    };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RPCBookOffersHandler,
+    RPCBookOffersNormalPathTest,
+    testing::ValuesIn(generateNormalPathBookOffersTestBundles()),
+    RPCBookOffersNormalPathTest::NameGenerator());
+
+// ledger not exist
+TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaSequence)
+{
+    auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    mockBackendPtr->updateRange(10);  // min
+    mockBackendPtr->updateRange(30);  // max
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    // return empty ledgerinfo
+    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(30, _))
+        .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+
+    auto const static input = boost::json::parse(fmt::format(
+        R"({{
+            "ledger_index": 30,
+            "taker_gets": {{
+                "currency": "XRP"
+            }},
+            "taker_pays": {{
+                "currency": "USD",
+                "issuer": "{}"
+            }}
+        }})",
+        ACCOUNT));
+    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const output = handler.process(input, yield);
+        ASSERT_FALSE(output);
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
+        EXPECT_EQ(err.at("error_message").as_string(), "ledgerNotFound");
+    });
+}
+
+TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaHash)
+{
+    auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    mockBackendPtr->updateRange(10);  // min
+    mockBackendPtr->updateRange(30);  // max
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    // return empty ledgerinfo
+    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+        .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+
+    auto const static input = boost::json::parse(fmt::format(
+        R"({{
+            "ledger_hash": "{}",
+            "taker_gets": {{
+                "currency": "XRP"
+            }},
+            "taker_pays": {{
+                "currency": "USD",
+                "issuer": "{}"
+            }}
+        }})",
+        LEDGERHASH,
+        ACCOUNT));
+    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const output = handler.process(input);
+        ASSERT_FALSE(output);
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
+        EXPECT_EQ(err.at("error_message").as_string(), "ledgerNotFound");
+    });
+}
+
+TEST_F(RPCBookOffersHandlerTest, Limit)
+{
+    auto const seq = 300;
+    auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    mockBackendPtr->updateRange(10);   // min
+    mockBackendPtr->updateRange(seq);  // max
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    // return valid ledgerinfo
+    auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, seq);
+    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(seq, _))
+        .WillByDefault(Return(ledgerinfo));
+
+    auto const issuer = GetAccountIDWithString(ACCOUNT);
+    // return valid book dir
+    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(1);
+
+    auto const getsXRPPaysUSDBook =
+        getBookBase(std::get<ripple::Book>(RPC::parseBook(
+            ripple::to_currency("USD"),
+            issuer,
+            ripple::xrpCurrency(),
+            ripple::xrpAccount())));
+    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(getsXRPPaysUSDBook, seq, _))
+        .WillByDefault(Return(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}));
+
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(5);
+    auto const indexes =
+        std::vector<ripple::uint256>(10, ripple::uint256{INDEX2});
+
+    ON_CALL(
+        *rawBackendPtr,
+        doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, seq, _))
+        .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes, INDEX1)
+                                  .getSerializer()
+                                  .peekData()));
+    ON_CALL(
+        *rawBackendPtr,
+        doFetchLedgerObject(
+            ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key,
+            seq,
+            _))
+        .WillByDefault(
+            Return(CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX1, 2)
+                       .getSerializer()
+                       .peekData()));
+
+    ON_CALL(
+        *rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, seq, _))
+        .WillByDefault(Return(CreateFeeSettingBlob(1, 2, 3, 4, 0)));
+
+    ON_CALL(
+        *rawBackendPtr,
+        doFetchLedgerObject(ripple::keylet::account(issuer).key, seq, _))
+        .WillByDefault(
+            Return(CreateAccountRootObject(
+                       ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2)
+                       .getSerializer()
+                       .peekData()));
+
+    auto const gets10XRPPays20USDOffer = CreateOfferLedgerObject(
+        ACCOUNT2,
+        10,
+        20,
+        ripple::to_string(ripple::xrpCurrency()),
+        ripple::to_string(ripple::to_currency("USD")),
+        toBase58(ripple::xrpAccount()),
+        ACCOUNT,
+        PAYS20USDGETS10XRPBOOKDIR);
+
+    std::vector<Blob> bbs(
+        10, gets10XRPPays20USDOffer.getSerializer().peekData());
+    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+
+    auto const static input = boost::json::parse(fmt::format(
+        R"({{
+            "taker_gets": {{
+                "currency": "XRP"
+            }},
+            "taker_pays": {{
+                "currency": "USD",
+                "issuer": "{}"
+            }},
+            "limit": 5
+        }})",
+        ACCOUNT));
+    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const output = handler.process(input, yield);
+        ASSERT_TRUE(output);
+        std::cout << output.value() << std::endl;
+        EXPECT_EQ(output.value().as_object().at("offers").as_array().size(), 5);
+    });
+}
+
+// taker

--- a/unittests/rpc/handlers/BookOffersTest.cpp
+++ b/unittests/rpc/handlers/BookOffersTest.cpp
@@ -97,20 +97,22 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "MissingTakerGets",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "USD",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    }
+                }
             })",
             "invalidParams",
             "Required field 'taker_gets' missing"},
         ParameterTestBundle{
             "MissingTakerPays",
             R"({
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "USD",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    }
+                }
             })",
             "invalidParams",
             "Required field 'taker_pays' missing"},
@@ -118,9 +120,10 @@ generateParameterBookOffersTestBundles()
             "WrongTypeTakerPays",
             R"({
                 "taker_pays" : "wrong",
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "invalidParams",
             "Invalid parameters."},
@@ -128,9 +131,10 @@ generateParameterBookOffersTestBundles()
             "WrongTypeTakerGets",
             R"({
                 "taker_gets" : "wrong",
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "invalidParams",
             "Invalid parameters."},
@@ -138,9 +142,10 @@ generateParameterBookOffersTestBundles()
             "TakerPaysMissingCurrency",
             R"({
                 "taker_pays" : {},
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "invalidParams",
             "Required field 'currency' missing"},
@@ -148,100 +153,115 @@ generateParameterBookOffersTestBundles()
             "TakerGetsMissingCurrency",
             R"({
                 "taker_gets" : {},
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "invalidParams",
             "Required field 'currency' missing"},
         ParameterTestBundle{
             "TakerGetsWrongCurrency",
             R"({
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "CNYY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                 },
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "dstAmtMalformed",
             "Destination amount/currency/issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysWrongCurrency",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNYY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                 },
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "srcCurMalformed",
             "Source currency is malformed."},
         ParameterTestBundle{
             "TakerGetsCurrencyNotString",
             R"({
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : 123,
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                 },
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "dstAmtMalformed",
             "Destination amount/currency/issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysCurrencyNotString",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : 123,
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
                 },
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "srcCurMalformed",
             "Source currency is malformed."},
         ParameterTestBundle{
             "TakerGetsWrongIssuer",
             R"({
-                "taker_gets" : {
+                "taker_gets" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs5"
-                    },
-                "taker_pays" : {
+                },
+                "taker_pays" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "dstIsrMalformed",
             "Destination issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysWrongIssuer",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs5"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    }
+                }
             })",
             "srcIsrMalformed",
             "Source issuer is malformed."},
         ParameterTestBundle{
             "InvalidTaker",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "taker": "123"
             })",
             "invalidParams",
@@ -249,13 +269,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "TakerNotString",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "taker": 123
             })",
             "invalidParams",
@@ -263,13 +285,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LimitNotInt",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "limit": "123"
             })",
             "invalidParams",
@@ -277,13 +301,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LimitLargerThanMax",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "limit": 101
             })",
             "invalidParams",
@@ -291,13 +317,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LimitSmallerThanMin",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "limit": 0
             })",
             "invalidParams",
@@ -305,13 +333,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LedgerIndexInvalid",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "ledger_index": "xxx"
             })",
             "invalidParams",
@@ -319,13 +349,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LedgerHashInvalid",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "ledger_hash": "xxx"
             })",
             "invalidParams",
@@ -333,13 +365,15 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "LedgerHashNotString",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP"
-                    },
+                },
                 "ledger_hash": 123
             })",
             "invalidParams",
@@ -347,14 +381,16 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "GetsPaysXRPWithIssuer",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
-                    }
+                }
             })",
             "srcIsrMalformed",
             "Unneeded field 'taker_pays.issuer' for XRP currency "
@@ -362,38 +398,45 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "PaysCurrencyWithXRPIssuer",
             R"({
-                "taker_pays" : {
-                    "currency" : "JPY"                    },
-                "taker_gets" : {
+                "taker_pays" : 
+                {
+                    "currency" : "JPY"                    
+                },
+                "taker_gets" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
-                    }
+                }
             })",
             "srcIsrMalformed",
             "Invalid field 'taker_pays.issuer', expected non-XRP issuer."},
         ParameterTestBundle{
             "GetsCurrencyWithXRPIssuer",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "XRP"                    
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "CNY"                    
-                    }            
+                }            
             })",
             "dstIsrMalformed",
             "Invalid field 'taker_gets.issuer', expected non-XRP issuer."},
         ParameterTestBundle{
             "GetsXRPWithIssuer",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "XRP",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
-                    }            
+                }            
             })",
             "dstIsrMalformed",
             "Unneeded field 'taker_gets.issuer' for XRP currency "
@@ -401,14 +444,16 @@ generateParameterBookOffersTestBundles()
         ParameterTestBundle{
             "BadMarket",
             R"({
-                "taker_pays" : {
+                "taker_pays" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                    
-                    },
-                "taker_gets" : {
+                },
+                "taker_gets" : 
+                {
                     "currency" : "CNY",
                     "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"                   
-                    }            
+                }            
             })",
             "badMarket",
             "badMarket"}};
@@ -560,10 +605,12 @@ generateNormalPathBookOffersTestBundles()
 
     auto const getsXRPPaysUSDInputJson = fmt::format(
         R"({{
-            "taker_gets": {{
+            "taker_gets": 
+            {{
                 "currency": "XRP"
             }},
-            "taker_pays": {{
+            "taker_pays": 
+            {{
                 "currency": "USD",
                 "issuer": "{}"
             }}
@@ -572,10 +619,12 @@ generateNormalPathBookOffersTestBundles()
 
     auto const paysXRPGetsUSDInputJson = fmt::format(
         R"({{
-            "taker_pays": {{
+            "taker_pays": 
+            {{
                 "currency": "XRP"
             }},
-            "taker_gets": {{
+            "taker_gets": 
+            {{
                 "currency": "USD",
                 "issuer": "{}"
             }}
@@ -708,7 +757,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000",
@@ -768,7 +818,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"43B83ADC452B85FCBADA6CAEAC5181C255A213630D58FFD455071AFD498D0000",
@@ -835,7 +886,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"{}",
@@ -902,7 +954,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"{}",
@@ -975,7 +1028,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"{}",
@@ -1059,7 +1113,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"{}",
@@ -1120,7 +1175,8 @@ generateNormalPathBookOffersTestBundles()
                 R"({{
                     "ledger_hash":"{}",
                     "ledger_index":300,
-                    "offers":[
+                    "offers":
+                    [
                         {{
                             "Account":"{}",
                             "BookDirectory":"{}",
@@ -1177,10 +1233,12 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaSequence)
     auto const static input = boost::json::parse(fmt::format(
         R"({{
             "ledger_index": 30,
-            "taker_gets": {{
+            "taker_gets": 
+            {{
                 "currency": "XRP"
             }},
-            "taker_pays": {{
+            "taker_pays": 
+            {{
                 "currency": "USD",
                 "issuer": "{}"
             }}
@@ -1209,10 +1267,12 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaHash)
     auto const static input = boost::json::parse(fmt::format(
         R"({{
             "ledger_hash": "{}",
-            "taker_gets": {{
+            "taker_gets": 
+            {{
                 "currency": "XRP"
             }},
-            "taker_pays": {{
+            "taker_pays": 
+            {{
                 "currency": "USD",
                 "issuer": "{}"
             }}
@@ -1305,10 +1365,12 @@ TEST_F(RPCBookOffersHandlerTest, Limit)
 
     auto const static input = boost::json::parse(fmt::format(
         R"({{
-            "taker_gets": {{
+            "taker_gets": 
+            {{
                 "currency": "XRP"
             }},
-            "taker_pays": {{
+            "taker_pays": 
+            {{
                 "currency": "USD",
                 "issuer": "{}"
             }},

--- a/unittests/rpc/handlers/BookOffersTest.cpp
+++ b/unittests/rpc/handlers/BookOffersTest.cpp
@@ -165,8 +165,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "malformedCurrency",
-            "malformedCurrency"},
+            "dstAmtMalformed",
+            "Destination amount/currency/issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysWrongCurrency",
             R"({
@@ -178,8 +178,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "malformedCurrency",
-            "malformedCurrency"},
+            "srcCurMalformed",
+            "Source currency is malformed."},
         ParameterTestBundle{
             "TakerGetsCurrencyNotString",
             R"({
@@ -191,8 +191,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "invalidParams",
-            "currencyNotString"},
+            "dstAmtMalformed",
+            "Destination amount/currency/issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysCurrencyNotString",
             R"({
@@ -204,8 +204,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "invalidParams",
-            "currencyNotString"},
+            "srcCurMalformed",
+            "Source currency is malformed."},
         ParameterTestBundle{
             "TakerGetsWrongIssuer",
             R"({
@@ -217,8 +217,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "invalidParams",
-            "Invalid field 'issuer', bad issuer."},
+            "dstIsrMalformed",
+            "Destination issuer is malformed."},
         ParameterTestBundle{
             "TakerPaysWrongIssuer",
             R"({
@@ -230,8 +230,8 @@ generateParameterBookOffersTestBundles()
                     "currency" : "XRP"
                     }
             })",
-            "invalidParams",
-            "Invalid field 'issuer', bad issuer."},
+            "srcIsrMalformed",
+            "Source issuer is malformed."},
         ParameterTestBundle{
             "InvalidTaker",
             R"({

--- a/unittests/rpc/handlers/LedgerEntryTest.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTest.cpp
@@ -746,7 +746,15 @@ generateTestValuesForNormalPathTest()
                 }})",
                 INDEX1),
             ripple::uint256{INDEX1},
-            CreateOfferLedgerObject(ACCOUNT, 100, 200, "USD", ACCOUNT2)},
+            CreateOfferLedgerObject(
+                ACCOUNT,
+                100,
+                200,
+                "USD",
+                "XRP",
+                ACCOUNT2,
+                ripple::toBase58(ripple::xrpAccount()),
+                INDEX1)},
         NormalPathTestBundle{
             "EscrowIndex",
             fmt::format(
@@ -879,7 +887,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2,
                 20,
                 INDEX1,
-                123)},
+                123,
+                0)},
         NormalPathTestBundle{
             "Ticket",
             fmt::format(
@@ -905,7 +914,15 @@ generateTestValuesForNormalPathTest()
                 }})",
                 ACCOUNT),
             ripple::keylet::offer(account1, 2).key,
-            CreateOfferLedgerObject(ACCOUNT, 100, 200, "USD", ACCOUNT2)}};
+            CreateOfferLedgerObject(
+                ACCOUNT,
+                100,
+                200,
+                "USD",
+                "XRP",
+                ACCOUNT2,
+                ripple::toBase58(ripple::xrpAccount()),
+                INDEX1)}};
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -152,6 +152,21 @@ struct SyncAsioContextTest : virtual public NoLoggerFixture
     {
     }
 
+    template <typename F>
+    void
+    runSpawn(F&& f)
+    {
+        auto called = false;
+        auto work = std::optional<boost::asio::io_context::work>{ctx};
+        boost::asio::spawn(ctx, [&](boost::asio::yield_context yield) {
+            f(yield);
+            called = true;
+            work.reset();
+        });
+        ctx.run();
+        ASSERT_TRUE(called);
+    }
+
 protected:
     boost::asio::io_context ctx;
 };

--- a/unittests/util/TestObject.cpp
+++ b/unittests/util/TestObject.cpp
@@ -101,7 +101,8 @@ CreateAccountRootObject(
     int balance,
     uint32_t ownerCount,
     std::string_view previousTxnID,
-    uint32_t previousTxnSeq)
+    uint32_t previousTxnSeq,
+    uint32_t transferRate)
 {
     ripple::STObject accountRoot(ripple::sfAccount);
     accountRoot.setFieldU16(ripple::sfLedgerEntryType, ripple::ltACCOUNT_ROOT);
@@ -115,6 +116,7 @@ CreateAccountRootObject(
     accountRoot.setFieldH256(
         ripple::sfPreviousTxnID, ripple::uint256{previousTxnID});
     accountRoot.setFieldU32(ripple::sfPreviousTxnLgrSeq, previousTxnSeq);
+    accountRoot.setFieldU32(ripple::sfTransferRate, transferRate);
     return accountRoot;
 }
 
@@ -303,11 +305,12 @@ CreateRippleStateLedgerObject(
     std::string_view highNodeAccountId,
     int highLimit,
     std::string_view previousTxnId,
-    uint32_t previousTxnSeq)
+    uint32_t previousTxnSeq,
+    uint32_t flag)
 {
     auto line = ripple::STObject(ripple::sfLedgerEntry);
     line.setFieldU16(ripple::sfLedgerEntryType, ripple::ltRIPPLE_STATE);
-    line.setFieldU32(ripple::sfFlags, 0);
+    line.setFieldU32(ripple::sfFlags, flag);
     line.setFieldAmount(
         ripple::sfBalance,
         ripple::STAmount(GetIssue(currency, issuerId), balance));
@@ -327,22 +330,27 @@ CreateOfferLedgerObject(
     std::string_view account,
     int takerGets,
     int takerPays,
-    std::string_view currency,
-    std::string_view issueId)
+    std::string_view getsCurrency,
+    std::string_view paysCurrency,
+    std::string_view getsIssueId,
+    std::string_view paysIssueId,
+    std::string_view dirId)
 {
     ripple::STObject offer(ripple::sfLedgerEntry);
     offer.setFieldU16(ripple::sfLedgerEntryType, ripple::ltOFFER);
     offer.setAccountID(ripple::sfAccount, GetAccountIDWithString(account));
     offer.setFieldU32(ripple::sfSequence, 0);
     offer.setFieldU32(ripple::sfFlags, 0);
-    ripple::Issue issue1 = GetIssue(currency, issueId);
+    ripple::Issue issue1 = GetIssue(getsCurrency, getsIssueId);
     offer.setFieldAmount(
         ripple::sfTakerGets, ripple::STAmount(issue1, takerGets));
+    ripple::Issue issue2 = GetIssue(paysCurrency, paysIssueId);
     offer.setFieldAmount(
-        ripple::sfTakerPays, ripple::STAmount(takerPays, false));
+        ripple::sfTakerPays, ripple::STAmount(issue2, takerPays));
     offer.setFieldH256(ripple::sfBookDirectory, ripple::uint256{});
     offer.setFieldU64(ripple::sfBookNode, 0);
     offer.setFieldU64(ripple::sfOwnerNode, 0);
+    offer.setFieldH256(ripple::sfBookDirectory, ripple::uint256{dirId});
     offer.setFieldH256(ripple::sfPreviousTxnID, ripple::uint256{});
     offer.setFieldU32(ripple::sfPreviousTxnLgrSeq, 0);
     return offer;

--- a/unittests/util/TestObject.h
+++ b/unittests/util/TestObject.h
@@ -79,7 +79,8 @@ CreateAccountRootObject(
     int balance,
     uint32_t ownerCount,
     std::string_view previousTxnID,
-    uint32_t previousTxnSeq);
+    uint32_t previousTxnSeq,
+    uint32_t transferRate = 0);
 
 /*
  * Create a createoffer treansaction
@@ -168,15 +169,19 @@ CreateRippleStateLedgerObject(
     std::string_view highNodeAccountId,
     int highLimit,
     std::string_view previousTxnId,
-    uint32_t previousTxnSeq);
+    uint32_t previousTxnSeq,
+    uint32_t flag = 0);
 
 ripple::STObject
 CreateOfferLedgerObject(
     std::string_view account,
     int takerGets,
     int takerPays,
-    std::string_view currency,
-    std::string_view issueId);
+    std::string_view getsCurrency,
+    std::string_view payssCurrency,
+    std::string_view getsIssueId,
+    std::string_view paysIssueId,
+    std::string_view bookDirId);
 
 ripple::STObject
 CreateTicketLedgerObject(std::string_view rootIndex, uint32_t sequence);


### PR DESCRIPTION
1 Implement book_offers in new RPC framework
This implementation is same as the previous book_offers. Both clio and rippled list all the offers regardless the funding status, which mismatches the document.
An open issue : https://github.com/XRPLF/xrpl-dev-portal/issues/1818
2 Remove unused parameters
3 Add IssuerValidator


