### PR TITLE
Raise error when marker's index not in marker's page

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -706,8 +706,8 @@ traverseOwnedNodes(
         if (auto const& indexes = sle.getFieldV256(ripple::sfIndexes);
             std::find(std::begin(indexes), std::end(indexes), hexMarker) == std::end(indexes))
         {
-            // result in empty dataset
-            return AccountCursor({beast::zero, 0});
+            // the index specified by marker is not in the page specified by marker
+            return Status(ripple::rpcINVALID_PARAMS, "Invalid marker");
         }
 
         currentIndex = hintIndex;

--- a/unittests/rpc/RPCHelpersTest.cpp
+++ b/unittests/rpc/RPCHelpersTest.cpp
@@ -311,7 +311,7 @@ TEST_F(RPCHelpersTest, TraverseOwnedNodesWithMarkerReturnSamePageMarker)
 }
 
 // Send a valid marker, but marker contain an unexisting index
-// return empty
+// return invalid params error
 TEST_F(RPCHelpersTest, TraverseOwnedNodesWithUnexistingIndexMarker)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
@@ -345,13 +345,10 @@ TEST_F(RPCHelpersTest, TraverseOwnedNodesWithUnexistingIndexMarker)
         auto count = 0;
         auto ret = traverseOwnedNodes(
             *mockBackendPtr, account, 9, limit, fmt::format("{},{}", INDEX2, pageNum), yield, [&](auto) { count++; });
-        auto cursor = std::get_if<AccountCursor>(&ret);
-        EXPECT_TRUE(cursor != nullptr);
-        EXPECT_EQ(count, 0);
-        EXPECT_EQ(
-            cursor->toString(),
-            "00000000000000000000000000000000000000000000000000000000000000"
-            "00,0");
+        auto status = std::get_if<Status>(&ret);
+        EXPECT_TRUE(status != nullptr);
+        EXPECT_EQ(*status, ripple::rpcINVALID_PARAMS);
+        EXPECT_EQ(status->message, "Invalid marker");
     });
     ctx.run();
 }


### PR DESCRIPTION
Marker is composed by index and page. 

The next request will firstly find the account dir node specified by page and start to traverse from the marker's index. 
If the marker's index is not in the marker's page, previous clio will just return empty set.

This PR is to fix #609 #610 #611  I am okay to either keep this or fix this. @godexsoft WDYT 
