### PR TITLE
Use clamp modifier on limit field instead of between validator

### DIFF
--- a/src/rpc/handlers/AccountChannels.h
+++ b/src/rpc/handlers/AccountChannels.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/JS.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -94,7 +95,7 @@ public:
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(destination_account), validation::Type<std::string>{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{10, 400}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{10, 400}},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
         };

--- a/src/rpc/handlers/AccountLines.h
+++ b/src/rpc/handlers/AccountLines.h
@@ -22,6 +22,7 @@
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -97,7 +98,7 @@ public:
             {JS(peer), meta::WithCustomError{validation::AccountValidator, Status(RippledError::rpcACT_MALFORMED)}},
             {JS(ignore_default), validation::Type<bool>{}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{10, 400}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{10, 400}},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
         };

--- a/src/rpc/handlers/AccountNFTs.h
+++ b/src/rpc/handlers/AccountNFTs.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -71,7 +72,7 @@ public:
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{20, 400}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{20, 400}},
         };
 
         return rpcSpec;

--- a/src/rpc/handlers/AccountObjects.h
+++ b/src/rpc/handlers/AccountObjects.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -81,7 +82,7 @@ public:
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between(10, 400)},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>(10, 400)},
             {JS(type),
              validation::Type<std::string>{},
              validation::OneOf<std::string>{

--- a/src/rpc/handlers/AccountOffers.h
+++ b/src/rpc/handlers/AccountOffers.h
@@ -22,6 +22,7 @@
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -83,7 +84,7 @@ public:
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{10, 400}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{10, 400}},
             {JS(strict), meta::IfType<bool>{validation::NotSupported{false}}},
         };
 

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -23,6 +23,7 @@
 #include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -91,7 +92,9 @@ public:
             {JS(ledger_index_max), validation::Type<int32_t>{}},
             {JS(binary), validation::Type<bool>{}},
             {JS(forward), validation::Type<bool>{}},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{1, std::numeric_limits<int32_t>::max()}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             modifiers::Clamp<int32_t>{1, std::numeric_limits<int32_t>::max()}},
             {JS(marker),
              meta::WithCustomError{
                  validation::Type<boost::json::object>{},

--- a/src/rpc/handlers/BookOffers.h
+++ b/src/rpc/handlers/BookOffers.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -91,7 +92,7 @@ public:
             {JS(taker),
              meta::WithCustomError{
                  validation::AccountValidator, Status(RippledError::rpcINVALID_PARAMS, "Invalid field 'taker'")}},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{1, 100}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{1, 100}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
         };

--- a/src/rpc/handlers/NFTHistory.h
+++ b/src/rpc/handlers/NFTHistory.h
@@ -23,6 +23,7 @@
 #include <log/Logger.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -91,7 +92,7 @@ public:
             {JS(ledger_index_max), validation::Type<int32_t>{}},
             {JS(binary), validation::Type<bool>{}},
             {JS(forward), validation::Type<bool>{}},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{1, 100}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{1, 100}},
             {JS(marker),
              meta::WithCustomError{
                  validation::Type<boost::json::object>{}, Status{RippledError::rpcINVALID_PARAMS, "invalidMarker"}},

--- a/src/rpc/handlers/NFTOffersCommon.h
+++ b/src/rpc/handlers/NFTOffersCommon.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -65,7 +66,7 @@ public:
             {JS(nft_id), validation::Required{}, validation::Uint256HexStringValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>{}, validation::Between{50, 500}},
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{50, 500}},
             {JS(marker), validation::Uint256HexStringValidator},
         };
 

--- a/src/rpc/handlers/NoRippleCheck.h
+++ b/src/rpc/handlers/NoRippleCheck.h
@@ -22,6 +22,7 @@
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/MetaProcessors.h>
+#include <rpc/common/Modifiers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -79,7 +80,7 @@ public:
                  Status{RippledError::rpcINVALID_PARAMS, "role field is invalid"}}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>(), validation::Between{1, 500}},
+            {JS(limit), validation::Type<uint32_t>(), modifiers::Clamp<int32_t>{1, 500}},
             {JS(transactions), validation::Type<bool>()},
         };
 

--- a/unittests/rpc/handlers/AccountChannelsTest.cpp
+++ b/unittests/rpc/handlers/AccountChannelsTest.cpp
@@ -36,11 +36,11 @@ constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B25
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 constexpr static auto TXNID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD";
 
-class RPCAccountHandlerTest : public HandlerBaseTest
+class RPCAccountChannelsHandlerTest : public HandlerBaseTest
 {
 };
 
