### PR TITLE
Support `api_version`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(clio PRIVATE
   src/rpc/WorkQueue.cpp
   src/rpc/common/Specs.cpp
   src/rpc/common/Validators.cpp
+  src/rpc/common/impl/APIVersionParser.cpp
   # RPC impl
   src/rpc/common/impl/HandlerProvider.cpp
   ## RPC handler
@@ -125,6 +126,7 @@ if(BUILD_TESTS)
     unittests/rpc/RPCHelpersTest.cpp
     unittests/rpc/CountersTest.cpp
     unittests/rpc/AdminVerificationTest.cpp
+    unittests/rpc/APIVersionTests.cpp
     ## RPC handlers
     unittests/rpc/handlers/DefaultProcessorTests.cpp
     unittests/rpc/handlers/TestHandlerTests.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,10 @@ if(BUILD_TESTS)
     unittests/webserver/RPCExecutorTest.cpp)
   include(CMake/deps/gtest.cmake)
 
-  # test for dwarf5 bug on ci 
+  # fix for dwarf5 bug on ci 
   target_compile_options(clio PUBLIC -gdwarf-4)
+
+  target_compile_definitions(${TEST_TARGET} PUBLIC UNITTEST_BUILD)
 
   # if CODE_COVERAGE enable, add clio_test-ccov
   if(CODE_COVERAGE)

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ The parameters `ssl_cert_file` and `ssl_key_file` can also be added to the top l
 An example of how to specify `ssl_cert_file` and `ssl_key_file` in the config:
 
 ```json
-"server":{
+"server": {
     "ip": "0.0.0.0",
     "port": 51233
 },
-"ssl_cert_file" : "/full/path/to/cert.file",
-"ssl_key_file" : "/full/path/to/key.file"
+"ssl_cert_file": "/full/path/to/cert.file",
+"ssl_key_file": "/full/path/to/key.file"
 ```
 
 Once your config files are ready, start rippled and Clio. It doesn't matter which you
@@ -171,6 +171,20 @@ are doing this, be aware that database traffic will be flowing across regions,
 which can cause high latencies. A possible alternative to this is to just deploy
 a database in each region, and the Clio nodes in each region use their region's database.
 This is effectively two systems.
+
+Clio supports API versioning as [described here](https://xrpl.org/request-formatting.html#api-versioning).
+It's possible to configure `minimum`, `maximum` and `default` version like so: 
+```json
+"api_version": {
+    "min": 1,
+    "max": 2,
+    "default": 2 
+}
+```
+All of the above are optional. 
+Clio will fallback to hardcoded defaults when not specified in the config file or configured values are outside 
+of the minimum and maximum supported versions hardcoded in `src/rpc/common/APIVersion.h`.
+> **Note:** See `example-config.json` for more details. 
 
 ## Developing against `rippled` in standalone mode
 

--- a/example-config.json
+++ b/example-config.json
@@ -90,4 +90,9 @@
     //"finish_sequence": [integer] the ledger index to finish at,
     //"ssl_cert_file" : "/full/path/to/cert.file",
     //"ssl_key_file" : "/full/path/to/key.file"
+    "api_version": {
+        "min": 2,
+        "max": 2,
+        "default": 2 // Clio only supports API v2 and newer
+    }
 }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -142,6 +142,15 @@ Config::section(key_type key) const
     throw std::logic_error("No section found at '" + key + "'");
 }
 
