### PR TITLE
Implement extractor tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ if(BUILD_TESTS)
     unittests/util/TestObject.cpp
     # ETL
     unittests/etl/ExtractionDataPipeTest.cpp
+    unittests/etl/ExtractorTest.cpp
     # RPC
     unittests/rpc/ErrorTests.cpp
     unittests/rpc/BaseTests.cpp

--- a/src/etl/impl/Extractor.h
+++ b/src/etl/impl/Extractor.h
@@ -24,8 +24,6 @@
 #include <util/Profiler.h>
 
 #include <ripple/beast/core/CurrentThreadName.h>
-#include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
-#include <grpcpp/grpcpp.h>
 
 #include <chrono>
 #include <mutex>

--- a/src/etl/impl/Extractor.h
+++ b/src/etl/impl/Extractor.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <etl/SystemState.h>
 #include <log/Logger.h>
 #include <util/Profiler.h>
 
@@ -89,11 +90,7 @@ private:
         double totalTime = 0.0;
         auto currentSequence = startSequence_;
 
-        // Two stopping conditions:
-        // - if there is a write conflict in the load thread, the ETL mechanism should stop.
-        // - if the entire server is shutting down - this can be detected in a variety of ways.
-        while ((not finishSequence_ || currentSequence <= *finishSequence_) && not state_.get().writeConflict &&
-               not isStopping() && networkValidatedLedgers_->waitUntilValidatedByNetwork(currentSequence))
+        while (!shouldFinish(currentSequence) && networkValidatedLedgers_->waitUntilValidatedByNetwork(currentSequence))
         {
             auto [fetchResponse, time] = util::timed<std::chrono::duration<double>>(
                 [this, currentSequence]() { return ledgerFetcher_.get().fetchDataAndDiff(currentSequence); });
@@ -101,11 +98,12 @@ private:
 
             // if the fetch is unsuccessful, stop. fetchLedger only returns false if the server is shutting down, or if
             // the ledger was found in the database (which means another process already wrote the ledger that this
-            // process was trying to extract; this is a form of a write conflict). Otherwise, fetchLedgerDataAndDiff
-            // will keep trying to fetch the specified ledger until successful.
+            // process was trying to extract; this is a form of a write conflict).
+            // Otherwise, fetchDataAndDiff will keep trying to fetch the specified ledger until successful.
             if (!fetchResponse)
                 break;
 
+            // TODO: extract this part into a strategy perhaps
             auto const tps = fetchResponse->transactions_list().transactions_size() / time;
             log_.info() << "Extract phase time = " << time << "; Extract phase tps = " << tps
                         << "; Avg extract time = " << totalTime / (currentSequence - startSequence_ + 1)
@@ -113,9 +111,6 @@ private:
 
             pipe_.get().push(currentSequence, std::move(fetchResponse));
             currentSequence += pipe_.get().getStride();
-
-            if (finishSequence_ && currentSequence > *finishSequence_)
-                break;
         }
 
         pipe_.get().finish(startSequence_);
@@ -125,6 +120,22 @@ private:
     isStopping() const
     {
         return state_.get().isStopping;
+    }
+
+    bool
+    hasWriteConflict() const
+    {
+        return state_.get().writeConflict;
+    }
+
+    bool
+    shouldFinish(uint32_t seq) const
+    {
+        // Stopping conditions:
+        // - if there is a write conflict in the load thread, the ETL mechanism should stop.
+        // - if the entire server is shutting down - this can be detected in a variety of ways.
+        // - when the given sequence is past the finishSequence in case one is specified
+        return hasWriteConflict() || isStopping() || (finishSequence_ && seq > *finishSequence_);
     }
 };
 

--- a/unittests/etl/ExtractorTest.cpp
+++ b/unittests/etl/ExtractorTest.cpp
@@ -82,7 +82,7 @@ TEST_F(ETLExtractorTest, StopsWhenCurrentSequenceExceedsFinishSequence)
     EXPECT_CALL(dataPipe_, push).Times(3);
     EXPECT_CALL(dataPipe_, finish(0)).Times(1);
 
