### PR TITLE
Add "network_id" to server_info

### DIFF
--- a/src/rpc/handlers/ServerInfo.h
+++ b/src/rpc/handlers/ServerInfo.h
@@ -189,6 +189,7 @@ private:
                 jv.as_object()[JS(load_factor)] = rippledInfo.at(JS(load_factor));
                 jv.as_object()[JS(validation_quorum)] = rippledInfo.at(JS(validation_quorum));
                 jv.as_object()["rippled_version"] = rippledInfo.at(JS(build_version));
+                jv.as_object()[JS(network_id)] = rippledInfo.at(JS(network_id));
             }
             catch (std::exception const&)
             {

--- a/unittests/rpc/handlers/ServerInfoTest.cpp
+++ b/unittests/rpc/handlers/ServerInfoTest.cpp
@@ -115,6 +115,8 @@ protected:
         EXPECT_EQ(info.at("validation_quorum").as_int64(), 456);
         EXPECT_TRUE(info.contains("rippled_version"));
         EXPECT_STREQ(info.at("rippled_version").as_string().c_str(), "1234");
+        EXPECT_TRUE(info.contains("network_id"));
+        EXPECT_EQ(info.at("network_id").as_int64(), 2);
     }
 
     void
@@ -290,7 +292,8 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesPresent)
             "info": {
                 "build_version": "1234",
                 "validation_quorum": 456,
-                "load_factor": 234
+                "load_factor": 234,
+                "network_id": 2
             }
         }
     })");


### PR DESCRIPTION
[EASY]
Clio does not have this field. This PR forward it to server_info's response.
  
main    -> 0   testnet -> 1. devnet  -> 2
