### PR TITLE
Overflow response change 

### DIFF
--- a/src/rpc/handlers/GatewayBalances.cpp
+++ b/src/rpc/handlers/GatewayBalances.cpp
@@ -99,7 +99,7 @@ GatewayBalancesHandler::process(GatewayBalancesHandler::Input input, Context con
                     }
                     catch (std::runtime_error const& e)
                     {
-                        output.overflow = true;
+                        bal = ripple::STAmount(bal.issue(), ripple::STAmount::cMaxValue, ripple::STAmount::cMaxOffset);
                     }
                 }
             }

--- a/unittests/rpc/handlers/GatewayBalancesTest.cpp
+++ b/unittests/rpc/handlers/GatewayBalancesTest.cpp
@@ -517,10 +517,9 @@ generateNormalPathTestBundles()
             fmt::format(
                 R"({{
                     "obligations":{{
-                        "JPY":"9922966390934554e80"
+                        "JPY":"9999999999999999e80"
                     }},
                     "account":"{}",
-                    "overflow":true,
                     "ledger_index":300,
                     "ledger_hash":"4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652"
                 }})",


### PR DESCRIPTION
Previously, we handled the obligation overflow case refer to this https://github.com/XRPLF/rippled/pull/4355/commits/0d0464fdb98952d7e5fbfbdc815e4ae996d6d02f,
which changed afterwards.
This PR is to sync the behavior, fix #652 

![Screenshot 2023-05-31 at 10 35 26](https://github.com/XRPLF/clio/assets/120398799/230c273e-0c91-488a-9a97-bf83c5e06a9a)

 