-    // run the thread. expected to invoke for seq 0, 4, 8 and finally stop as seq will be greater than finishing seq
+    // expected to invoke for seq 0, 4, 8 and finally stop as seq will be greater than finishing seq
     extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 11, state_);
 }
 
@@ -118,7 +118,7 @@ TEST_F(ETLExtractorTest, StopsIfFetchIsUnsuccessful)
     EXPECT_CALL(dataPipe_, finish(0)).Times(1);
 
     // we break immediately because fetchDataAndDiff returns nullopt
-    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 1, state_);
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 64, state_);
 }
 
 TEST_F(ETLExtractorTest, StopsIfWaitingUntilValidatedByNetworkTimesOut)
@@ -153,7 +153,7 @@ TEST_F(ETLExtractorTest, SendsCorrectResponseToDataPipe)
     EXPECT_CALL(dataPipe_, push).Times(1).WillOnce(SaveArg<1>(&optionalResponse));
     EXPECT_CALL(dataPipe_, finish(0)).Times(1);
 
-    // run the thread. expect to finish after just one response due to finishSequence set to 1
+    // expect to finish after just one response due to finishSequence set to 1
     extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 1, state_);
     extractor_->waitTillFinished();  // this is what clio does too. waiting for the thread to join
 

--- a/unittests/etl/ExtractorTest.cpp
+++ b/unittests/etl/ExtractorTest.cpp
@@ -1,0 +1,170 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <etl/impl/Extractor.h>
+#include <util/FakeFetchResponse.h>
+#include <util/Fixtures.h>
+#include <util/MockExtractionDataPipe.h>
+#include <util/MockLedgerFetcher.h>
+#include <util/MockNetworkValidatedLedgers.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace testing;
+
+class ETLExtractorTest : public NoLoggerFixture
+{
+protected:
+    using DataType = FakeFetchResponse;
+    using ExtractionDataPipeType = MockExtractionDataPipe<DataType>;
+    using LedgerFetcherType = MockLedgerFetcher<DataType>;
+    using ExtractorType =
+        clio::detail::Extractor<ExtractionDataPipeType, MockNetworkValidatedLedgers, LedgerFetcherType>;
+
+    ExtractionDataPipeType dataPipe_;
+    std::shared_ptr<MockNetworkValidatedLedgers> networkValidatedLedgers_ =
+        std::make_shared<MockNetworkValidatedLedgers>();
+    LedgerFetcherType ledgerFetcher_;
+    SystemState state_;
+
+    std::unique_ptr<ExtractorType> extractor_;
+
+public:
+    void
+    SetUp() override
+    {
+        NoLoggerFixture::SetUp();
+        state_.isStopping = false;
+        state_.writeConflict = false;
+        state_.isReadOnly = false;
+        state_.isWriting = false;
+    }
+
+    void
+    TearDown() override
+    {
+        extractor_.reset();
+        NoLoggerFixture::TearDown();
+    }
+};
+
+TEST_F(ETLExtractorTest, StopsWhenCurrentSequenceExceedsFinishSequence)
+{
+    auto const rawNetworkValidatedLedgersPtr =
+        static_cast<MockNetworkValidatedLedgers*>(networkValidatedLedgers_.get());
+
+    ON_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).WillByDefault(Return(true));
+    EXPECT_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).Times(3);
+    ON_CALL(dataPipe_, getStride).WillByDefault(Return(4));
+    EXPECT_CALL(dataPipe_, getStride).Times(3);
+
+    auto response = FakeFetchResponse{};
+    ON_CALL(ledgerFetcher_, fetchDataAndDiff(_)).WillByDefault(Return(response));
+    EXPECT_CALL(ledgerFetcher_, fetchDataAndDiff).Times(3);
+    EXPECT_CALL(dataPipe_, push).Times(3);
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+
+    // run the thread. expected to invoke for seq 0, 4, 8 and finally stop as seq will be greater than finishing seq
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 11, state_);
+}
+
+TEST_F(ETLExtractorTest, StopsOnWriteConflict)
+{
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+    state_.writeConflict = true;
+
+    // despite finish sequence being far ahead, we set writeConflict and so exit the loop immediately
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 64, state_);
+}
+
+TEST_F(ETLExtractorTest, StopsOnServerShutdown)
+{
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+    state_.isStopping = true;
+
+    // despite finish sequence being far ahead, we set isStopping and so exit the loop immediately
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 64, state_);
+}
+
+// stop extractor thread if fetcheResponse is empty
+TEST_F(ETLExtractorTest, StopsIfFetchIsUnsuccessful)
+{
+    auto const rawNetworkValidatedLedgersPtr =
+        static_cast<MockNetworkValidatedLedgers*>(networkValidatedLedgers_.get());
+
+    ON_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).WillByDefault(Return(true));
+    EXPECT_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).Times(1);
+
+    ON_CALL(ledgerFetcher_, fetchDataAndDiff(_)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(ledgerFetcher_, fetchDataAndDiff).Times(1);
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+
+    // we break immediately because fetchDataAndDiff returns nullopt
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 1, state_);
+}
+
+TEST_F(ETLExtractorTest, StopsIfWaitingUntilValidatedByNetworkTimesOut)
+{
+    auto const rawNetworkValidatedLedgersPtr =
+        static_cast<MockNetworkValidatedLedgers*>(networkValidatedLedgers_.get());
+
+    // note that in actual clio code we don't return false unless a timeout is specified and exceeded
+    ON_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).WillByDefault(Return(false));
+    EXPECT_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).Times(1);
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+
+    // we emulate waitUntilValidatedByNetwork timing out which would lead to shutdown of the extractor thread
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 64, state_);
+}
+
+TEST_F(ETLExtractorTest, SendsCorrectResponseToDataPipe)
+{
+    auto const rawNetworkValidatedLedgersPtr =
+        static_cast<MockNetworkValidatedLedgers*>(networkValidatedLedgers_.get());
+
+    ON_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).WillByDefault(Return(true));
+    EXPECT_CALL(*rawNetworkValidatedLedgersPtr, waitUntilValidatedByNetwork).Times(1);
+    ON_CALL(dataPipe_, getStride).WillByDefault(Return(4));
+    EXPECT_CALL(dataPipe_, getStride).Times(1);
+
+    auto response = FakeFetchResponse{1234};
+    auto optionalResponse = std::optional<FakeFetchResponse>{};
+
+    ON_CALL(ledgerFetcher_, fetchDataAndDiff(_)).WillByDefault(Return(response));
+    EXPECT_CALL(ledgerFetcher_, fetchDataAndDiff).Times(1);
+    EXPECT_CALL(dataPipe_, push).Times(1).WillOnce(SaveArg<1>(&optionalResponse));
+    EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+
+    // run the thread. expect to finish after just one response due to finishSequence set to 1
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 0, 1, state_);
+    extractor_->waitTillFinished();  // this is what clio does too. waiting for the thread to join
+
+    EXPECT_TRUE(optionalResponse.has_value());
+    EXPECT_EQ(optionalResponse.value(), response);
+}
+
+TEST_F(ETLExtractorTest, CallsPipeFinishWithInitialSequenceAtExit)
+{
+    EXPECT_CALL(dataPipe_, finish(123)).Times(1);
+    state_.isStopping = true;
+
+    extractor_ = std::make_unique<ExtractorType>(dataPipe_, networkValidatedLedgers_, ledgerFetcher_, 123, 234, state_);
+}