+Config
+Config::sectionOr(key_type key, boost::json::object fallback) const
+{
+    auto maybe_element = lookup(key);
+    if (maybe_element && maybe_element->is_object())
+        return Config{std::move(*maybe_element)};
+    return Config{std::move(fallback)};
+}
+
 Config::array_type
 Config::array() const
 {

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -266,6 +266,20 @@ public:
     [[nodiscard]] Config
     section(key_type key) const;
 
+    /**
+     * @brief Interface for fetching a sub section by key with a fallback object.
+     *
+     * Will attempt to fetch an entire section under the desired key and return
+     * it as a Config instance. If the section does not exist or another type is
+     * stored under the desired key - fallback object is used instead.
+     *
+     * @param key The key to check
+     * @param fallabkc The fallback object
+     * @return Config Section represented as a separate instance of Config
+     */
+    [[nodiscard]] Config
+    sectionOr(key_type key, boost::json::object fallback) const;
+
     //
     // Direct self-value access
     //

--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <rpc/Errors.h>
+#include <rpc/JS.h>
 
 #include <algorithm>
 
@@ -77,7 +78,8 @@ getErrorInfo(ClioError code)
         {ClioError::rpcMALFORMED_REQUEST, "malformedRequest", "Malformed request."},
         {ClioError::rpcMALFORMED_OWNER, "malformedOwner", "Malformed owner."},
         {ClioError::rpcMALFORMED_ADDRESS, "malformedAddress", "Malformed address."},
-        {ClioError::rpcINVALID_HOT_WALLET, "invalidHotWallet", "Invalid hot wallet."}};
+        {ClioError::rpcINVALID_HOT_WALLET, "invalidHotWallet", "Invalid hot wallet."},
+        {ClioError::rpcINVALID_API_VERSION, JS(invalid_API_version), "Invalid API version."}};
 
     auto matchByCode = [code](auto const& info) { return info.code == code; };
     if (auto it = find_if(begin(infos), end(infos), matchByCode); it != end(infos))

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -34,11 +34,15 @@ namespace RPC {
  * @brief Custom clio RPC Errors.
  */
 enum class ClioError {
+    // normal clio errors start with 5000
     rpcMALFORMED_CURRENCY = 5000,
     rpcMALFORMED_REQUEST = 5001,
     rpcMALFORMED_OWNER = 5002,
     rpcMALFORMED_ADDRESS = 5003,
     rpcINVALID_HOT_WALLET = 5004,
+
+    // special system errors start with 6000
+    rpcINVALID_API_VERSION = 6000,
 };
 
 /**

--- a/src/rpc/Factories.cpp
+++ b/src/rpc/Factories.cpp
@@ -18,21 +18,25 @@
 //==============================================================================
 
 #include <rpc/Factories.h>
+#include <rpc/common/Types.h>
 
 using namespace std;
 using namespace clio;
 
 namespace RPC {
 
-optional<Web::Context>
+util::Expected<Web::Context, Status>
 make_WsContext(
     boost::asio::yield_context& yc,
     boost::json::object const& request,
     shared_ptr<Server::ConnectionBase> const& session,
     util::TagDecoratorFactory const& tagFactory,
     Backend::LedgerRange const& range,
-    string const& clientIp)
+    string const& clientIp,
+    std::reference_wrapper<APIVersionParser const> apiVersionParser)
 {
+    using Error = util::Unexpected<Status>;
+
     boost::json::value commandValue = nullptr;
     if (!request.contains("command") && request.contains("method"))
         commandValue = request.at("method");
@@ -40,40 +44,48 @@ make_WsContext(
         commandValue = request.at("command");
 
     if (!commandValue.is_string())
-        return {};
+        return Error{{RippledError::rpcBAD_SYNTAX, "Method/Command is not specified or is not a string."}};
+
+    auto const apiVersion = apiVersionParser.get().parse(request);
+    if (!apiVersion)
+        return Error{{ClioError::rpcINVALID_API_VERSION, apiVersion.error()}};
 
     string command = commandValue.as_string().c_str();
-    return make_optional<Web::Context>(yc, command, 1, request, session, tagFactory, range, clientIp);
+    return Web::Context(yc, command, *apiVersion, request, session, tagFactory, range, clientIp);
 }
 
-optional<Web::Context>
+util::Expected<Web::Context, Status>
 make_HttpContext(
     boost::asio::yield_context& yc,
     boost::json::object const& request,
     util::TagDecoratorFactory const& tagFactory,
     Backend::LedgerRange const& range,
-    string const& clientIp)
+    string const& clientIp,
+    std::reference_wrapper<APIVersionParser const> apiVersionParser)
 {
+    using Error = util::Unexpected<Status>;
+
     if (!request.contains("method") || !request.at("method").is_string())
-        return {};
+        return Error{{RippledError::rpcBAD_SYNTAX, "Method is not specified or is not a string."}};
 
     string const& command = request.at("method").as_string().c_str();
 
     if (command == "subscribe" || command == "unsubscribe")
-        return {};
+        return Error{{RippledError::rpcBAD_SYNTAX, "Subscribe and unsubscribe are only allowed or websocket."}};
 
     if (!request.at("params").is_array())
-        return {};
+        return Error{{RippledError::rpcBAD_SYNTAX, "Missing params array."}};
 
     boost::json::array const& array = request.at("params").as_array();
 
-    if (array.size() != 1)
-        return {};
+    if (array.size() != 1 || !array.at(0).is_object())
+        return Error{{RippledError::rpcBAD_SYNTAX, "Params must be an array holding exactly one object."}};
 
-    if (!array.at(0).is_object())
-        return {};
+    auto const apiVersion = apiVersionParser.get().parse(request.at("params").as_array().at(0).as_object());
+    if (!apiVersion)
+        return Error{{ClioError::rpcINVALID_API_VERSION, apiVersion.error()}};
 
-    return make_optional<Web::Context>(yc, command, 1, array.at(0).as_object(), nullptr, tagFactory, range, clientIp);
+    return Web::Context(yc, command, *apiVersion, array.at(0).as_object(), nullptr, tagFactory, range, clientIp);
 }
 
 }  // namespace RPC

--- a/src/rpc/Factories.h
+++ b/src/rpc/Factories.h
@@ -20,6 +20,9 @@
 #pragma once
 
 #include <backend/BackendInterface.h>
+#include <rpc/Errors.h>
+#include <rpc/common/APIVersion.h>
+#include <util/Expected.h>
 #include <webserver/Context.h>
 #include <webserver/interface/ConnectionBase.h>
 
@@ -38,21 +41,23 @@
  */
 namespace RPC {
 
-std::optional<Web::Context>
+util::Expected<Web::Context, Status>
 make_WsContext(
     boost::asio::yield_context& yc,
     boost::json::object const& request,
     std::shared_ptr<Server::ConnectionBase> const& session,
     util::TagDecoratorFactory const& tagFactory,
     Backend::LedgerRange const& range,
-    std::string const& clientIp);
+    std::string const& clientIp,
+    std::reference_wrapper<APIVersionParser const> apiVersionParser);
 
-std::optional<Web::Context>
+util::Expected<Web::Context, Status>
 make_HttpContext(
     boost::asio::yield_context& yc,
     boost::json::object const& request,
     util::TagDecoratorFactory const& tagFactory,
     Backend::LedgerRange const& range,
-    std::string const& clientIp);
+    std::string const& clientIp,
+    std::reference_wrapper<APIVersionParser const> apiVersionParser);
 
 }  // namespace RPC

--- a/src/rpc/README.md
+++ b/src/rpc/README.md
@@ -24,6 +24,6 @@ Handlers need to fulfil the requirements specified by the **`Handler`** concept 
 - Expose types: 
 	* `Input` - The POD struct which acts as input for the handler
 	* `Output` - The POD struct which acts as output of a valid handler invocation
-- Have a `spec()` member function returning a const reference to an **`RpcSpec`** describing the JSON input.
+- Have a `spec(uint32_t)` member function returning a const reference to an **`RpcSpec`** describing the JSON input.
 - Have a `process(Input)` member function that operates on `Input` POD and returns `HandlerReturnType<Output>`
 - Implement `value_from` and `value_to` support using `tag_invoke` as per `boost::json` documentation for these functions.

--- a/src/rpc/RPCEngine.h
+++ b/src/rpc/RPCEngine.h
@@ -148,7 +148,7 @@ public:
             perfLog_.debug() << ctx.tag() << " start executing rpc `" << ctx.method << '`';
 
             auto const isAdmin = adminVerifier_.isAdmin(ctx.clientIp);
-            auto const context = Context{ctx.yield, ctx.session, isAdmin, ctx.clientIp};
+            auto const context = Context{ctx.yield, ctx.session, isAdmin, ctx.clientIp, ctx.apiVersion};
             auto const v = (*method).process(ctx.params, context);
 
             perfLog_.debug() << ctx.tag() << " finish executing rpc `" << ctx.method << '`';
