### PR TITLE
Remove "strict"

### DIFF
--- a/src/rpc/handlers/AccountCurrencies.h
+++ b/src/rpc/handlers/AccountCurrencies.h
@@ -72,9 +72,7 @@ public:
         static auto const rpcSpec = RpcSpec{
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
-            {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(strict), meta::IfType<bool>{validation::NotSupported{false}}},
-        };
+            {JS(ledger_index), validation::LedgerIndexValidator}};
 
         return rpcSpec;
     }

--- a/src/rpc/handlers/AccountInfo.h
+++ b/src/rpc/handlers/AccountInfo.h
@@ -90,9 +90,7 @@ public:
             {JS(ident), validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(signer_lists), validation::Type<bool>{}},
-            {JS(strict), meta::IfType<bool>{validation::NotSupported{false}}},
-        };
+            {JS(signer_lists), validation::Type<bool>{}}};
 
         return rpcSpec;
     }

--- a/src/rpc/handlers/AccountOffers.h
+++ b/src/rpc/handlers/AccountOffers.h
@@ -84,9 +84,7 @@ public:
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{10, 400}},
-            {JS(strict), meta::IfType<bool>{validation::NotSupported{false}}},
-        };
+            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{10, 400}}};
 
         return rpcSpec;
     }

--- a/src/rpc/handlers/GatewayBalances.h
+++ b/src/rpc/handlers/GatewayBalances.h
@@ -106,9 +106,7 @@ public:
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(hotwallet), hotWalletValidator},
-            {JS(strict), meta::IfType<bool>{validation::NotSupported{false}}},
-        };
+            {JS(hotwallet), hotWalletValidator}};
 
         return rpcSpec;
     }

--- a/unittests/rpc/handlers/AccountCurrenciesTest.cpp
+++ b/unittests/rpc/handlers/AccountCurrenciesTest.cpp
@@ -40,30 +40,6 @@ class RPCAccountCurrenciesHandlerTest : public HandlerBaseTest
 {
 };
 
-TEST_F(RPCAccountCurrenciesHandlerTest, StrictSetToFalseUnsupported)
-{
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-
-    auto const static input = boost::json::parse(fmt::format(
-        R"({{
-            "account": "{}",
-            "strict": false
-        }})",
-        ACCOUNT));
-
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
-
-    runSpawn([&](auto& yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_FALSE(output);
-
-        auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "notSupported");
-        EXPECT_EQ(err.at("error_message").as_string(), "Not supported field 'strict's value 'false'");
-    });
-}
-
 TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
 {
     auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());

--- a/unittests/rpc/handlers/AccountInfoTest.cpp
+++ b/unittests/rpc/handlers/AccountInfoTest.cpp
@@ -91,11 +91,6 @@ generateTestValuesForParametersTest()
             R"({"ident":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "ledger_index":"a"})",
             "invalidParams",
             "ledgerIndexMalformed"},
-        AccountInfoParamTestCaseBundle{
-            "StrictFieldUnsupportedValue",
-            R"({"ident": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "strict": false})",
-            "notSupported",
-            "Not supported field 'strict's value 'false'"},
     };
 }
 

--- a/unittests/rpc/handlers/AccountOffersTest.cpp
+++ b/unittests/rpc/handlers/AccountOffersTest.cpp
@@ -119,12 +119,6 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Malformed cursor.",
         },
-        {
-            "StrictFieldUnsupportedValue",
-            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "strict": false})",
-            "notSupported",
-            "Not supported field 'strict's value 'false'",
-        },
     };
 }
 

--- a/unittests/rpc/handlers/GatewayBalancesTest.cpp
+++ b/unittests/rpc/handlers/GatewayBalancesTest.cpp
@@ -170,18 +170,6 @@ generateParameterTestBundles()
                 ACCOUNT),
             "invalidParams",
             "hotwalletMalformed"},
-        ParameterTestBundle{
-            "StrictFieldUnsupportedValue",
-            fmt::format(
-                R"({{
-                    "account": "{}",
-                    "hotwallet": "{}",
-                    "strict": false
-                }})",
-                ACCOUNT,
-                ACCOUNT2),
-            "notSupported",
-            "Not supported field 'strict's value 'false'"},
     };
 }
 


### PR DESCRIPTION
Since the "strict" got removed from document, Clio also remove all "strict" fields.