-TEST_F(RPCAccountHandlerTest, NonHexLedgerHash)
+TEST_F(RPCAccountChannelsHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -60,7 +60,7 @@ TEST_F(RPCAccountHandlerTest, NonHexLedgerHash)
     });
 }
 
-TEST_F(RPCAccountHandlerTest, NonStringLedgerHash)
+TEST_F(RPCAccountChannelsHandlerTest, NonStringLedgerHash)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -80,7 +80,7 @@ TEST_F(RPCAccountHandlerTest, NonStringLedgerHash)
     });
 }
 
-TEST_F(RPCAccountHandlerTest, InvalidLedgerIndexString)
+TEST_F(RPCAccountChannelsHandlerTest, InvalidLedgerIndexString)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -100,7 +100,7 @@ TEST_F(RPCAccountHandlerTest, InvalidLedgerIndexString)
     });
 }
 
-TEST_F(RPCAccountHandlerTest, MarkerNotString)
+TEST_F(RPCAccountChannelsHandlerTest, MarkerNotString)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -122,7 +122,7 @@ TEST_F(RPCAccountHandlerTest, MarkerNotString)
 // error case : invalid marker
 // marker format is composed of a comma separated index and start hint. The
 // former will be read as hex, and the latter using boost lexical cast.
-TEST_F(RPCAccountHandlerTest, InvalidMarker)
+TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -155,41 +155,8 @@ TEST_F(RPCAccountHandlerTest, InvalidMarker)
     });
 }
 
-// the limit is between 10 400
-TEST_F(RPCAccountHandlerTest, IncorrectLimit)
-{
-    runSpawn([this](auto& yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const input = json::parse(fmt::format(
-            R"({{ 
-                "account": "{}", 
-                "limit": 9
-            }})",
-            ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_FALSE(output);
-
-        auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-    });
-    runSpawn([this](auto& yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const input = json::parse(fmt::format(
-            R"({{ 
-                "account": "{}", 
-                "limit": 401
-            }})",
-            ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_FALSE(output);
-
-        auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-    });
-}
-
 // error case: account invalid format, length is incorrect
-TEST_F(RPCAccountHandlerTest, AccountInvalidFormat)
+TEST_F(RPCAccountChannelsHandlerTest, AccountInvalidFormat)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -205,7 +172,7 @@ TEST_F(RPCAccountHandlerTest, AccountInvalidFormat)
 }
 
 // error case: account invalid format
-TEST_F(RPCAccountHandlerTest, AccountNotString)
+TEST_F(RPCAccountChannelsHandlerTest, AccountNotString)
 {
     runSpawn([this](auto& yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
@@ -222,7 +189,7 @@ TEST_F(RPCAccountHandlerTest, AccountNotString)
 }
 
 // error case ledger non exist via hash
-TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerHash)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     // mock fetchLedgerByHash return empty
@@ -249,7 +216,7 @@ TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerHash)
 }
 
 // error case ledger non exist via index
-TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerStringIndex)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -273,7 +240,7 @@ TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerStringIndex)
     });
 }
 
-TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerIntIndex)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -299,7 +266,7 @@ TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerIntIndex)
 
 // error case ledger > max seq via hash
 // idk why this case will happen in reality
-TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerHash2)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -326,7 +293,7 @@ TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerHash2)
 }
 
 // error case ledger > max seq via index
-TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerIndex2)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -351,7 +318,7 @@ TEST_F(RPCAccountHandlerTest, NonExistLedgerViaLedgerIndex2)
 }
 
 // error case account not exist
-TEST_F(RPCAccountHandlerTest, NonExistAccount)
+TEST_F(RPCAccountChannelsHandlerTest, NonExistAccount)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -380,7 +347,7 @@ TEST_F(RPCAccountHandlerTest, NonExistAccount)
 }
 
 // normal case when only provide account
-TEST_F(RPCAccountHandlerTest, DefaultParameterTest)
+TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
 {
     constexpr static auto correctOutput = R"({
         "account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -454,14 +421,14 @@ TEST_F(RPCAccountHandlerTest, DefaultParameterTest)
 }
 
 // normal case : limit is used
-TEST_F(RPCAccountHandlerTest, UseLimit)
+TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
     mockBackendPtr->updateRange(30);  // max
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
     ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(3);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
@@ -486,28 +453,53 @@ TEST_F(RPCAccountHandlerTest, UseLimit)
     ownerDir.setFieldU64(ripple::sfIndexNext, 99);
     ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(7);
 
     ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
