### PR TITLE
Implement basic transformer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ if(BUILD_TESTS)
     unittests/SubscriptionTest.cpp
     unittests/SubscriptionManagerTest.cpp
     unittests/util/TestObject.cpp
+    unittests/util/StringUtils.cpp
     # ETL
     unittests/etl/ExtractionDataPipeTest.cpp
     unittests/etl/ExtractorTest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ if(BUILD_TESTS)
     # ETL
     unittests/etl/ExtractionDataPipeTest.cpp
     unittests/etl/ExtractorTest.cpp
+    unittests/etl/TransformerTest.cpp
     # RPC
     unittests/rpc/ErrorTests.cpp
     unittests/rpc/BaseTests.cpp

--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -17,10 +17,11 @@
 */
 //==============================================================================
 
-#include <ripple/protocol/Indexes.h>
-#include <ripple/protocol/STLedgerEntry.h>
 #include <backend/BackendInterface.h>
 #include <log/Logger.h>
+
+#include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/STLedgerEntry.h>
 
 using namespace clio;
 

--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -107,10 +107,10 @@ LoadBalancer::loadInitialLedger(uint32_t sequence, bool cacheOnly)
     return {std::move(response), success};
 }
 
-LoadBalancer::DataType
+LoadBalancer::OptionalGetLedgerResponseType
 LoadBalancer::fetchLedger(uint32_t ledgerSequence, bool getObjects, bool getObjectNeighbors)
 {
-    RawDataType response;
+    GetLedgerResponseType response;
     bool success = execute(
         [&response, ledgerSequence, getObjects, getObjectNeighbors, log = log_](auto& source) {
             auto [status, data] = source->fetchLedger(ledgerSequence, getObjects, getObjectNeighbors);

--- a/src/etl/LoadBalancer.h
+++ b/src/etl/LoadBalancer.h
@@ -43,8 +43,9 @@ class SubscriptionManager;
 class LoadBalancer
 {
 public:
-    using RawDataType = org::xrpl::rpc::v1::GetLedgerResponse;
-    using DataType = std::optional<RawDataType>;
+    using RawLedgerObjectType = org::xrpl::rpc::v1::RawLedgerObject;
+    using GetLedgerResponseType = org::xrpl::rpc::v1::GetLedgerResponse;
+    using OptionalGetLedgerResponseType = std::optional<GetLedgerResponseType>;
 
 private:
     clio::Logger log_{"ETL"};
@@ -109,7 +110,7 @@ public:
      * @return the extracted data, if extraction was successful. If the ledger was found in the database or the server
      * is shutting down, the optional will be empty
      */
-    DataType
+    OptionalGetLedgerResponseType
     fetchLedger(uint32_t ledgerSequence, bool getObjects, bool getObjectNeighbors);
 
     /**

--- a/src/etl/ProbingSource.cpp
+++ b/src/etl/ProbingSource.cpp
@@ -113,7 +113,7 @@ ProbingSource::loadInitialLedger(std::uint32_t ledgerSequence, std::uint32_t num
     return currentSrc_->loadInitialLedger(ledgerSequence, numMarkers, cacheOnly);
 }
 
-std::pair<grpc::Status, org::xrpl::rpc::v1::GetLedgerResponse>
+std::pair<grpc::Status, ProbingSource::GetLedgerResponseType>
 ProbingSource::fetchLedger(uint32_t ledgerSequence, bool getObjects, bool getObjectNeighbors)
 {
     if (!currentSrc_)

--- a/src/etl/ProbingSource.h
+++ b/src/etl/ProbingSource.h
@@ -39,6 +39,11 @@
  */
 class ProbingSource : public Source
 {
+public:
+    // TODO: inject when unit tests will be written for ProbingSource
+    using GetLedgerResponseType = org::xrpl::rpc::v1::GetLedgerResponse;
+
+private:
     clio::Logger log_{"ETL"};
 
     std::mutex mtx_;
@@ -94,7 +99,7 @@ public:
     std::pair<std::vector<std::string>, bool>
     loadInitialLedger(std::uint32_t ledgerSequence, std::uint32_t numMarkers, bool cacheOnly = false) override;
 
-    std::pair<grpc::Status, org::xrpl::rpc::v1::GetLedgerResponse>
+    std::pair<grpc::Status, GetLedgerResponseType>
     fetchLedger(uint32_t ledgerSequence, bool getObjects = true, bool getObjectNeighbors = false) override;
 
     std::optional<boost::json::object>

--- a/src/etl/Source.cpp
+++ b/src/etl/Source.cpp
@@ -451,6 +451,7 @@ SourceImpl<Derived>::handleMessage()
     }
 }
 
+// TODO: move to detail
 class AsyncCallData
 {
     clio::Logger log_{"ETL"};

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -38,7 +38,7 @@ template <typename LoadBalancerType>
 class LedgerFetcher
 {
 public:
-    using DataType = typename LoadBalancerType::DataType;
+    using OptionalGetLedgerResponseType = typename LoadBalancerType::OptionalGetLedgerResponseType;
 
 private:
     clio::Logger log_{"ETL"};
@@ -64,7 +64,7 @@ public:
      * @param sequence sequence of the ledger to extract
      * @return ledger header and transaction+metadata blobs; empty optional if the server is shutting down
      */
-    DataType
+    OptionalGetLedgerResponseType
     fetchData(uint32_t seq)
     {
         log_.debug() << "Attempting to fetch ledger with sequence = " << seq;
@@ -85,7 +85,7 @@ public:
      * @return ledger header, transaction+metadata blobs, and all ledger objects created, modified or deleted between
      * this ledger and the parent; Empty optional if the server is shutting down
      */
-    DataType
+    OptionalGetLedgerResponseType
     fetchDataAndDiff(uint32_t seq)
     {
         log_.debug() << "Attempting to fetch ledger with sequence = " << seq;

--- a/src/etl/impl/LedgerLoader.h
+++ b/src/etl/impl/LedgerLoader.h
@@ -48,7 +48,9 @@ template <typename LoadBalancerType, typename LedgerFetcherType>
 class LedgerLoader
 {
 public:
-    using DataType = typename LoadBalancerType::RawDataType;
+    using GetLedgerResponseType = typename LoadBalancerType::GetLedgerResponseType;
+    using OptionalGetLedgerResponseType = typename LoadBalancerType::OptionalGetLedgerResponseType;
+    using RawLedgerObjectType = typename LoadBalancerType::RawLedgerObjectType;
 
 private:
     clio::Logger log_{"ETL"};
@@ -83,7 +85,7 @@ public:
      * nft_token_transactions tables (mostly transaction hashes, corresponding nodestore hashes and affected accounts)
      */
     FormattedTransactionsData
-    insertTransactions(ripple::LedgerInfo const& ledger, DataType& data)
+    insertTransactions(ripple::LedgerInfo const& ledger, GetLedgerResponseType& data)
     {
         FormattedTransactionsData result;
 
@@ -150,10 +152,9 @@ public:
             return {};
         }
 
-        // fetch the ledger from the network. This function will not return until
-        // either the fetch is successful, or the server is being shutdown. This
-        // only fetches the ledger header and the transactions+metadata
-        std::optional<org::xrpl::rpc::v1::GetLedgerResponse> ledgerData{fetcher_.get().fetchData(sequence)};
+        // Fetch the ledger from the network. This function will not return until either the fetch is successful, or the
+        // server is being shutdown. This only fetches the ledger header and the transactions+metadata
+        OptionalGetLedgerResponseType ledgerData{fetcher_.get().fetchData(sequence)};
         if (!ledgerData)
             return {};
 

--- a/src/etl/impl/LedgerLoader.h
+++ b/src/etl/impl/LedgerLoader.h
@@ -29,8 +29,6 @@
 
 #include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/ledger/ReadView.h>
-#include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
-#include <grpcpp/grpcpp.h>
 
 #include <memory>
 
@@ -49,6 +47,10 @@ namespace clio::detail {
 template <typename LoadBalancerType, typename LedgerFetcherType>
 class LedgerLoader
 {
+public:
+    using DataType = typename LoadBalancerType::RawDataType;
+
+private:
     clio::Logger log_{"ETL"};
 
     std::shared_ptr<BackendInterface> backend_;
@@ -81,7 +83,7 @@ public:
      * nft_token_transactions tables (mostly transaction hashes, corresponding nodestore hashes and affected accounts)
      */
     FormattedTransactionsData
-    insertTransactions(ripple::LedgerInfo const& ledger, org::xrpl::rpc::v1::GetLedgerResponse& data)
+    insertTransactions(ripple::LedgerInfo const& ledger, DataType& data)
     {
         FormattedTransactionsData result;
 

--- a/src/etl/impl/Transformer.h
+++ b/src/etl/impl/Transformer.h
@@ -142,15 +142,14 @@ private:
                             << ". txn count = " << numTxns << ". object count = " << numObjects
                             << ". load time = " << duration << ". load txns per second = " << numTxns / duration
                             << ". load objs per second = " << numObjects / duration;
+
+                // success is false if the ledger was already written
+                publisher_.get().publish(lgrInfo);
             }
             else
             {
                 log_.error() << "Error writing ledger. " << util::toString(lgrInfo);
             }
-
-            // success is false if the ledger was already written
-            if (success)
-                publisher_.get().publish(lgrInfo);
 
             setWriteConflict(not success);
         }

--- a/src/rpc/RPCEngine.h
+++ b/src/rpc/RPCEngine.h
@@ -186,10 +186,7 @@ public:
     bool
     post(Fn&& func, std::string const& ip)
     {
-        if (!workQueue_.get().postCoro(std::forward<Fn>(func), dosGuard_.get().isWhiteListed(ip)))
-            return false;
-
-        return true;
+        return workQueue_.get().postCoro(std::forward<Fn>(func), dosGuard_.get().isWhiteListed(ip));
     }
 
     /**

--- a/src/rpc/RPCEngine.h
+++ b/src/rpc/RPCEngine.h
@@ -187,10 +187,7 @@ public:
     post(Fn&& func, std::string const& ip)
     {
         if (!workQueue_.get().postCoro(std::forward<Fn>(func), dosGuard_.get().isWhiteListed(ip)))
-        {
-            notifyTooBusy();
             return false;
-        }
 
         return true;
     }

--- a/src/util/LedgerUtils.h
+++ b/src/util/LedgerUtils.h
@@ -30,7 +30,6 @@ inline ripple::LedgerInfo
 deserializeHeader(ripple::Slice data)
 {
     ripple::SerialIter sit(data.data(), data.size());
-
     ripple::LedgerInfo info;
 
     info.seq = sit.get32();
@@ -42,7 +41,6 @@ deserializeHeader(ripple::Slice data)
     info.closeTime = ripple::NetClock::time_point{ripple::NetClock::duration{sit.get32()}};
     info.closeTimeResolution = ripple::NetClock::duration{sit.get8()};
     info.closeFlags = sit.get8();
-
     info.hash = sit.get256();
 
     return info;

--- a/unittests/backend/cassandra/BackendTests.cpp
+++ b/unittests/backend/cassandra/BackendTests.cpp
@@ -18,13 +18,13 @@
 //==============================================================================
 
 #include <util/Fixtures.h>
+#include <util/StringUtils.h>
 
 #include <backend/CassandraBackend.h>
 #include <config/Config.h>
 #include <etl/NFTHelpers.h>
 #include <rpc/RPCHelpers.h>
 
-#include <ripple/basics/base_uint.h>
 #include <boost/json/parse.hpp>
 #include <fmt/compile.h>
 #include <gtest/gtest.h>
@@ -88,29 +88,6 @@ TEST_F(BackendCassandraTest, Basic)
             "6DB6FE30CC5909B285080FCD6773CC883F9FE0EE4D439340AC592AADB973ED3CF5"
             "3E2232B33EF57CECAC2816E3122816E31A0A00F8377CD95DFA484CFAE282656A58"
             "CE5AA29652EFFD80AC59CD91416E4E13DBBE";
-
-        auto hexStringToBinaryString = [](auto const& hex) {
-            auto blob = ripple::strUnHex(hex);
-            std::string strBlob;
-            for (auto c : *blob)
-            {
-                strBlob += c;
-            }
-            return strBlob;
-        };
-        [[maybe_unused]] auto binaryStringToUint256 = [](auto const& bin) -> ripple::uint256 {
-            ripple::uint256 uint;
-            return uint.fromVoid((void const*)bin.data());
-        };
-        [[maybe_unused]] auto ledgerInfoToBinaryString = [](auto const& info) {
-            auto blob = ledgerInfoToBlob(info, true);
-            std::string strBlob;
-            for (auto c : blob)
-            {
-                strBlob += c;
-            }
-            return strBlob;
-        };
 
         std::string rawHeaderBlob = hexStringToBinaryString(rawHeader);
         ripple::LedgerInfo lgrInfo = util::deserializeHeader(ripple::makeSlice(rawHeaderBlob));
@@ -905,29 +882,6 @@ TEST_F(BackendCassandraTest, CacheIntegration)
             "17C5C9DCCF872F36837C2C6136ACF80F2A24079CF81FD0624000000005FF0E0781"
             "142252F328CF91263417762570D67220CCB33B1370";
         std::string accountIndexHex = "E0311EB450B6177F969B94DBDDA83E99B7A0576ACD9079573876F16C0C004F06";
-
-        auto hexStringToBinaryString = [](auto const& hex) {
-            auto blob = ripple::strUnHex(hex);
-            std::string strBlob;
-            for (auto c : *blob)
-            {
-                strBlob += c;
-            }
-            return strBlob;
-        };
-        auto binaryStringToUint256 = [](auto const& bin) -> ripple::uint256 {
-            ripple::uint256 uint;
-            return uint.fromVoid((void const*)bin.data());
-        };
-        auto ledgerInfoToBinaryString = [](auto const& info) {
-            auto blob = ledgerInfoToBlob(info, true);
-            std::string strBlob;
-            for (auto c : blob)
-            {
-                strBlob += c;
-            }
-            return strBlob;
-        };
 
         std::string rawHeaderBlob = hexStringToBinaryString(rawHeader);
         std::string accountBlob = hexStringToBinaryString(accountHex);

--- a/unittests/etl/ExtractorTest.cpp
+++ b/unittests/etl/ExtractorTest.cpp
@@ -33,9 +33,8 @@ using namespace testing;
 class ETLExtractorTest : public NoLoggerFixture
 {
 protected:
-    using DataType = FakeFetchResponse;
-    using ExtractionDataPipeType = MockExtractionDataPipe<DataType>;
-    using LedgerFetcherType = MockLedgerFetcher<DataType>;
+    using ExtractionDataPipeType = MockExtractionDataPipe;
+    using LedgerFetcherType = MockLedgerFetcher;
     using ExtractorType =
         clio::detail::Extractor<ExtractionDataPipeType, MockNetworkValidatedLedgers, LedgerFetcherType>;
 

--- a/unittests/etl/TransformerTest.cpp
+++ b/unittests/etl/TransformerTest.cpp
@@ -34,8 +34,8 @@ class ETLTransformerTest : public MockBackendTest
 {
 protected:
     using DataType = FakeFetchResponse;
-    using ExtractionDataPipeType = MockExtractionDataPipe<DataType>;
-    using LedgerLoaderType = MockLedgerLoader<DataType>;
+    using ExtractionDataPipeType = MockExtractionDataPipe;
+    using LedgerLoaderType = MockLedgerLoader;
     using LedgerPublisherType = MockLedgerPublisher;
     using TransformerType = clio::detail::Transformer<ExtractionDataPipeType, LedgerLoaderType, LedgerPublisherType>;
 

--- a/unittests/etl/TransformerTest.cpp
+++ b/unittests/etl/TransformerTest.cpp
@@ -1,0 +1,81 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <etl/impl/Transformer.h>
+#include <util/FakeFetchResponse.h>
+#include <util/Fixtures.h>
+#include <util/MockExtractionDataPipe.h>
+#include <util/MockLedgerLoader.h>
+#include <util/MockLedgerPublisher.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace testing;
+
+class ETLTransformerTest : public MockBackendTest
+{
+protected:
+    using DataType = FakeFetchResponse;
+    using ExtractionDataPipeType = MockExtractionDataPipe<DataType>;
+    using LedgerLoaderType = MockLedgerLoader<DataType>;
+    using LedgerPublisherType = MockLedgerPublisher;
+    using TransformerType = clio::detail::Transformer<ExtractionDataPipeType, LedgerLoaderType, LedgerPublisherType>;
+
+    ExtractionDataPipeType dataPipe_;
+    LedgerLoaderType ledgerLoader_;
+    LedgerPublisherType ledgerPublisher_;
+    SystemState state_;
+
+    std::unique_ptr<TransformerType> transformer_;
+
+public:
+    void
+    SetUp() override
+    {
+        MockBackendTest::SetUp();
+        state_.isStopping = false;
+        state_.writeConflict = false;
+        state_.isReadOnly = false;
+        state_.isWriting = false;
+    }
+
+    void
+    TearDown() override
+    {
+        transformer_.reset();
+        MockBackendTest::TearDown();
+    }
+};
+
+TEST_F(ETLTransformerTest, Tmp)
+{
+    // ON_CALL(dataPipe_, getStride).WillByDefault(Return(4));
+    // EXPECT_CALL(dataPipe_, getStride).Times(3);
+
+    // auto response = FakeFetchResponse{};
+    // ON_CALL(ledgerFetcher_, fetchDataAndDiff(_)).WillByDefault(Return(response));
+    // EXPECT_CALL(ledgerFetcher_, fetchDataAndDiff).Times(3);
+    // EXPECT_CALL(dataPipe_, push).Times(3);
+    // EXPECT_CALL(dataPipe_, finish(0)).Times(1);
+
+    transformer_ =
+        std::make_unique<TransformerType>(dataPipe_, mockBackendPtr, ledgerLoader_, ledgerPublisher_, 0, state_);
+}

--- a/unittests/util/FakeFetchResponse.h
+++ b/unittests/util/FakeFetchResponse.h
@@ -171,6 +171,11 @@ struct FakeFetchResponse
     {
     }
 
+    FakeFetchResponse(std::string blob, uint32_t id = 0, bool objectNeighborsIncluded = false)
+        : id{id}, objectNeighborsIncluded{objectNeighborsIncluded}, ledgerHeader{blob}
+    {
+    }
+
     bool
     operator==(FakeFetchResponse const& other) const
     {

--- a/unittests/util/FakeFetchResponse.h
+++ b/unittests/util/FakeFetchResponse.h
@@ -20,13 +20,114 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
+#include <vector>
+
+class FakeBook
+{
+    std::string base_;
+    std::string first_;
+
+public:
+    std::string*
+    mutable_first_book()
+    {
+        return &first_;
+    }
+
+    std::string
+    book_base() const
+    {
+        return base_;
+    }
+
+    std::string*
+    mutable_book_base()
+    {
+        return &base_;
+    }
+};
+
+class FakeBookSuccessors
+{
+    std::vector<FakeBook> books_;
+
+public:
+    auto
+    begin()
+    {
+        return books_.begin();
+    }
+
+    auto
+    end()
+    {
+        return books_.end();
+    }
+};
+
+class FakeLedgerObject
+{
+public:
+    enum ModType : int { MODIFIED, DELETED };
+
+private:
+    std::string key_;
+    std::string data_;
+    std::string predecessor_;
+    std::string successor_;
+    ModType mod_ = MODIFIED;
+
+public:
+    ModType
+    mod_type() const
+    {
+        return mod_;
+    }
+
+    std::string
+    key() const
+    {
+        return key_;
+    }
+
+    std::string*
+    mutable_key()
+    {
+        return &key_;
+    }
+
+    std::string
+    data() const
+    {
+        return data_;
+    }
+
+    std::string*
+    mutable_data()
+    {
+        return &data_;
+    }
+
+    std::string*
+    mutable_predecessor()
+    {
+        return &predecessor_;
+    }
+
+    std::string*
+    mutable_successor()
+    {
+        return &successor_;
+    }
+};
 
 class FakeLedgerObjects
 {
-    std::vector<int> objects;
+    std::vector<FakeLedgerObject> objects;
 
 public:
-    std::vector<int>*
+    std::vector<FakeLedgerObject>*
     mutable_objects()
     {
         return &objects;
@@ -62,6 +163,8 @@ struct FakeFetchResponse
     uint32_t id;
     bool objectNeighborsIncluded;
     FakeLedgerObjects ledgerObjects;
+    std::string ledgerHeader;
+    FakeBookSuccessors bookSuccessors;
 
     FakeFetchResponse(uint32_t id = 0, bool objectNeighborsIncluded = false)
         : id{id}, objectNeighborsIncluded{objectNeighborsIncluded}
@@ -92,9 +195,27 @@ struct FakeFetchResponse
         return objectNeighborsIncluded;
     }
 
-    FakeLedgerObjects&
+    FakeLedgerObjects*
     mutable_ledger_objects()
     {
-        return ledgerObjects;
+        return &ledgerObjects;
+    }
+
+    std::string
+    ledger_header() const
+    {
+        return ledgerHeader;
+    }
+
+    std::string*
+    mutable_ledger_header()
+    {
+        return &ledgerHeader;
+    }
+
+    FakeBookSuccessors*
+    mutable_book_successors()
+    {
+        return &bookSuccessors;
     }
 };

--- a/unittests/util/FakeFetchResponse.h
+++ b/unittests/util/FakeFetchResponse.h
@@ -21,6 +21,18 @@
 
 #include <cstddef>
 
+class FakeLedgerObjects
+{
+    std::vector<int> objects;
+
+public:
+    std::vector<int>*
+    mutable_objects()
+    {
+        return &objects;
+    }
+};
+
 class FakeTransactionsList
 {
     std::size_t size_ = 0;
@@ -33,11 +45,26 @@ public:
     }
 };
 
+class FakeObjectsList
+{
+    std::size_t size_ = 0;
+
+public:
+    std::size_t
+    objects_size()
+    {
+        return size_;
+    }
+};
+
 struct FakeFetchResponse
 {
     uint32_t id;
+    bool objectNeighborsIncluded;
+    FakeLedgerObjects ledgerObjects;
 
-    FakeFetchResponse(uint32_t id = 0) : id{id}
+    FakeFetchResponse(uint32_t id = 0, bool objectNeighborsIncluded = false)
+        : id{id}, objectNeighborsIncluded{objectNeighborsIncluded}
     {
     }
 
@@ -51,5 +78,23 @@ struct FakeFetchResponse
     transactions_list() const
     {
         return {};
+    }
+
+    FakeObjectsList
+    ledger_objects() const
+    {
+        return {};
+    }
+
+    bool
+    object_neighbors_included() const
+    {
+        return objectNeighborsIncluded;
+    }
+
+    FakeLedgerObjects&
+    mutable_ledger_objects()
+    {
+        return ledgerObjects;
     }
 };

--- a/unittests/util/MockExtractionDataPipe.h
+++ b/unittests/util/MockExtractionDataPipe.h
@@ -23,11 +23,10 @@
 
 #include <chrono>
 
-template <typename DataType>
 struct MockExtractionDataPipe
 {
-    MOCK_METHOD(void, push, (uint32_t, std::optional<DataType>&&), ());
-    MOCK_METHOD(std::optional<DataType>, popNext, (uint32_t), ());
+    MOCK_METHOD(void, push, (uint32_t, std::optional<FakeFetchResponse>&&), ());
+    MOCK_METHOD(std::optional<FakeFetchResponse>, popNext, (uint32_t), ());
     MOCK_METHOD(uint32_t, getStride, (), (const));
     MOCK_METHOD(void, finish, (uint32_t), ());
     MOCK_METHOD(void, cleanup, (), ());

--- a/unittests/util/MockLedgerFetcher.h
+++ b/unittests/util/MockLedgerFetcher.h
@@ -19,13 +19,14 @@
 
 #pragma once
 
+#include <util/FakeFetchResponse.h>
+
 #include <gmock/gmock.h>
 
 #include <optional>
 
-template <typename DataType>
 struct MockLedgerFetcher
 {
-    MOCK_METHOD(std::optional<DataType>, fetchData, (uint32_t), ());
-    MOCK_METHOD(std::optional<DataType>, fetchDataAndDiff, (uint32_t), ());
+    MOCK_METHOD(std::optional<FakeFetchResponse>, fetchData, (uint32_t), ());
+    MOCK_METHOD(std::optional<FakeFetchResponse>, fetchDataAndDiff, (uint32_t), ());
 };

--- a/unittests/util/MockLedgerLoader.h
+++ b/unittests/util/MockLedgerLoader.h
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <etl/impl/LedgerLoader.h>
+
+#include <gmock/gmock.h>
+
+#include <optional>
+
+template <typename InDataType>
+struct MockLedgerLoader
+{
+    using DataType = InDataType;
+
+    MOCK_METHOD(FormattedTransactionsData, insertTransactions, (ripple::LedgerInfo const&, DataType& data), ());
+    MOCK_METHOD(std::optional<ripple::LedgerInfo>, loadInitialLedger, (uint32_t sequence), ());
+};

--- a/unittests/util/MockLedgerLoader.h
+++ b/unittests/util/MockLedgerLoader.h
@@ -25,11 +25,15 @@
 
 #include <optional>
 
-template <typename InDataType>
 struct MockLedgerLoader
 {
-    using DataType = InDataType;
+    using GetLedgerResponseType = FakeFetchResponse;
+    using RawLedgerObjectType = FakeLedgerObject;
 
-    MOCK_METHOD(FormattedTransactionsData, insertTransactions, (ripple::LedgerInfo const&, DataType& data), ());
+    MOCK_METHOD(
+        FormattedTransactionsData,
+        insertTransactions,
+        (ripple::LedgerInfo const&, GetLedgerResponseType& data),
+        ());
     MOCK_METHOD(std::optional<ripple::LedgerInfo>, loadInitialLedger, (uint32_t sequence), ());
 };

--- a/unittests/util/MockLedgerPublisher.h
+++ b/unittests/util/MockLedgerPublisher.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <optional>
+
+struct MockLedgerPublisher
+{
+    MOCK_METHOD(bool, publish, (uint32_t, std::optional<uint32_t>), ());
+    MOCK_METHOD(void, publish, (ripple::LedgerInfo const&), ());
+    MOCK_METHOD(std::uint32_t, lastPublishAgeSeconds, (), (const));
+    MOCK_METHOD(std::chrono::time_point<std::chrono::system_clock>, getLastPublish, (), (const));
+    MOCK_METHOD(std::uint32_t, lastCloseAgeSeconds, (), (const));
+    MOCK_METHOD(std::optional<uint32_t>, getLastPublishedSequence, (), (const));
+};

--- a/unittests/util/MockLoadBalancer.h
+++ b/unittests/util/MockLoadBalancer.h
@@ -20,20 +20,20 @@
 #pragma once
 
 #include <etl/Source.h>
+#include <util/FakeFetchResponse.h>
 
 #include <boost/asio/spawn.hpp>
 #include <boost/json.hpp>
 #include <gmock/gmock.h>
 
-#include "org/xrpl/rpc/v1/xrp_ledger.grpc.pb.h"
-#include <grpcpp/grpcpp.h>
-
 #include <optional>
 
 struct MockLoadBalancer
 {
+    using RawLedgerObjectType = FakeLedgerObject;
+
     MOCK_METHOD(void, loadInitialLedger, (std::uint32_t, bool), ());
-    MOCK_METHOD(std::optional<org::xrpl::rpc::v1::GetLedgerResponse>, fetchLedger, (uint32_t, bool, bool), ());
+    MOCK_METHOD(std::optional<FakeFetchResponse>, fetchLedger, (uint32_t, bool, bool), ());
     MOCK_METHOD(bool, shouldPropagateTxnStream, (Source*), (const));
     MOCK_METHOD(boost::json::value, toJson, (), (const));
     MOCK_METHOD(

--- a/unittests/util/StringUtils.cpp
+++ b/unittests/util/StringUtils.cpp
@@ -24,7 +24,7 @@
 std::string
 hexStringToBinaryString(std::string const& hex)
 {
-    auto blob = ripple::strUnHex(hex);
+    auto const blob = ripple::strUnHex(hex);
     std::string strBlob;
 
     for (auto c : *blob)
@@ -43,7 +43,7 @@ binaryStringToUint256(std::string const& bin)
 std::string
 ledgerInfoToBinaryString(ripple::LedgerInfo const& info)
 {
-    auto blob = RPC::ledgerInfoToBlob(info, true);
+    auto const blob = RPC::ledgerInfoToBlob(info, true);
     std::string strBlob;
     for (auto c : blob)
         strBlob += c;

--- a/unittests/util/StringUtils.cpp
+++ b/unittests/util/StringUtils.cpp
@@ -1,0 +1,52 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <util/StringUtils.h>
+
+#include <rpc/RPCHelpers.h>
+
+std::string
+hexStringToBinaryString(std::string const& hex)
+{
+    auto blob = ripple::strUnHex(hex);
+    std::string strBlob;
+
+    for (auto c : *blob)
+        strBlob += c;
+
+    return strBlob;
+}
+
+ripple::uint256
+binaryStringToUint256(std::string const& bin)
+{
+    ripple::uint256 uint;
+    return uint.fromVoid((void const*)bin.data());
+}
+
+std::string
+ledgerInfoToBinaryString(ripple::LedgerInfo const& info)
+{
+    auto blob = RPC::ledgerInfoToBlob(info, true);
+    std::string strBlob;
+    for (auto c : blob)
+        strBlob += c;
+
+    return strBlob;
+};

--- a/unittests/util/StringUtils.h
+++ b/unittests/util/StringUtils.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <ripple/basics/base_uint.h>
+#include <ripple/ledger/ReadView.h>
+
+#include <string>
+
+std::string
+hexStringToBinaryString(std::string const& hex);
+
+ripple::uint256
+binaryStringToUint256(std::string const& bin);
+
+std::string
+ledgerInfoToBinaryString(ripple::LedgerInfo const& info);


### PR DESCRIPTION
This pr adds a bunch of mocks and fakes to support ETL tests as well as implements a few tests for the Transformer.
By no means is this complete but it may be just enough for a start. Next iteration it would be good to separate some of the transformer logic into another entity that can be tested separately from the threading facilities it provides. Transform is doing way too much atm. so it's not worth spending more time adding tests for what it is atm.