@@ -303,7 +303,7 @@ private:
     bool
     shouldForwardToRippled(Web::Context const& ctx) const
     {
-        auto request = ctx.params;
+        auto const& request = ctx.params;
 
         if (isClioOnly(ctx.method))
             return false;

--- a/src/rpc/common/APIVersion.h
+++ b/src/rpc/common/APIVersion.h
@@ -20,35 +20,40 @@
 #pragma once
 
 #include <rpc/common/Types.h>
+#include <util/Expected.h>
 
-#include <boost/json/value.hpp>
+#include <boost/json.hpp>
 
 #include <string>
 
 namespace RPC {
 
 /**
- * @brief The random command provides a random number to be used as a source of entropy for random number generation by
- * clients.
- *
- * For more details see: https://xrpl.org/random.html
+ * @brief Default API version to use if no version is specified by clients
  */
-class RandomHandler
+static constexpr uint32_t API_VERSION_DEFAULT = 2u;
+
+/**
+ * @brief Minimum API version supported by this build
+ *
+ * Note: Clio does not support v1 and only supports v2 and newer.
+ */
+static constexpr uint32_t API_VERSION_MIN = 2u;
+
+/**
+ * @brief Maximum API version supported by this build
+ */
+static constexpr uint32_t API_VERSION_MAX = 2u;
+
+/**
+ * @brief A baseclass for API version helper
+ */
+class APIVersionParser
 {
 public:
-    struct Output
-    {
-        std::string random;
-    };
+    virtual ~APIVersionParser() = default;
 
-    using Result = HandlerReturnType<Output>;
-
-    Result
-    process(Context const& ctx) const;
-
-private:
-    friend void
-    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, Output const& output);
+    util::Expected<uint32_t, std::string> virtual parse(boost::json::object const& request) const = 0;
 };
 
 }  // namespace RPC

--- a/src/rpc/common/AnyHandler.h
+++ b/src/rpc/common/AnyHandler.h
@@ -69,18 +69,7 @@ public:
      * @brief Process incoming JSON by the stored handler
      *
      * @param value The JSON to process
-     * @return JSON result or @ref Status on error
-     */
-    [[nodiscard]] ReturnType
-    process(boost::json::value const& value) const
-    {
-        return pimpl_->process(value);
-    }
-
-    /**
-     * @brief Process incoming JSON by the stored handler in a provided coroutine
-     *
-     * @param value The JSON to process
+     * @param ctx Request context
      * @return JSON result or @ref Status on error
      */
     [[nodiscard]] ReturnType
@@ -97,9 +86,6 @@ private:
         [[nodiscard]] virtual ReturnType
         process(boost::json::value const& value, Context const& ctx) const = 0;
 
-        [[nodiscard]] virtual ReturnType
-        process(boost::json::value const& value) const = 0;
-
         [[nodiscard]] virtual std::unique_ptr<Concept>
         clone() const = 0;
     };
@@ -115,15 +101,9 @@ private:
         }
 
         [[nodiscard]] ReturnType
-        process(boost::json::value const& value) const override
-        {
-            return processor(handler, value);
-        }
-
-        [[nodiscard]] ReturnType
         process(boost::json::value const& value, Context const& ctx) const override
         {
-            return processor(handler, value, &ctx);
+            return processor(handler, value, ctx);
         }
 
         [[nodiscard]] std::unique_ptr<Concept>

--- a/src/rpc/common/Concepts.h
+++ b/src/rpc/common/Concepts.h
@@ -59,22 +59,14 @@ concept ContextProcessWithoutInput = requires(T a, typename T::Output out, Conte
 };
 
 template <typename T>
-concept NonContextProcess = requires(T a, typename T::Input in, typename T::Output out) {
-    { a.process(in) } -> std::same_as<HandlerReturnType<decltype(out)>>; 
-};
-
-template <typename T>
-concept HandlerWithInput = requires(T a) {
-    { a.spec() } -> std::same_as<RpcSpecConstRef>; 
+concept HandlerWithInput = requires(T a, uint32_t version) {
+    { a.spec(version) } -> std::same_as<RpcSpecConstRef>; 
 }
-and (ContextProcessWithInput<T> or NonContextProcess<T>)
+and ContextProcessWithInput<T>
 and boost::json::has_value_to<typename T::Input>::value;
 
 template <typename T>
-concept HandlerWithoutInput = requires(T a, typename T::Output out) {
-    { a.process() } -> std::same_as<HandlerReturnType<decltype(out)>>; 
-} 
-or ContextProcessWithoutInput<T>;
+concept HandlerWithoutInput = ContextProcessWithoutInput<T>;
 
 template <typename T>
 concept Handler = 

--- a/src/rpc/common/Types.h
+++ b/src/rpc/common/Types.h
@@ -73,6 +73,7 @@ struct Context
     std::shared_ptr<Server::ConnectionBase> session;
     bool isAdmin = false;
     std::string clientIp;
+    uint32_t apiVersion = 0u;  // invalid by default
 };
 
 using Result = std::variant<Status, boost::json::object>;

