### PR TITLE
Fix marker issue

### DIFF
--- a/src/backend/cassandra/Schema.h
+++ b/src/backend/cassandra/Schema.h
@@ -528,7 +528,7 @@ public:
                 SELECT hash, seq_idx 
                   FROM {}               
                  WHERE account = ?
-                   AND seq_idx <= ?
+                   AND seq_idx < ?
                  LIMIT ?
                 )",
                 qualifiedTableName(settingsProvider_.get(), "account_tx")));
@@ -540,7 +540,7 @@ public:
                 SELECT hash, seq_idx 
                   FROM {}               
                  WHERE account = ?
-                   AND seq_idx >= ?
+                   AND seq_idx > ?
               ORDER BY seq_idx ASC 
                  LIMIT ?
                 )",


### PR DESCRIPTION
The first tx of account_tx's second page overlaps the last tx of the first page. This should be a old issue for clio. 

SQL query should exclude the marker.