### PR TITLE
Use InvalidLgrRange for type error

### DIFF
--- a/src/backend/DBHelpers.h
+++ b/src/backend/DBHelpers.h
@@ -181,16 +181,6 @@ isBookDir(T const& key, R const& object)
 
 template <class T>
 inline ripple::uint256
-getBook(T const& offer)
-{
-    ripple::SerialIter it{offer.data(), offer.size()};
-    ripple::SLE sle{it, {}};
-    ripple::uint256 book = sle.getFieldH256(ripple::sfBookDirectory);
-    return book;
-}
-
-template <class T>
-inline ripple::uint256
 getBookBase(T const& key)
 {
     assert(key.size() == ripple::uint256::size());

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -607,21 +607,6 @@ traverseOwnedNodes(
     return AccountCursor({beast::zero, 0});
 }
 
-std::shared_ptr<ripple::SLE const>
-read(
-    std::shared_ptr<Backend::BackendInterface const> const& backend,
-    ripple::Keylet const& keylet,
-    ripple::LedgerInfo const& lgrInfo,
-    Web::Context const& context)
-{
-    if (auto const blob = backend->fetchLedgerObject(keylet.key, lgrInfo.seq, context.yield); blob)
-    {
-        return std::make_shared<ripple::SLE const>(ripple::SerialIter{blob->data(), blob->size()}, keylet.key);
-    }
-
-    return nullptr;
-}
-
 std::optional<ripple::Seed>
 parseRippleLibSeed(boost::json::value const& value)
 {

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -425,15 +425,7 @@ traverseOwnedNodes(
     auto [hexCursor, startHint] = *maybeCursor;
 
     return traverseOwnedNodes(
-        backend,
-        ripple::keylet::ownerDir(accountID),
-        hexCursor,
-        startHint,
-        sequence,
-        limit,
-        jsonCursor,
-        yield,
-        atOwnedNode);
+        backend, ripple::keylet::ownerDir(accountID), hexCursor, startHint, sequence, limit, yield, atOwnedNode);
 }
 
 std::variant<Status, AccountCursor>
@@ -451,15 +443,7 @@ ngTraverseOwnedNodes(
     auto const [hexCursor, startHint] = *maybeCursor;
 
     return traverseOwnedNodes(
-        backend,
-        ripple::keylet::ownerDir(accountID),
-        hexCursor,
-        startHint,
-        sequence,
-        limit,
-        jsonCursor,
-        yield,
-        atOwnedNode);
+        backend, ripple::keylet::ownerDir(accountID), hexCursor, startHint, sequence, limit, yield, atOwnedNode);
 }
 
 std::variant<Status, AccountCursor>