--- a/src/rpc/common/impl/APIVersionParser.cpp
+++ b/src/rpc/common/impl/APIVersionParser.cpp
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <log/Logger.h>
+#include <rpc/common/impl/APIVersionParser.h>
+
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <stdexcept>
+
+using namespace std;
+
+namespace RPC::detail {
+
+ProductionAPIVersionParser::ProductionAPIVersionParser(
+    uint32_t defaultVersion,
+    uint32_t minVersion,
+    uint32_t maxVersion)
+    : defaultVersion_{defaultVersion}, minVersion_{minVersion}, maxVersion_{maxVersion}
+{
+#ifndef DEBUG
+    // in production, we don't want the ability to misconfigure clio with bogus versions
+    // that are not actually supported by the code itself. for testing it is desired however.
+    auto checkRange = [this](uint32_t version, std::string label) {
+        if (clamp(version, API_VERSION_MIN, API_VERSION_MAX) != version)
+        {
+            log_.error() << "API version settings issue detected: " << label << " version with value " << version
+                         << " is outside of supported range " << API_VERSION_MIN << "-" << API_VERSION_MAX
+                         << "; Falling back to hardcoded values.";
+
+            defaultVersion_ = API_VERSION_DEFAULT;
+            minVersion_ = API_VERSION_MIN;
+            maxVersion_ = API_VERSION_MAX;
+        }
+    };
+
+    checkRange(defaultVersion, "default");
+    checkRange(minVersion, "minimum");
+    checkRange(maxVersion, "maximum");
+#endif
+
+    log_.info() << "API version settings: [min = " << minVersion_ << "; max = " << maxVersion_
+                << "; default = " << defaultVersion_ << "]";
+}
+
+ProductionAPIVersionParser::ProductionAPIVersionParser(clio::Config const& config)
+    : ProductionAPIVersionParser(
+          config.valueOr("default", API_VERSION_DEFAULT),
+          config.valueOr("min", API_VERSION_MIN),
+          config.valueOr("max", API_VERSION_MAX))
+{
+}
+
+util::Expected<uint32_t, std::string>
+ProductionAPIVersionParser::parse(boost::json::object const& request) const
+{
+    using Error = util::Unexpected<std::string>;
+
+    if (request.contains("api_version"))
+    {
+        if (!request.at("api_version").is_int64())
+            return Error{"API version must be an integer"};
+
+        auto const version = request.at("api_version").as_int64();
+
+        if (version > maxVersion_)
+            return Error{fmt::format("Requested API version is higher than maximum supported ({})", maxVersion_)};
+
+        if (version < minVersion_)
+            return Error{fmt::format("Requested API version is lower than minimum supported ({})", minVersion_)};
+
+        return version;
+    }
+
+    return defaultVersion_;
+}
+
+}  // namespace RPC::detail

--- a/src/rpc/common/impl/APIVersionParser.cpp
+++ b/src/rpc/common/impl/APIVersionParser.cpp
@@ -22,43 +22,9 @@
 
 #include <fmt/core.h>
 
-#include <algorithm>
-#include <stdexcept>
-
 using namespace std;
 
 namespace RPC::detail {
-
-ProductionAPIVersionParser::ProductionAPIVersionParser(
-    uint32_t defaultVersion,
-    uint32_t minVersion,
-    uint32_t maxVersion)
-    : defaultVersion_{defaultVersion}, minVersion_{minVersion}, maxVersion_{maxVersion}
-{
-#ifndef DEBUG
-    // in production, we don't want the ability to misconfigure clio with bogus versions
-    // that are not actually supported by the code itself. for testing it is desired however.
-    auto checkRange = [this](uint32_t version, std::string label) {
-        if (clamp(version, API_VERSION_MIN, API_VERSION_MAX) != version)
-        {
-            log_.error() << "API version settings issue detected: " << label << " version with value " << version
-                         << " is outside of supported range " << API_VERSION_MIN << "-" << API_VERSION_MAX
-                         << "; Falling back to hardcoded values.";
-
-            defaultVersion_ = API_VERSION_DEFAULT;
-            minVersion_ = API_VERSION_MIN;
-            maxVersion_ = API_VERSION_MAX;
-        }
-    };
-
-    checkRange(defaultVersion, "default");
-    checkRange(minVersion, "minimum");
-    checkRange(maxVersion, "maximum");
-#endif
-
-    log_.info() << "API version settings: [min = " << minVersion_ << "; max = " << maxVersion_
-                << "; default = " << defaultVersion_ << "]";
-}
 
 ProductionAPIVersionParser::ProductionAPIVersionParser(clio::Config const& config)
     : ProductionAPIVersionParser(

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -19,36 +19,31 @@
 
 #pragma once
 
-#include <rpc/common/Types.h>
+#include <config/Config.h>
+#include <log/Logger.h>
+#include <rpc/common/APIVersion.h>
+#include <util/Expected.h>
 
-#include <boost/json/value.hpp>
+namespace RPC::detail {
 
-#include <string>
-
-namespace RPC {
-
-/**
- * @brief The random command provides a random number to be used as a source of entropy for random number generation by
- * clients.
- *
- * For more details see: https://xrpl.org/random.html
- */
-class RandomHandler
+class ProductionAPIVersionParser : public APIVersionParser
 {
+    clio::Logger log_{"RPC"};
+
+    uint32_t defaultVersion_;
+    uint32_t minVersion_;
+    uint32_t maxVersion_;
+
 public:
-    struct Output
-    {
-        std::string random;
-    };
+    ProductionAPIVersionParser(
+        uint32_t defaultVersion = API_VERSION_DEFAULT,
+        uint32_t minVersion = API_VERSION_MIN,
+        uint32_t maxVersion = API_VERSION_MAX);
 
-    using Result = HandlerReturnType<Output>;
+    ProductionAPIVersionParser(clio::Config const& config);
 
-    Result
-    process(Context const& ctx) const;
-
-private:
-    friend void
-    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, Output const& output);
+    util::Expected<uint32_t, std::string>
+    parse(boost::json::object const& request) const override;
 };
 
-}  // namespace RPC
+}  // namespace RPC::detail

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -24,6 +24,9 @@
 #include <rpc/common/APIVersion.h>
 #include <util/Expected.h>
 
+#include <algorithm>
+#include <string>
+
 namespace RPC::detail {
 
 class ProductionAPIVersionParser : public APIVersionParser
@@ -35,10 +38,37 @@ class ProductionAPIVersionParser : public APIVersionParser
     uint32_t maxVersion_;
 
 public:
+    // Note: this constructor must remain in the header because of UNITTEST_BUILD definition below
     ProductionAPIVersionParser(
         uint32_t defaultVersion = API_VERSION_DEFAULT,
         uint32_t minVersion = API_VERSION_MIN,
-        uint32_t maxVersion = API_VERSION_MAX);
+        uint32_t maxVersion = API_VERSION_MAX)
+        : defaultVersion_{defaultVersion}, minVersion_{minVersion}, maxVersion_{maxVersion}
+    {
+#ifndef UNITTEST_BUILD
+        // in production, we don't want the ability to misconfigure clio with bogus versions
+        // that are not actually supported by the code itself. for testing it is desired however.
+        auto checkRange = [this](uint32_t version, std::string label) {
+            if (std::clamp(version, API_VERSION_MIN, API_VERSION_MAX) != version)
+            {
+                log_.error() << "API version settings issue detected: " << label << " version with value " << version
+                             << " is outside of supported range " << API_VERSION_MIN << "-" << API_VERSION_MAX
+                             << "; Falling back to hardcoded values.";
+
+                defaultVersion_ = API_VERSION_DEFAULT;
+                minVersion_ = API_VERSION_MIN;
+                maxVersion_ = API_VERSION_MAX;
+            }
+        };
+
+        checkRange(defaultVersion, "default");
+        checkRange(minVersion, "minimum");
+        checkRange(maxVersion, "maximum");
+#endif
+
+        log_.info() << "API version settings: [min = " << minVersion_ << "; max = " << maxVersion_
+                    << "; default = " << defaultVersion_ << "]";
+    }
 
     ProductionAPIVersionParser(clio::Config const& config);
 

--- a/src/rpc/common/impl/HandlerProvider.h
+++ b/src/rpc/common/impl/HandlerProvider.h
@@ -43,11 +43,7 @@ class ProductionHandlerProvider final : public HandlerProvider
     struct Handler
     {
         AnyHandler handler;
-        bool isClioOnly;
-
-        /* implicit */ Handler(AnyHandler handler, bool clioOnly = false) : handler{handler}, isClioOnly{clioOnly}
-        {
-        }
+        bool isClioOnly = false;
     };
 
     std::unordered_map<std::string, Handler> handlerMap_;

--- a/src/rpc/handlers/AccountChannels.h
+++ b/src/rpc/handlers/AccountChannels.h
@@ -88,7 +88,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountCurrencies.h
+++ b/src/rpc/handlers/AccountCurrencies.h
@@ -66,7 +66,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountInfo.h
+++ b/src/rpc/handlers/AccountInfo.h
@@ -81,7 +81,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::AccountValidator},

