### PR TITLE
Missing "tx_hash" for transaction_entry

### DIFF
--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -80,12 +80,13 @@ getErrorInfo(ClioError code)
         {ClioError::rpcMALFORMED_ADDRESS, "malformedAddress", "Malformed address."},
         {ClioError::rpcINVALID_HOT_WALLET, "invalidHotWallet", "Invalid hot wallet."},
         {ClioError::rpcUNKNOWN_OPTION, "unknownOption", "Unknown option."},
+        {ClioError::rpcFIELD_NOT_FOUND_TRANSACTION, "fieldNotFoundTransaction", "Missing field."},
+        // special system errors
         {ClioError::rpcINVALID_API_VERSION, JS(invalid_API_version), "Invalid API version."},
         {ClioError::rpcCOMMAND_IS_MISSING, JS(missingCommand), "Method is not specified or is not a string."},
         {ClioError::rpcCOMMAND_NOT_STRING, "commandNotString", "Method is not a string."},
         {ClioError::rpcCOMMAND_IS_EMPTY, "emptyCommand", "Method is an empty string."},
         {ClioError::rpcPARAMS_UNPARSEABLE, "paramsUnparseable", "Params must be an array holding exactly one object."},
-        {ClioError::rpcFIELD_NOT_FOUND_TRANSACTION, "fieldNotFoundTransaction", "Missing field."},
     };
 
     auto matchByCode = [code](auto const& info) { return info.code == code; };

--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -85,6 +85,7 @@ getErrorInfo(ClioError code)
         {ClioError::rpcCOMMAND_NOT_STRING, "commandNotString", "Method is not a string."},
         {ClioError::rpcCOMMAND_IS_EMPTY, "emptyCommand", "Method is an empty string."},
         {ClioError::rpcPARAMS_UNPARSEABLE, "paramsUnparseable", "Params must be an array holding exactly one object."},
+        {ClioError::rpcFIELD_NOT_FOUND_TRANSACTION, "fieldNotFoundTransaction", "Missing field."},
     };
 
     auto matchByCode = [code](auto const& info) { return info.code == code; };

--- a/src/rpc/Errors.h
+++ b/src/rpc/Errors.h
@@ -41,6 +41,7 @@ enum class ClioError {
     rpcMALFORMED_ADDRESS = 5003,
     rpcINVALID_HOT_WALLET = 5004,
     rpcUNKNOWN_OPTION = 5005,
+    rpcFIELD_NOT_FOUND_TRANSACTION = 5006,
 
     // special system errors start with 6000
     rpcINVALID_API_VERSION = 6000,

--- a/src/rpc/handlers/TransactionEntry.h
+++ b/src/rpc/handlers/TransactionEntry.h
@@ -21,6 +21,7 @@
 
 #include <backend/BackendInterface.h>
 #include <rpc/RPCHelpers.h>
+#include <rpc/common/MetaProcessors.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
 
@@ -65,7 +66,9 @@ public:
     spec([[maybe_unused]] uint32_t apiVersion) const
     {
         static auto const rpcSpec = RpcSpec{
-            {JS(tx_hash), validation::Required{}, validation::Uint256HexStringValidator},
+            {JS(tx_hash),
+             meta::WithCustomError{validation::Required{}, Status(ClioError::rpcFIELD_NOT_FOUND_TRANSACTION)},
+             validation::Uint256HexStringValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
         };

--- a/src/webserver/details/ErrorHandling.h
+++ b/src/webserver/details/ErrorHandling.h
@@ -85,6 +85,7 @@ public:
                     case RPC::ClioError::rpcMALFORMED_OWNER:
                     case RPC::ClioError::rpcMALFORMED_ADDRESS:
                     case RPC::ClioError::rpcINVALID_HOT_WALLET:
+                    case RPC::ClioError::rpcFIELD_NOT_FOUND_TRANSACTION:
                         assert(false);  // this should never happen
                         break;
                 }

--- a/unittests/rpc/handlers/TransactionEntryTest.cpp
+++ b/unittests/rpc/handlers/TransactionEntryTest.cpp
@@ -45,8 +45,8 @@ TEST_F(RPCTransactionEntryHandlerTest, TxHashNotProvide)
         auto const output = handler.process(json::parse("{}"), Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
-        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
-        EXPECT_EQ(err.at("error_message").as_string(), "Required field 'tx_hash' missing");
+        EXPECT_EQ(err.at("error").as_string(), "fieldNotFoundTransaction");
+        EXPECT_EQ(err.at("error_message").as_string(), "Missing field.");
     });
 }
 


### PR DESCRIPTION
According to document, we shall return "fieldNotFoundTransaction" when tx_hash is missing
https://xrpl.org/transaction_entry.html#possible-errors
