### PR TITLE
invalid hot wallet error

### DIFF
--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -77,7 +77,7 @@ getErrorInfo(ClioError code)
         {ClioError::rpcMALFORMED_REQUEST, "malformedRequest", "Malformed request."},
         {ClioError::rpcMALFORMED_OWNER, "malformedOwner", "Malformed owner."},
         {ClioError::rpcMALFORMED_ADDRESS, "malformedAddress", "Malformed address."},
-    };
+        {ClioError::rpcINVALID_HOT_WALLET, "invalidHotWallet", "Invalid hot wallet."}};
 
     auto matchByCode = [code](auto const& info) { return info.code == code; };
     if (auto it = find_if(begin(infos), end(infos), matchByCode); it != end(infos))

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -38,6 +38,7 @@ enum class ClioError {
     rpcMALFORMED_REQUEST = 5001,
     rpcMALFORMED_OWNER = 5002,
     rpcMALFORMED_ADDRESS = 5003,
+    rpcINVALID_HOT_WALLET = 5004,
 };
 
 /**

--- a/src/rpc/handlers/GatewayBalances.cpp
+++ b/src/rpc/handlers/GatewayBalances.cpp
@@ -123,7 +123,7 @@ GatewayBalancesHandler::process(GatewayBalancesHandler::Input input, Context con
 
     auto inHotbalances = [&](auto const& hw) { return output.hotBalances.contains(hw); };
     if (not std::all_of(input.hotWallets.begin(), input.hotWallets.end(), inHotbalances))
-        return Error{Status{RippledError::rpcINVALID_PARAMS, "invalidHotWallet"}};
+        return Error{Status{ClioError::rpcINVALID_HOT_WALLET}};
 
     output.accountID = input.account;
     output.ledgerHash = ripple::strHex(lgrInfo.hash);

--- a/unittests/rpc/handlers/GatewayBalancesTest.cpp
+++ b/unittests/rpc/handlers/GatewayBalancesTest.cpp
@@ -337,8 +337,8 @@ TEST_F(RPCGatewayBalancesHandlerTest, InvalidHotWallet)
             Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-        EXPECT_EQ(err.at("error_message").as_string(), "invalidHotWallet");
+        EXPECT_EQ(err.at("error").as_string(), "invalidHotWallet");
+        EXPECT_EQ(err.at("error_message").as_string(), "Invalid hot wallet.");
     });
 }
 


### PR DESCRIPTION
Instead of return "invalidParam" error_code + "invalidHotWallet" error_message, we shall return "invalidHotWallet" as error_code. Rippled does not have such error_code, it just assigns the json directly. ![Screenshot 2023-05-31 at 10 23 27](https://github.com/XRPLF/clio/assets/120398799/e4d04f9a-07ee-44f1-9dcc-142499d2bf5b)
Clio creates the "invalidHotWallet" in this PR, Fix #654 