@@ -470,7 +454,6 @@ traverseOwnedNodes(
     std::uint32_t const startHint,
     std::uint32_t sequence,
     std::uint32_t limit,
-    std::optional<std::string> jsonCursor,
     boost::asio::yield_context& yield,
     std::function<void(ripple::SLE&&)> atOwnedNode)
 {

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -119,7 +119,6 @@ traverseOwnedNodes(
     std::uint32_t const startHint,
     std::uint32_t sequence,
     std::uint32_t limit,
-    std::optional<std::string> jsonCursor,
     boost::asio::yield_context& yield,
     std::function<void(ripple::SLE&&)> atOwnedNode);
 

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -135,13 +135,6 @@ ngTraverseOwnedNodes(
     boost::asio::yield_context& yield,
     std::function<void(ripple::SLE&&)> atOwnedNode);
 
-std::shared_ptr<ripple::SLE const>
-read(
-    std::shared_ptr<Backend::BackendInterface const> const& backend,
-    ripple::Keylet const& keylet,
-    ripple::LedgerInfo const& lgrInfo,
-    Web::Context const& context);
-
 std::variant<Status, std::pair<ripple::PublicKey, ripple::SecretKey>>
 keypairFromRequst(boost::json::object const& request);
 

--- a/src/rpc/handlers/AccountInfo.h
+++ b/src/rpc/handlers/AccountInfo.h
@@ -65,6 +65,7 @@ public:
 
     // "queue" is not available in Reporting mode
     // "ident" is deprecated, keep it for now, in line with rippled
+    // TODO: We did not implement the "strict" field
     struct Input
     {
         std::optional<std::string> account;

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -57,7 +57,6 @@ public:
         bool validated = true;
     };
 
-    // TODO:we did not implement the "strict" field
     struct Input
     {
         std::string account;

--- a/src/rpc/handlers/NFTHistory.h
+++ b/src/rpc/handlers/NFTHistory.h
@@ -58,7 +58,6 @@ public:
         bool validated = true;
     };
 
-    // TODO: We did not implement the "strict" field
     struct Input
     {
         std::string nftID;

--- a/src/rpc/handlers/NFTOffersCommon.cpp
+++ b/src/rpc/handlers/NFTOffersCommon.cpp
@@ -111,15 +111,7 @@ NFTOffersHandlerBase::iterateOfferDirectory(
     }
 
     auto result = traverseOwnedNodes(
-        *sharedPtrBackend_,
-        directory,
-        cursor,
-        startHint,
-        lgrInfo.seq,
-        reserve,
-        {},
-        yield,
-        [&offers](ripple::SLE&& offer) {
+        *sharedPtrBackend_, directory, cursor, startHint, lgrInfo.seq, reserve, yield, [&offers](ripple::SLE&& offer) {
             if (offer.getType() == ripple::ltNFTOKEN_OFFER)
             {
                 offers.push_back(std::move(offer));

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -69,8 +69,14 @@ public:
         static const RpcSpec rpcSpec = {
             {JS(transaction), validation::Required{}, validation::Uint256HexStringValidator},
             {JS(binary), validation::Type<bool>{}},
-            {JS(min_ledger), validation::Type<uint32_t>{}},
-            {JS(max_ledger), validation::Type<uint32_t>{}},
+            // Usually , clio give "invalidParam" error when parameter type does not match
+            // but for tx method, doc specifies that:
+            // invalidLgrRange - The specified min_ledger is larger than the max_ledger, or one of those parameters is
+            // not a valid ledger index.
+            {JS(min_ledger),
+             validation::WithCustomError{validation::Type<uint32_t>{}, Status{RippledError::rpcINVALID_LGR_RANGE}}},
+            {JS(max_ledger),
+             validation::WithCustomError{validation::Type<uint32_t>{}, Status{RippledError::rpcINVALID_LGR_RANGE}}},
         };
 
         return rpcSpec;

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -48,7 +48,6 @@ public:
         bool validated = true;
     };
 
-    // TODO: we did not implement the "strict" field
     struct Input
     {
         std::string transaction;

--- a/unittests/rpc/handlers/TxTest.cpp
+++ b/unittests/rpc/handlers/TxTest.cpp
@@ -47,7 +47,7 @@ TEST_F(RPCTxTest, ExcessiveLgrRange)
                 "transaction": "{}",
                 "min_ledger": 1,
                 "max_ledger":1002
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -68,7 +68,7 @@ TEST_F(RPCTxTest, InvalidLgrRange)
                 "transaction": "{}",
                 "max_ledger": 1,
                 "min_ledger": 10
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -110,7 +110,7 @@ TEST_F(RPCTxTest, MinLedgerNotInt)
                 "transaction": "{}",
                 "max_ledger": 10,
                 "min_ledger": "xx"
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -133,7 +133,7 @@ TEST_F(RPCTxTest, TxnNotFound)
             R"({{ 
                 "command": "tx",
                 "transaction": "{}"
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -160,7 +160,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllFalse)
                 "transaction": "{}",
                 "min_ledger": 1,
                 "max_ledger":1000
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -188,7 +188,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllTrue)
                 "transaction": "{}",
                 "min_ledger": 1,
                 "max_ledger":1000
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -253,7 +253,7 @@ TEST_F(RPCTxTest, DefaultParameter)
             R"({{ 
                 "command": "tx",
                 "transaction": "{}"
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_TRUE(output);
@@ -287,7 +287,7 @@ TEST_F(RPCTxTest, ReturnBinary)
                 "command": "tx",
                 "transaction": "{}",
                 "binary": true
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/TxTest.cpp
+++ b/unittests/rpc/handlers/TxTest.cpp
@@ -89,7 +89,7 @@ TEST_F(RPCTxTest, MaxLedgerNotInt)
                 "transaction": "{}",
                 "max_ledger": "xx",
                 "min_ledger": 10
-                }})",
+            }})",
             TXNID));
         auto const output = handler.process(req, Context{std::ref(yield)});
         ASSERT_FALSE(output);


### PR DESCRIPTION
Usually Clio returns "invalidParam" error for parameter type error, for example, int is given for a field expecting string.
But for tx, the doc specifies 
"invalidLgrRange - The specified min_ledger is larger than the max_ledger, or one of those parameters is not a valid ledger index."