--- a/src/rpc/handlers/AccountLines.h
+++ b/src/rpc/handlers/AccountLines.h
@@ -87,7 +87,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountNFTs.h
+++ b/src/rpc/handlers/AccountNFTs.h
@@ -64,7 +64,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountObjects.h
+++ b/src/rpc/handlers/AccountObjects.h
@@ -75,7 +75,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountOffers.h
+++ b/src/rpc/handlers/AccountOffers.h
@@ -75,7 +75,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -81,7 +81,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/BookChanges.h
+++ b/src/rpc/handlers/BookChanges.h
@@ -60,7 +60,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(ledger_hash), validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/BookOffers.h
+++ b/src/rpc/handlers/BookOffers.h
@@ -65,7 +65,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(taker_gets),

--- a/src/rpc/handlers/GatewayBalances.h
+++ b/src/rpc/handlers/GatewayBalances.h
@@ -68,7 +68,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const hotWalletValidator =
             validation::CustomValidator{[](boost::json::value const& value, std::string_view key) -> MaybeError {

--- a/src/rpc/handlers/Ledger.h
+++ b/src/rpc/handlers/Ledger.h
@@ -65,7 +65,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(full), validation::Type<bool>{}, validation::NotSupported{true}},

--- a/src/rpc/handlers/LedgerData.h
+++ b/src/rpc/handlers/LedgerData.h
@@ -76,7 +76,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static const auto rpcSpec = RpcSpec{
             {JS(binary), validation::Type<bool>{}},

--- a/src/rpc/handlers/LedgerEntry.h
+++ b/src/rpc/handlers/LedgerEntry.h
@@ -74,7 +74,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         // Validator only works in this handler
         // The accounts array must have two different elements

--- a/src/rpc/handlers/LedgerRange.cpp
+++ b/src/rpc/handlers/LedgerRange.cpp
@@ -25,7 +25,7 @@
 namespace RPC {
 
 LedgerRangeHandler::Result
-LedgerRangeHandler::process() const
+LedgerRangeHandler::process([[maybe_unused]] Context const& ctx) const
 {
     // note: we can't get here if range is not available so it's safe
     return Output{sharedPtrBackend_->fetchLedgerRange().value()};

--- a/src/rpc/handlers/LedgerRange.h
+++ b/src/rpc/handlers/LedgerRange.h
@@ -50,7 +50,7 @@ public:
     }
 
     Result
-    process() const;
+    process(Context const& ctx) const;
 
 private:
     friend void

--- a/src/rpc/handlers/NFTHistory.h
+++ b/src/rpc/handlers/NFTHistory.h
@@ -81,7 +81,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(nft_id), validation::Required{}, validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/NFTInfo.h
+++ b/src/rpc/handlers/NFTInfo.h
@@ -68,7 +68,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(nft_id), validation::Required{}, validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/NFTOffersCommon.h
+++ b/src/rpc/handlers/NFTOffersCommon.h
@@ -59,7 +59,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(nft_id), validation::Required{}, validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/NoRippleCheck.h
+++ b/src/rpc/handlers/NoRippleCheck.h
@@ -67,7 +67,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},

--- a/src/rpc/handlers/Ping.h
+++ b/src/rpc/handlers/Ping.h
@@ -35,7 +35,7 @@ public:
     using Result = HandlerReturnType<Output>;
 
     Result
-    process() const
+    process([[maybe_unused]] Context const& ctx) const
     {
         return Output{};
     }

--- a/src/rpc/handlers/Random.cpp
+++ b/src/rpc/handlers/Random.cpp
@@ -26,7 +26,7 @@
 namespace RPC {
 
 RandomHandler::Result
-RandomHandler::process() const
+RandomHandler::process([[maybe_unused]] Context const& ctx) const
 {
     ripple::uint256 rand;
     beast::rngfill(rand.begin(), rand.size(), ripple::crypto_prng());

--- a/src/rpc/handlers/Subscribe.h
+++ b/src/rpc/handlers/Subscribe.h
@@ -72,7 +72,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const booksValidator =
             validation::CustomValidator{[](boost::json::value const& value, std::string_view key) -> MaybeError {

--- a/src/rpc/handlers/TransactionEntry.h
+++ b/src/rpc/handlers/TransactionEntry.h
@@ -62,7 +62,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
             {JS(tx_hash), validation::Required{}, validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -64,7 +64,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static const RpcSpec rpcSpec = {
             {JS(transaction), validation::Required{}, validation::Uint256HexStringValidator},

--- a/src/rpc/handlers/Unsubscribe.h
+++ b/src/rpc/handlers/Unsubscribe.h
@@ -58,7 +58,7 @@ public:
     }
 
     RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const booksValidator =
             validation::CustomValidator{[](boost::json::value const& value, std::string_view key) -> MaybeError {

--- a/src/util/Taggable.h
+++ b/src/util/Taggable.h
@@ -259,6 +259,9 @@ protected:
 
 public:
     virtual ~Taggable() = default;
+    Taggable(Taggable&&) = default;
+    Taggable&
+    operator=(Taggable&&) = default;
 
     /**
      * @brief Getter for tag decorator.

--- a/src/webserver/Context.h
+++ b/src/webserver/Context.h
@@ -32,37 +32,41 @@
 
 namespace Web {
 
-struct Context : public util::Taggable
+struct Context : util::Taggable
 {
-    clio::Logger perfLog_{"Performance"};
-    boost::asio::yield_context& yield;
+    std::reference_wrapper<boost::asio::yield_context> yield;
     std::string method;
-    std::uint32_t version;
-    boost::json::object const& params;
+    std::uint32_t apiVersion;
+    boost::json::object params;
     std::shared_ptr<Server::ConnectionBase> session;
-    Backend::LedgerRange const& range;
+    Backend::LedgerRange range;
     std::string clientIp;
 
     Context(
-        boost::asio::yield_context& yield_,
-        std::string const& command_,
-        std::uint32_t version_,
-        boost::json::object const& params_,
-        std::shared_ptr<Server::ConnectionBase> const& session_,
-        util::TagDecoratorFactory const& tagFactory_,
-        Backend::LedgerRange const& range_,
-        std::string const& clientIp_)
-        : Taggable(tagFactory_)
-        , yield(yield_)
-        , method(command_)
-        , version(version_)
-        , params(params_)
-        , session(session_)
-        , range(range_)
-        , clientIp(clientIp_)
+        boost::asio::yield_context& yield,
+        std::string const& command,
+        std::uint32_t apiVersion,
+        boost::json::object params,
+        std::shared_ptr<Server::ConnectionBase> const& session,
+        util::TagDecoratorFactory const& tagFactory,
+        Backend::LedgerRange const& range,
+        std::string const& clientIp)
+        : Taggable(tagFactory)
+        , yield(std::ref(yield))
+        , method(command)
+        , apiVersion(apiVersion)
+        , params(std::move(params))
+        , session(session)
+        , range(range)
+        , clientIp(clientIp)
     {
-        perfLog_.debug() << tag() << "new Context created";
+        static clio::Logger perfLog{"Performance"};
+        perfLog.debug() << tag() << "new Context created";
     }
+
+    Context(Context&&) = default;
+    Context&
+    operator=(Context&&) = default;
 };
 
 }  // namespace Web

--- a/unittests/Config.cpp
+++ b/unittests/Config.cpp
@@ -153,6 +153,21 @@ TEST_F(ConfigTest, Section)
     ASSERT_EQ(sub.value<bool>("bool"), true);
 }
 
+TEST_F(ConfigTest, SectionOr)
+{
+    {
+        auto sub = cfg.sectionOr("section.test", {});  // exists
+
+        ASSERT_EQ(sub.value<string>("str"), "hello");
+        ASSERT_EQ(sub.value<int64_t>("int"), 9042);
+        ASSERT_EQ(sub.value<bool>("bool"), true);
+    }
+    {
+        auto sub = cfg.sectionOr("section.doesnotexist", {{"int", 9043}});  // does not exist
+        ASSERT_EQ(sub.value<int64_t>("int"), 9043);                         // default from fallback
+    }
+}
+
 TEST_F(ConfigTest, Array)
 {
     auto arr = cfg.array("arr");

--- a/unittests/rpc/APIVersionTests.cpp
+++ b/unittests/rpc/APIVersionTests.cpp
@@ -1,0 +1,137 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <util/Fixtures.h>
+
+#include <rpc/common/impl/APIVersionParser.h>
+
+#include <boost/json/parse.hpp>
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+constexpr static auto DEFAULT_API_VERSION = 5u;
+constexpr static auto MIN_API_VERSION = 2u;
+constexpr static auto MAX_API_VERSION = 10u;
+
+using namespace RPC::detail;
+namespace json = boost::json;
+
+class RPCAPIVersionTest : public NoLoggerFixture
+{
+protected:
+    ProductionAPIVersionParser parser{DEFAULT_API_VERSION, MIN_API_VERSION, MAX_API_VERSION};
+};
+
+TEST_F(RPCAPIVersionTest, ReturnsDefaultVersionIfNotSpecified)
+{
+    auto ver = parser.parse(json::parse("{}").as_object());
+    EXPECT_TRUE(ver);
+    EXPECT_EQ(ver.value(), DEFAULT_API_VERSION);
+}
+
+TEST_F(RPCAPIVersionTest, ReturnsErrorIfVersionHigherThanMaxSupported)
+{
+    auto ver = parser.parse(json::parse(R"({"api_version": 11})").as_object());
+    EXPECT_FALSE(ver);
+}
+
+TEST_F(RPCAPIVersionTest, ReturnsErrorIfVersionLowerThanMinSupported)
+{
+    auto ver = parser.parse(json::parse(R"({"api_version": 1})").as_object());
+    EXPECT_FALSE(ver);
+}
+
+TEST_F(RPCAPIVersionTest, ReturnsErrorOnWrongType)
+{
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": null})").as_object());
+        EXPECT_FALSE(ver);
+    }
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": "5"})").as_object());
+        EXPECT_FALSE(ver);
+    }
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": "wrong"})").as_object());
+        EXPECT_FALSE(ver);
+    }
+}
+
+TEST_F(RPCAPIVersionTest, ReturnsParsedVersionIfAllPreconditionsAreMet)
+{
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": 2})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 2u);
+    }
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": 10})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 10u);
+    }
+    {
+        auto ver = parser.parse(json::parse(R"({"api_version": 5})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 5u);
+    }
+}
+
+TEST_F(RPCAPIVersionTest, GetsValuesFromConfigCorrectly)
+{
+    clio::Config cfg{json::parse(fmt::format(
+        R"({{
+            "min": {},
+            "max": {},
+            "default": {}
+        }})",
+        MIN_API_VERSION,
+        MAX_API_VERSION,
+        DEFAULT_API_VERSION))};
+
+    ProductionAPIVersionParser configuredParser{cfg};
+
+    {
+        auto ver = configuredParser.parse(json::parse(R"({"api_version": 2})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 2u);
+    }
+    {
+        auto ver = configuredParser.parse(json::parse(R"({"api_version": 10})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 10u);
+    }
+    {
+        auto ver = configuredParser.parse(json::parse(R"({"api_version": 5})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), 5u);
+    }
+    {
+        auto ver = configuredParser.parse(json::parse(R"({})").as_object());
+        EXPECT_TRUE(ver);
+        EXPECT_EQ(ver.value(), DEFAULT_API_VERSION);
+    }
+    {
+        auto ver = configuredParser.parse(json::parse(R"({"api_version": 11})").as_object());
+        EXPECT_FALSE(ver);
+    }
+    {
+        auto ver = configuredParser.parse(json::parse(R"({"api_version": 1})").as_object());
+        EXPECT_FALSE(ver);
+    }
+}

--- a/unittests/rpc/handlers/LedgerRangeTest.cpp
+++ b/unittests/rpc/handlers/LedgerRangeTest.cpp
@@ -36,25 +36,29 @@ class RPCLedgerRangeTest : public HandlerBaseTest
 
 TEST_F(RPCLedgerRangeTest, LedgerRangeMinMaxSame)
 {
-    mockBackendPtr->updateRange(RANGEMIN);
-    auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
-    auto const req = json::parse("{}");
-    auto const output = handler.process(req);
-    ASSERT_TRUE(output);
-    auto const json = output.value();
-    EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);
-    EXPECT_EQ(json.at("ledger_index_max").as_uint64(), RANGEMIN);
+    runSpawn([this](auto& yield) {
+        mockBackendPtr->updateRange(RANGEMIN);
+        auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
+        auto const req = json::parse("{}");
+        auto const output = handler.process(req, Context{std::ref(yield)});
+        ASSERT_TRUE(output);
+        auto const json = output.value();
+        EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);
+        EXPECT_EQ(json.at("ledger_index_max").as_uint64(), RANGEMIN);
+    });
 }
 
 TEST_F(RPCLedgerRangeTest, LedgerRangeFullySet)
 {
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
-    auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
-    auto const req = json::parse("{}");
-    auto const output = handler.process(req);
-    ASSERT_TRUE(output);
-    auto const json = output.value();
-    EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);
-    EXPECT_EQ(json.at("ledger_index_max").as_uint64(), RANGEMAX);
+    runSpawn([this](auto& yield) {
+        mockBackendPtr->updateRange(RANGEMIN);
+        mockBackendPtr->updateRange(RANGEMAX);
+        auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
+        auto const req = json::parse("{}");
+        auto const output = handler.process(req, Context{std::ref(yield)});
+        ASSERT_TRUE(output);
+        auto const json = output.value();
+        EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);
+        EXPECT_EQ(json.at("ledger_index_max").as_uint64(), RANGEMAX);
+    });
 }

--- a/unittests/rpc/handlers/PingTest.cpp
+++ b/unittests/rpc/handlers/PingTest.cpp
@@ -23,15 +23,17 @@
 
 using namespace RPC;
 
-class RPCPingHandlerTest : public NoLoggerFixture
+class RPCPingHandlerTest : public HandlerBaseTest
 {
 };
 
 // example handler tests
 TEST_F(RPCPingHandlerTest, Default)
 {
-    auto const handler = AnyHandler{PingHandler{}};
-    auto const output = handler.process(boost::json::parse(R"({})"));
-    ASSERT_TRUE(output);
-    EXPECT_EQ(output.value(), boost::json::parse(R"({})"));
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{PingHandler{}};
+        auto const output = handler.process(boost::json::parse(R"({})"), Context{std::ref(yield)});
+        ASSERT_TRUE(output);
+        EXPECT_EQ(output.value(), boost::json::parse(R"({})"));
+    });
 }

--- a/unittests/rpc/handlers/RandomTest.cpp
+++ b/unittests/rpc/handlers/RandomTest.cpp
@@ -24,15 +24,17 @@
 
 using namespace RPC;
 
-class RPCRandomHandlerTest : public NoLoggerFixture
+class RPCRandomHandlerTest : public HandlerBaseTest
 {
 };
 
 TEST_F(RPCRandomHandlerTest, Default)
 {
-    auto const handler = AnyHandler{RandomHandler{}};
-    auto const output = handler.process(boost::json::parse(R"({})"));
-    ASSERT_TRUE(output);
-    EXPECT_TRUE(output->as_object().contains(JS(random)));
-    EXPECT_EQ(output->as_object().at(JS(random)).as_string().size(), 64u);
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{RandomHandler{}};
+        auto const output = handler.process(boost::json::parse(R"({})"), Context{std::ref(yield)});
+        ASSERT_TRUE(output);
+        EXPECT_TRUE(output->as_object().contains(JS(random)));
+        EXPECT_EQ(output->as_object().at(JS(random)).as_string().size(), 64u);
+    });
 }

--- a/unittests/rpc/handlers/TestHandlerTests.cpp
+++ b/unittests/rpc/handlers/TestHandlerTests.cpp
@@ -31,83 +31,73 @@ using namespace unittests::detail;
 
 namespace json = boost::json;
 
-class RPCTestHandlerTest : public NoLoggerFixture
+class RPCTestHandlerTest : public HandlerBaseTest
 {
 };
 
 // example handler tests
 TEST_F(RPCTestHandlerTest, HandlerSuccess)
 {
-    auto const handler = AnyHandler{HandlerFake{}};
-    auto const input = json::parse(R"({ 
-        "hello": "world", 
-        "limit": 10
-    })");
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{HandlerFake{}};
+        auto const input = json::parse(R"({ 
+            "hello": "world", 
+            "limit": 10
+        })");
 
-    auto const output = handler.process(input);
-    ASSERT_TRUE(output);
-
-    auto const val = output.value();
-    EXPECT_EQ(val.as_object().at("computed").as_string(), "world_10");
-}
-
-TEST_F(RPCTestHandlerTest, CoroutineHandlerSuccess)
-{
-    auto const handler = AnyHandler{CoroutineHandlerFake{}};
-    auto const input = json::parse(R"({ 
-        "hello": "world", 
-        "limit": 10
-    })");
-    boost::asio::io_context ctx;
-    boost::asio::spawn(ctx, [&](boost::asio::yield_context yield) {
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_TRUE(output);
 
         auto const val = output.value();
         EXPECT_EQ(val.as_object().at("computed").as_string(), "world_10");
     });
-    ctx.run();
 }
 
 TEST_F(RPCTestHandlerTest, NoInputHandlerSuccess)
 {
-    auto const handler = AnyHandler{NoInputHandlerFake{}};
-    auto const output = handler.process(json::parse(R"({})"));
-    ASSERT_TRUE(output);
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{NoInputHandlerFake{}};
+        auto const output = handler.process(json::parse(R"({})"), Context{std::ref(yield)});
+        ASSERT_TRUE(output);
 
-    auto const val = output.value();
-    EXPECT_EQ(val.as_object().at("computed").as_string(), "test");
+        auto const val = output.value();
+        EXPECT_EQ(val.as_object().at("computed").as_string(), "test");
+    });
 }
 
 TEST_F(RPCTestHandlerTest, HandlerErrorHandling)
 {
-    auto const handler = AnyHandler{HandlerFake{}};
-    auto const input = json::parse(R"({ 
-        "hello": "not world", 
-        "limit": 10
-    })");
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{HandlerFake{}};
+        auto const input = json::parse(R"({ 
+            "hello": "not world", 
+            "limit": 10
+        })");
 
-    auto const output = handler.process(input);
-    ASSERT_FALSE(output);
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_FALSE(output);
 
-    auto const err = RPC::makeError(output.error());
-    EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-    EXPECT_EQ(err.at("error_message").as_string(), "Invalid parameters.");
-    EXPECT_EQ(err.at("error_code").as_uint64(), 31);
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+        EXPECT_EQ(err.at("error_message").as_string(), "Invalid parameters.");
+        EXPECT_EQ(err.at("error_code").as_uint64(), 31);
+    });
 }
 
 TEST_F(RPCTestHandlerTest, HandlerInnerErrorHandling)
 {
-    auto const handler = AnyHandler{FailingHandlerFake{}};
-    auto const input = json::parse(R"({ 
-        "hello": "world", 
-        "limit": 10
-    })");
+    runSpawn([](auto& yield) {
+        auto const handler = AnyHandler{FailingHandlerFake{}};
+        auto const input = json::parse(R"({ 
+            "hello": "world", 
+            "limit": 10
+        })");
 
-    // validation succeeds but handler itself returns error
-    auto const output = handler.process(input);
-    ASSERT_FALSE(output);
+        // validation succeeds but handler itself returns error
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_FALSE(output);
 
-    auto const err = RPC::makeError(output.error());
-    EXPECT_EQ(err.at("error").as_string(), "Very custom error");
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "Very custom error");
+    });
 }

--- a/unittests/rpc/handlers/impl/FakesAndMocks.h
+++ b/unittests/rpc/handlers/impl/FakesAndMocks.h
@@ -73,7 +73,7 @@ public:
     using Result = RPC::HandlerReturnType<Output>;
 
     RPC::RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         using namespace RPC::validation;
 
@@ -86,35 +86,7 @@ public:
     }
 
     Result
-    process(Input input) const
-    {
-        return Output{input.hello + '_' + std::to_string(input.limit.value_or(0))};
-    }
-};
-
-// example handler
-class CoroutineHandlerFake
-{
-public:
-    using Input = TestInput;
-    using Output = TestOutput;
-    using Result = RPC::HandlerReturnType<Output>;
-
-    RPC::RpcSpecConstRef
-    spec() const
-    {
-        using namespace RPC::validation;
-
-        static const auto rpcSpec = RPC::RpcSpec{
-            {"hello", Required{}, Type<std::string>{}, EqualTo{"world"}},
-            {"limit", Type<uint32_t>{}, Between<uint32_t>{0, 100}},  // optional field
-        };
-
-        return rpcSpec;
-    }
-
-    Result
-    process(Input input, RPC::Context const& ctx) const
+    process(Input input, [[maybe_unused]] RPC::Context const& ctx) const
     {
         return Output{input.hello + '_' + std::to_string(input.limit.value_or(0))};
     }
@@ -127,7 +99,7 @@ public:
     using Result = RPC::HandlerReturnType<Output>;
 
     Result
-    process() const
+    process([[maybe_unused]] RPC::Context const& ctx) const
     {
         return Output{"test"};
     }
@@ -142,7 +114,7 @@ public:
     using Result = RPC::HandlerReturnType<Output>;
 
     RPC::RpcSpecConstRef
-    spec() const
+    spec([[maybe_unused]] uint32_t apiVersion) const
     {
         using namespace RPC::validation;
 
@@ -155,7 +127,7 @@ public:
     }
 
     Result
-    process([[maybe_unused]] Input input) const
+    process([[maybe_unused]] Input input, [[maybe_unused]] RPC::Context const& ctx) const
     {
         // always fail
         return RPC::Error{RPC::Status{"Very custom error"}};
@@ -191,8 +163,8 @@ struct HandlerMock
     using Output = InOutFake;
     using Result = RPC::HandlerReturnType<Output>;
 
-    MOCK_METHOD(RPC::RpcSpecConstRef, spec, (), (const));
-    MOCK_METHOD(Result, process, (Input), (const));
+    MOCK_METHOD(RPC::RpcSpecConstRef, spec, (uint32_t), (const));
+    MOCK_METHOD(Result, process, (Input, RPC::Context const&), (const));
 };
 
 struct HandlerWithoutInputMock
@@ -200,7 +172,7 @@ struct HandlerWithoutInputMock
     using Output = InOutFake;
     using Result = RPC::HandlerReturnType<Output>;
 
-    MOCK_METHOD(Result, process, (), (const));
+    MOCK_METHOD(Result, process, (RPC::Context const&), (const));
 };
 
 }  // namespace unittests::detail


### PR DESCRIPTION
Fixes #64 

Adds a parser utility for parsing `api_version` out of request and validate it against configured values.
Supports reading configuration from config file with fallback to hardcoded values on misconfiguration.