### PR TITLE
Fix gmock warning of uninterested function 

### DIFF
--- a/unittests/rpc/handlers/UnsubscribeTest.cpp
+++ b/unittests/rpc/handlers/UnsubscribeTest.cpp
@@ -512,6 +512,7 @@ TEST_F(RPCUnsubscribeTest, Streams)
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubValidation).Times(1);
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubManifest).Times(1);
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubBookChanges).Times(1);
+    EXPECT_CALL(*rawSubscriptionManagerPtr, unsubProposedTransactions).Times(1);
 
     runSpawn([&, this](auto& yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};


### PR DESCRIPTION
Forgot to list all the expect call.
Add this to suppress the warning "Uninteresting mock function call"
 