### PR TITLE
add default ordering to issuer_nf_tokens_v2

### DIFF
--- a/src/backend/CassandraBackend.cpp
+++ b/src/backend/CassandraBackend.cpp
@@ -1314,7 +1314,9 @@ CassandraBackend::open(bool readOnly)
               << "    taxon bigint,"
               << "    token_id blob,"
               << "    PRIMARY KEY (issuer, taxon, token_id)"
-              << "  )";
+              << "  )"
+              << "  WITH CLUSTERING ORDER BY (taxon ASC, token_id ASC)"
+              << "    AND default_time_to_live = " << ttl;
         if (!executeSimpleStatement(query.str()))
             continue;
 

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -172,7 +172,7 @@ CREATE TABLE clio.issuer_nf_tokens_v2 (
 	taxon bigint,      # The NFT's token taxon
 	token_id blob,     # The NFT's ID
 	PRIMARY KEY (issuer, taxon, token_id)
-)
+) WITH CLUSTERING ORDER BY (taxon ASC, token_id ASC) ...
 ```
 This table indexes token IDs against their issuer and issuer/taxon
 combination. This is useful for determining all the NFTs a specific account

--- a/src/backend/cassandra/Schema.h
+++ b/src/backend/cassandra/Schema.h
@@ -214,15 +214,15 @@ public:
 
         statements.emplace_back(fmt::format(
             R"(
-            CREATE TABLE IF NOT EXISTS {}
-                ( 
-                    issuer blob,
-                    taxon bigint,
+           CREATE TABLE IF NOT EXISTS {}
+                  ( 
+                      issuer blob,
+                       taxon bigint,
                     token_id blob,
-                    PRIMARY KEY (issuer, taxon, token_id)
-                ) 
-                WITH CLUSTERING ORDER BY (taxon ASC, token_id ASC)
-                    AND default_time_to_live = {}
+                     PRIMARY KEY (issuer, taxon, token_id)
+                  ) 
+             WITH CLUSTERING ORDER BY (taxon ASC, token_id ASC)
+              AND default_time_to_live = {}
             )",
             qualifiedTableName(settingsProvider_.get(), "issuer_nf_tokens_v2"),
             settingsProvider_.get().getTtl()));

--- a/src/backend/cassandra/Schema.h
+++ b/src/backend/cassandra/Schema.h
@@ -214,15 +214,18 @@ public:
 
         statements.emplace_back(fmt::format(
             R"(
-           CREATE TABLE IF NOT EXISTS {}
-                  ( 
-                      issuer blob,
-                       taxon bigint,
+            CREATE TABLE IF NOT EXISTS {}
+                ( 
+                    issuer blob,
+                    taxon bigint,
                     token_id blob,
-                     PRIMARY KEY (issuer, taxon, token_id)
-                  ) 
+                    PRIMARY KEY (issuer, taxon, token_id)
+                ) 
+                WITH CLUSTERING ORDER BY (taxon ASC, token_id ASC)
+                    AND default_time_to_live = {}
             )",
-            qualifiedTableName(settingsProvider_.get(), "issuer_nf_tokens_v2")));
+            qualifiedTableName(settingsProvider_.get(), "issuer_nf_tokens_v2"),
+            settingsProvider_.get().getTtl()));
 
         statements.emplace_back(fmt::format(
             R"(


### PR DESCRIPTION
title says it all. adding this ordering shouldn't actually be strictly necessary since I've just specified what is the default ordering anyway (which is what we want). however, I think adding it adds to the clarity of what we're doing here.

Fix #589 