--- a/unittests/util/FakeFetchResponse.h
+++ b/unittests/util/FakeFetchResponse.h
@@ -1,0 +1,55 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <cstddef>
+
+class FakeTransactionsList
+{
+    std::size_t size_ = 0;
+
+public:
+    std::size_t
+    transactions_size()
+    {
+        return size_;
+    }
+};
+
+struct FakeFetchResponse
+{
+    uint32_t id;
+
+    FakeFetchResponse(uint32_t id = 0) : id{id}
+    {
+    }
+
+    bool
+    operator==(FakeFetchResponse const& other) const
+    {
+        return other.id == id;
+    }
+
+    FakeTransactionsList
+    transactions_list() const
+    {
+        return {};
+    }
+};

--- a/unittests/util/MockBackend.h
+++ b/unittests/util/MockBackend.h
@@ -24,12 +24,12 @@
 
 using namespace Backend;
 
-class MockBackend : public BackendInterface
+struct MockBackend : public BackendInterface
 {
-public:
     MockBackend(clio::Config)
     {
     }
+
     MOCK_METHOD(
         std::optional<ripple::LedgerInfo>,
         fetchLedgerBySequence,

--- a/unittests/util/MockCounters.h
+++ b/unittests/util/MockCounters.h
@@ -24,18 +24,10 @@
 
 #include <chrono>
 
-class MockCounters
+struct MockCounters
 {
-public:
-    MockCounters()
-    {
-    }
-
     MOCK_METHOD(void, rpcErrored, (std::string const&), ());
-
     MOCK_METHOD(void, rpcComplete, (std::string const&, std::chrono::microseconds const&), ());
-
     MOCK_METHOD(void, rpcForwarded, (std::string const&), ());
-
     MOCK_METHOD(boost::json::object, report, (), (const));
 };

--- a/unittests/util/MockETLService.h
+++ b/unittests/util/MockETLService.h
@@ -24,18 +24,10 @@
 
 #include <chrono>
 
-class MockETLService
+struct MockETLService
 {
-public:
-    MockETLService()
-    {
-    }
-
     MOCK_METHOD(boost::json::object, getInfo, (), (const));
-
     MOCK_METHOD(std::chrono::time_point<std::chrono::system_clock>, getLastPublish, (), (const));
-
     MOCK_METHOD(std::uint32_t, lastPublishAgeSeconds, (), (const));
-
     MOCK_METHOD(std::uint32_t, lastCloseAgeSeconds, (), (const));
 };

--- a/unittests/util/MockExtractionDataPipe.h
+++ b/unittests/util/MockExtractionDataPipe.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+
+template <typename DataType>
+class MockExtractionDataPipe
+{
+public:
+    MOCK_METHOD(void, push, (uint32_t, std::optional<DataType>&&), ());
+
+    MOCK_METHOD(std::optional<DataType>, popNext, (uint32_t), ());
+
+    MOCK_METHOD(uint32_t, getStride, (), (const));
+
+    MOCK_METHOD(void, finish, (uint32_t), ());
+
+    MOCK_METHOD(void, cleanup, (), ());
+};

--- a/unittests/util/MockExtractionDataPipe.h
+++ b/unittests/util/MockExtractionDataPipe.h
@@ -24,16 +24,11 @@
 #include <chrono>
 
 template <typename DataType>
-class MockExtractionDataPipe
+struct MockExtractionDataPipe
 {
-public:
     MOCK_METHOD(void, push, (uint32_t, std::optional<DataType>&&), ());
-
     MOCK_METHOD(std::optional<DataType>, popNext, (uint32_t), ());
-
     MOCK_METHOD(uint32_t, getStride, (), (const));
-
     MOCK_METHOD(void, finish, (uint32_t), ());
-
     MOCK_METHOD(void, cleanup, (), ());
 };

--- a/unittests/util/MockLedgerFetcher.h
+++ b/unittests/util/MockLedgerFetcher.h
@@ -24,10 +24,8 @@
 #include <optional>
 
 template <typename DataType>
-class MockLedgerFetcher
+struct MockLedgerFetcher
 {
-public:
     MOCK_METHOD(std::optional<DataType>, fetchData, (uint32_t), ());
-
     MOCK_METHOD(std::optional<DataType>, fetchDataAndDiff, (uint32_t), ());
 };

--- a/unittests/util/MockLedgerFetcher.h
+++ b/unittests/util/MockLedgerFetcher.h
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <optional>
+
+template <typename DataType>
+class MockLedgerFetcher
+{
+public:
+    MOCK_METHOD(std::optional<DataType>, fetchData, (uint32_t), ());
+
+    MOCK_METHOD(std::optional<DataType>, fetchDataAndDiff, (uint32_t), ());
+};

--- a/unittests/util/MockLoadBalancer.h
+++ b/unittests/util/MockLoadBalancer.h
@@ -30,21 +30,12 @@
 
 #include <optional>
 
-class MockLoadBalancer
+struct MockLoadBalancer
 {
-public:
-    MockLoadBalancer()
-    {
-    }
-
     MOCK_METHOD(void, loadInitialLedger, (std::uint32_t, bool), ());
-
     MOCK_METHOD(std::optional<org::xrpl::rpc::v1::GetLedgerResponse>, fetchLedger, (uint32_t, bool, bool), ());
-
     MOCK_METHOD(bool, shouldPropagateTxnStream, (Source*), (const));
-
     MOCK_METHOD(boost::json::value, toJson, (), (const));
-
     MOCK_METHOD(
         std::optional<boost::json::object>,
         forwardToRippled,

--- a/unittests/util/MockNetworkValidatedLedgers.h
+++ b/unittests/util/MockNetworkValidatedLedgers.h
@@ -23,14 +23,9 @@
 
 #include <optional>
 
-class MockNetworkValidatedLedgers
+struct MockNetworkValidatedLedgers
 {
-public:
     MOCK_METHOD(void, push, (uint32_t), ());
-
     MOCK_METHOD(std::optional<uint32_t>, getMostRecent, (), ());
-
-    //    MOCK_METHOD(bool, waitUntilValidatedByNetwork, (uint32_t, std::optional<uint32_t>), ());
-
     MOCK_METHOD(bool, waitUntilValidatedByNetwork, (uint32_t), ());
 };

--- a/unittests/util/MockNetworkValidatedLedgers.h
+++ b/unittests/util/MockNetworkValidatedLedgers.h
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <optional>
+
+class MockNetworkValidatedLedgers
+{
+public:
+    MOCK_METHOD(void, push, (uint32_t), ());
+
+    MOCK_METHOD(std::optional<uint32_t>, getMostRecent, (), ());
+
+    //    MOCK_METHOD(bool, waitUntilValidatedByNetwork, (uint32_t, std::optional<uint32_t>), ());
+
+    MOCK_METHOD(bool, waitUntilValidatedByNetwork, (uint32_t), ());
+};

--- a/unittests/util/MockSubscriptionManager.h
+++ b/unittests/util/MockSubscriptionManager.h
@@ -26,13 +26,9 @@
 #include <boost/json.hpp>
 #include <gmock/gmock.h>
 
-class MockSubscriptionManager
+struct MockSubscriptionManager
 {
-public:
     using session_ptr = std::shared_ptr<WsBase>;
-    MockSubscriptionManager()
-    {
-    }
 
     MOCK_METHOD(boost::json::object, subLedger, (boost::asio::yield_context&, session_ptr), ());
 

--- a/unittests/util/MockSubscriptionManager.h
+++ b/unittests/util/MockSubscriptionManager.h
@@ -26,8 +26,6 @@
 #include <boost/json.hpp>
 #include <gmock/gmock.h>
 
-#include <optional>
-
 class MockSubscriptionManager
 {
 public:


### PR DESCRIPTION
Implements unit tests for ETL's Extractor component.
This is part of a bigger refactoring effort but can be reviewed and merged separately.