### PR TITLE
Fix clang crash

### DIFF
--- a/src/webserver/RPCExecutor.h
+++ b/src/webserver/RPCExecutor.h
@@ -130,7 +130,7 @@ private:
             if (connection->upgraded)
                 return e;
             else
-                return boost::json::object{{"result", e}};
+                return {{"result", e}};
         };
 
         try


### PR DESCRIPTION
With coverage flag enable, clang 14 crashes when build RPCExecutor.h.
How to reproduce it in a minimum way : https://godbolt.org/z/o3f6o1soo