-    auto const input = json::parse(fmt::format(
-        R"({{ 
-            "account": "{}",
-            "limit": 20
-        }})",
-        ACCOUNT));
-    runSpawn([&, this](auto& yield) {
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(3);
+
+    runSpawn([this](auto& yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}",
+                "limit": 20
+            }})",
+            ACCOUNT));
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_TRUE(output);
 
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 20);
         EXPECT_THAT((*output).as_object().at("marker").as_string().c_str(), EndsWith(",0"));
     });
+
+    runSpawn([this](auto& yield) {
+        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}", 
+                "limit": 9
+            }})",
+            ACCOUNT));
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_TRUE(output);  // todo: check limit?
+    });
+
+    runSpawn([this](auto& yield) {
+        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}", 
+                "limit": 401
+            }})",
+            ACCOUNT));
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_TRUE(output);  // todo: check limit?
+    });
 }
 
 // normal case : destination is used
-TEST_F(RPCAccountHandlerTest, UseDestination)
+TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -570,7 +562,7 @@ TEST_F(RPCAccountHandlerTest, UseDestination)
 }
 
 // normal case : but the lines is emtpy
-TEST_F(RPCAccountHandlerTest, EmptyChannel)
+TEST_F(RPCAccountChannelsHandlerTest, EmptyChannel)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -606,7 +598,7 @@ TEST_F(RPCAccountHandlerTest, EmptyChannel)
 }
 
 // Return expiration cancel_offer source_tag destination_tag when available
-TEST_F(RPCAccountHandlerTest, OptionalResponseField)
+TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
 {
     constexpr static auto correctOutput = R"({
         "account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -691,7 +683,7 @@ TEST_F(RPCAccountHandlerTest, OptionalResponseField)
 }
 
 // normal case : test marker output correct
-TEST_F(RPCAccountHandlerTest, MarkerOutput)
+TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min
@@ -760,7 +752,7 @@ TEST_F(RPCAccountHandlerTest, MarkerOutput)
 }
 
 // normal case : handler marker correctly
-TEST_F(RPCAccountHandlerTest, MarkerInput)
+TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 {
     MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
     mockBackendPtr->updateRange(10);  // min

--- a/unittests/rpc/handlers/AccountNFTsTest.cpp
+++ b/unittests/rpc/handlers/AccountNFTsTest.cpp
@@ -115,18 +115,6 @@ generateTestValuesForParametersTest()
             "Invalid parameters.",
         },
         {
-            "LimitOverMax",
-            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 401})",
-            "invalidParams",
-            "Invalid parameters.",
-        },
-        {
-            "LimitLessThanMin",
-            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 19})",
-            "invalidParams",
-            "Invalid parameters.",
-        },
-        {
             "MarkerNotString",
             R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 123})",
             "invalidParams",

--- a/unittests/rpc/handlers/AccountObjectsTest.cpp
+++ b/unittests/rpc/handlers/AccountObjectsTest.cpp
@@ -107,16 +107,6 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         AccountObjectsParamTestCaseBundle{
-            "LimitLargerThanMax",
-            R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "limit":401})",
-            "invalidParams",
-            "Invalid parameters."},
-        AccountObjectsParamTestCaseBundle{
-            "LimitLessThanMin",
-            R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "limit":9})",
-            "invalidParams",
-            "Invalid parameters."},
-        AccountObjectsParamTestCaseBundle{
             "MarkerNotString",
             R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "marker":9})",
             "invalidParams",

--- a/unittests/rpc/handlers/AccountOffersTest.cpp
+++ b/unittests/rpc/handlers/AccountOffersTest.cpp
@@ -108,18 +108,6 @@ generateTestValuesForParametersTest()
             "Invalid parameters.",
         },
         {
-            "LimitOverMax",
-            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 401})",
-            "invalidParams",
-            "Invalid parameters.",
-        },
-        {
-            "LimitLessThanMin",
-            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 9})",
-            "invalidParams",
-            "Invalid parameters.",
-        },
-        {
             "MarkerNotString",
             R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 123})",
             "invalidParams",

--- a/unittests/rpc/handlers/AccountTxTest.cpp
+++ b/unittests/rpc/handlers/AccountTxTest.cpp
@@ -107,11 +107,6 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         AccountTxParamTestCaseBundle{
-            "limitNotInRange",
-            R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
-            "invalidParams",
-            "Invalid parameters."},
-        AccountTxParamTestCaseBundle{
             "MarkerNotObject",
             R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 101})",
             "invalidParams",

