### PR TITLE
Fix account_tx marker issue

### DIFF
--- a/src/backend/cassandra/Schema.h
+++ b/src/backend/cassandra/Schema.h
@@ -528,21 +528,19 @@ public:
                 SELECT hash, seq_idx 
                   FROM {}               
                  WHERE account = ?
-                   AND seq_idx <= ?
+                   AND seq_idx < ?
                  LIMIT ?
                 )",
                 qualifiedTableName(settingsProvider_.get(), "account_tx")));
         }();
 
-        // the smallest transaction idx is 0, we use uint to store the transaction index, so we shall use ">=" to
-        // include it(the transaction with idx 0) in the result
         PreparedStatement selectAccountTxForward = [this]() {
             return handle_.get().prepare(fmt::format(
                 R"(
                 SELECT hash, seq_idx 
                   FROM {}               
                  WHERE account = ?
-                   AND seq_idx >= ?
+                   AND seq_idx > ?
               ORDER BY seq_idx ASC 
                  LIMIT ?
                 )",

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -73,6 +73,8 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
     }
     else
     {
+        // if forward, start at minIndex - 1, because the SQL query is exclusive, we need to include the 0 transaction
+        // index of minIndex
         if (input.forward)
             cursor = {minIndex - 1, INT32_MAX};
         else

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -74,7 +74,7 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
     else
     {
         if (input.forward)
-            cursor = {minIndex, 0};
+            cursor = {minIndex - 1, INT32_MAX};
         else
             cursor = {maxIndex, INT32_MAX};
     }

--- a/unittests/rpc/handlers/AccountTxTest.cpp
+++ b/unittests/rpc/handlers/AccountTxTest.cpp
@@ -344,7 +344,11 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
     EXPECT_CALL(
         *rawBackendPtr,
         fetchAccountTransactions(
-            testing::_, testing::_, true, testing::Optional(testing::Eq(TransactionsCursor{MINSEQ-1, INT32_MAX})), testing::_))
+            testing::_,
+            testing::_,
+            true,
+            testing::Optional(testing::Eq(TransactionsCursor{MINSEQ - 1, INT32_MAX})),
+            testing::_))
         .Times(1);
 
     runSpawn([&, this](auto& yield) {

--- a/unittests/rpc/handlers/AccountTxTest.cpp
+++ b/unittests/rpc/handlers/AccountTxTest.cpp
@@ -265,7 +265,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
             testing::_,
             testing::_,
             true,
-            testing::Optional(testing::Eq(TransactionsCursor{MINSEQ + 1, 0})),
+            testing::Optional(testing::Eq(TransactionsCursor{MINSEQ, INT32_MAX})),
             testing::_))
         .Times(1);
 
@@ -344,7 +344,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
     EXPECT_CALL(
         *rawBackendPtr,
         fetchAccountTransactions(
-            testing::_, testing::_, true, testing::Optional(testing::Eq(TransactionsCursor{MINSEQ, 0})), testing::_))
+            testing::_, testing::_, true, testing::Optional(testing::Eq(TransactionsCursor{MINSEQ-1, INT32_MAX})), testing::_))
         .Times(1);
 
     runSpawn([&, this](auto& yield) {


### PR DESCRIPTION
There 2 two issues in account_tx.
1 The last tx in the page overlaps the first tx in the following page when marker is used. To fix it, we change the SQL to exclusive  < >
2 The tx of transaction index 0 can not be filtered out. To fix it , we change the SQL back to <= ; >=

This fix is to change the SQL to < and >. But decrease the seq number (seq-1, int32_max) to include the (seq,0) tx. According to the doc, the earliest ledger index is 1. https://xrpl.org/basic-data-types.html#ledger-index