### PR TITLE
Fix compile error on clang14.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,8 @@ if(PACKAGING)
   add_definitions(-DPKG=1)
 endif()
 
-#clang14.0.3 removed std::result_of but boost 1.75 is still using it.
-if("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
-  add_definitions(-DBOOST_ASIO_HAS_STD_INVOKE_RESULT=1)
-endif()
+#c++20 removed std::result_of but boost 1.75 is still using it.
+add_definitions(-DBOOST_ASIO_HAS_STD_INVOKE_RESULT=1)
 
 add_library(clio)
 target_compile_features(clio PUBLIC cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if(PACKAGING)
   add_definitions(-DPKG=1)
 endif()
 
+#clang14.0.3 removed std::result_of but boost 1.75 is still using it.
+if("${CMAKE_C_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+  add_definitions(-DBOOST_ASIO_HAS_STD_INVOKE_RESULT=1)
+endif()
+
 add_library(clio)
 target_compile_features(clio PUBLIC cxx_std_20)
 target_include_directories(clio PUBLIC src)

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -111,7 +111,7 @@ synchronous(F&& f)
      * R is the currently executing coroutine that is about to get passed.
      * If corountine types do not match, the current one's type is stored.
      */
-    using R = typename std::result_of<F(boost::asio::yield_context&)>::type;
+    using R = typename boost::result_of<F(boost::asio::yield_context&)>::type;
     if constexpr (!std::is_same<R, void>::value)
     {
         /**

--- a/src/rpc/RPC.cpp
+++ b/src/rpc/RPC.cpp
@@ -178,7 +178,7 @@ public:
     {
         for (auto const& handler : handlers)
         {
-            handlerMap_[handler.method] = move(handler);
+            handlerMap_[handler.method] = std::move(handler);
         }
     }
 

--- a/unittests/Backend.cpp
+++ b/unittests/Backend.cpp
@@ -988,7 +988,6 @@ TEST_F(BackendTest, Basic)
 
                     Backend::LedgerPage page;
                     std::vector<Backend::LedgerObject> retObjs;
-                    size_t numLoops = 0;
                     do
                     {
                         uint32_t limit = 10;
@@ -1000,7 +999,6 @@ TEST_F(BackendTest, Basic)
                             retObjs.end(),
                             page.objects.begin(),
                             page.objects.end());
-                        ++numLoops;
                     } while (page.cursor);
 
                     for (auto obj : objs)
@@ -2343,7 +2341,6 @@ TEST_F(BackendTest, cacheIntegration)
                     }
                     Backend::LedgerPage page;
                     std::vector<Backend::LedgerObject> retObjs;
-                    size_t numLoops = 0;
                     do
                     {
                         uint32_t limit = 10;
@@ -2355,7 +2352,6 @@ TEST_F(BackendTest, cacheIntegration)
                             retObjs.end(),
                             page.objects.begin(),
                             page.objects.end());
-                        ++numLoops;
                     } while (page.cursor);
                     for (auto obj : objs)
                     {

--- a/unittests/backend/cassandra/BackendTests.cpp
+++ b/unittests/backend/cassandra/BackendTests.cpp
@@ -893,7 +893,6 @@ TEST_F(BackendCassandraTest, Basic)
 
                     Backend::LedgerPage page;
                     std::vector<Backend::LedgerObject> retObjs;
-                    size_t numLoops = 0;
                     do
                     {
                         uint32_t limit = 10;
@@ -903,7 +902,6 @@ TEST_F(BackendCassandraTest, Basic)
                             retObjs.end(),
                             page.objects.begin(),
                             page.objects.end());
-                        ++numLoops;
                     } while (page.cursor);
 
                     for (auto obj : objs)
@@ -1544,7 +1542,6 @@ TEST_F(BackendCassandraTest, CacheIntegration)
                 }
                 Backend::LedgerPage page;
                 std::vector<Backend::LedgerObject> retObjs;
-                size_t numLoops = 0;
                 do
                 {
                     uint32_t limit = 10;
@@ -1554,7 +1551,6 @@ TEST_F(BackendCassandraTest, CacheIntegration)
                         retObjs.end(),
                         page.objects.begin(),
                         page.objects.end());
-                    ++numLoops;
                 } while (page.cursor);
                 for (auto obj : objs)
                 {


### PR DESCRIPTION
-std::result_of has been removed from this version. 
Add DBOOST_ASIO_HAS_STD_INVOKE_RESULT to force boost not use it

-move() throw "unqualified call to 'std::move' " error

- new version clang finds more static issue.