--- a/unittests/rpc/handlers/BookOffersTest.cpp
+++ b/unittests/rpc/handlers/BookOffersTest.cpp
@@ -290,38 +290,6 @@ generateParameterBookOffersTestBundles()
             "invalidParams",
             "Invalid parameters."},
         ParameterTestBundle{
-            "LimitLargerThanMax",
-            R"({
-                "taker_pays" : 
-                {
-                    "currency" : "CNY",
-                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                },
-                "taker_gets" : 
-                {
-                    "currency" : "XRP"
-                },
-                "limit": 101
-            })",
-            "invalidParams",
-            "Invalid parameters."},
-        ParameterTestBundle{
-            "LimitSmallerThanMin",
-            R"({
-                "taker_pays" : 
-                {
-                    "currency" : "CNY",
-                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                },
-                "taker_gets" : 
-                {
-                    "currency" : "XRP"
-                },
-                "limit": 0
-            })",
-            "invalidParams",
-            "Invalid parameters."},
-        ParameterTestBundle{
             "LedgerIndexInvalid",
             R"({
                 "taker_pays" : 

--- a/unittests/rpc/handlers/NFTBuyOffersTest.cpp
+++ b/unittests/rpc/handlers/NFTBuyOffersTest.cpp
@@ -315,39 +315,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, InvalidMarker)
     });
 }
 
-// the limit is between 50 500
-TEST_F(RPCNFTBuyOffersHandlerTest, IncorrectLimit)
-{
-    runSpawn([this](auto& yield) {
-        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const input = json::parse(fmt::format(
-            R"({{ 
-                "nft_id": "{}", 
-                "limit": 49
-            }})",
-            NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_FALSE(output);
-
-        auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-    });
-    runSpawn([this](auto& yield) {
-        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const input = json::parse(fmt::format(
-            R"({{ 
-                "nft_id": "{}", 
-                "limit": 501
-            }})",
-            NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_FALSE(output);
-
-        auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-    });
-}
-
 // normal case when only provide nft_id
 TEST_F(RPCNFTBuyOffersHandlerTest, DefaultParameters)
 {
@@ -525,7 +492,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
     mockBackendPtr->updateRange(30);  // max
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
     ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(3);
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -553,20 +520,20 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
     auto const secondKey = ripple::keylet::page(directory, startHint).key;
     ON_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(7);
 
     ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(3);
 
-    auto const input = json::parse(fmt::format(
-        R"({{
-            "nft_id": "{}",
-            "marker": "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC353",
-            "limit": 50
-        }})",
-        NFTID));
     runSpawn([&, this](auto& yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{
+                "nft_id": "{}",
+                "marker": "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC353",
+                "limit": 50
+            }})",
+            NFTID));
         auto const output = handler.process(input, Context{std::ref(yield)});
 
         ASSERT_TRUE(output);
@@ -574,5 +541,29 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
         // no marker/limit to output - we read all items already
         EXPECT_FALSE(output->as_object().contains("limit"));
         EXPECT_FALSE(output->as_object().contains("marker"));
+    });
+
+    runSpawn([this](auto& yield) {
+        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": 49
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_TRUE(output);  // todo: check limit somehow?
+    });
+
+    runSpawn([this](auto& yield) {
+        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": 501
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{std::ref(yield)});
+        ASSERT_TRUE(output);  // todo: check limit somehow?
     });
 }

--- a/unittests/rpc/handlers/NFTHistoryTest.cpp
+++ b/unittests/rpc/handlers/NFTHistoryTest.cpp
@@ -109,11 +109,6 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         NFTHistoryParamTestCaseBundle{
-            "limitOverRange",
-            R"({"nft_id":"00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004", "limit": 101})",
-            "invalidParams",
-            "Invalid parameters."},
-        NFTHistoryParamTestCaseBundle{
             "MarkerNotObject",
             R"({"nft_id":"00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004", "marker": 101})",
             "invalidParams",

--- a/unittests/rpc/handlers/NoRippleCheckTest.cpp
+++ b/unittests/rpc/handlers/NoRippleCheckTest.cpp
@@ -106,15 +106,6 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Required field 'role' missing"},
         NoRippleParamTestCaseBundle{
-            "LimitNotInRange",
-            R"({
-                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "role": "gateway",
-                "limit": 501
-             })",
-            "invalidParams",
-            "Invalid parameters."},
-        NoRippleParamTestCaseBundle{
             "LimitNotInt",
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",


### PR DESCRIPTION
This implements rippled-like clamping behaviour for all `limit` fields other than the special one in `ledger_data`.