### PR TITLE
Add time/uptime/amendment_blocked to server_info

### DIFF
--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -79,8 +79,7 @@ ETLService::monitor()
     auto rng = backend_->hardFetchLedgerRangeNoThrow();
     if (!rng)
     {
-        log_.info() << "Database is empty. Will download a ledger "
-                       "from the network.";
+        log_.info() << "Database is empty. Will download a ledger from the network.";
         std::optional<ripple::LedgerInfo> ledger;
 
         try
@@ -98,23 +97,22 @@ ETLService::monitor()
 
                 if (mostRecentValidated)
                 {
-                    log_.info() << "Ledger " << *mostRecentValidated << " has been validated. "
-                                << "Downloading...";
+                    log_.info() << "Ledger " << *mostRecentValidated << " has been validated. Downloading...";
                     ledger = ledgerLoader_.loadInitialLedger(*mostRecentValidated);
                 }
                 else
                 {
-                    log_.info() << "The wait for the next validated "
-                                << "ledger has been aborted. "
-                                << "Exiting monitor loop";
+                    log_.info() << "The wait for the next validated ledger has been aborted. Exiting monitor loop";
                     return;
                 }
             }
         }
         catch (std::runtime_error const& e)
         {
+            setAmendmentBlocked();
+
             log_.fatal()
-                << "Failed to load initial ledger, Exiting monitor loop : " << e.what()
+                << "Failed to load initial ledger, Exiting monitor loop: " << e.what()
                 << " Possible cause: The ETL node is not compatible with the version of the rippled lib Clio is using.";
             return;
         }

--- a/src/etl/ETLService.h
+++ b/src/etl/ETLService.h
@@ -153,6 +153,17 @@ public:
     }
 
     /**
+     * @brief Check for the amendment blocked state.
+     *
+     * @return true if currently amendment blocked; false otherwise
+     */
+    bool
+    isAmendmentBlocked() const
+    {
+        return state_.isAmendmentBlocked;
+    }
+
+    /**
      * @brief Get state of ETL as a JSON object
      */
     boost::json::object
@@ -236,4 +247,13 @@ private:
      */
     void
     doWork();
+
+    /**
+     * @brief Sets amendment blocked flag
+     */
+    void
+    setAmendmentBlocked()
+    {
+        state_.isAmendmentBlocked = true;
+    }
 };

--- a/src/etl/SystemState.h
+++ b/src/etl/SystemState.h
@@ -47,4 +47,9 @@ struct SystemState
      * @brief Whether a write conflict was detected
      */
     std::atomic_bool writeConflict = false;
+
+    /**
+     * @brief Whether we detected an amendment block
+     */
+    std::atomic_bool isAmendmentBlocked = false;
 };

--- a/src/etl/impl/Transformer.h
+++ b/src/etl/impl/Transformer.h
@@ -186,8 +186,10 @@ private:
         }
         catch (std::runtime_error const& e)
         {
+            setAmendmentBlocked();
+
             log_.fatal()
-                << "Failed to build next ledger : " << e.what()
+                << "Failed to build next ledger: " << e.what()
                 << " Possible cause: The ETL node is not compatible with the version of the rippled lib Clio is using.";
             return {ripple::LedgerInfo{}, false};
         }
@@ -413,6 +415,12 @@ private:
     setWriteConflict(bool conflict)
     {
         state_.get().writeConflict = conflict;
+    }
+
+    void
+    setAmendmentBlocked()
+    {
+        state_.get().isAmendmentBlocked = true;
     }
 };
 

--- a/src/rpc/Counters.cpp
+++ b/src/rpc/Counters.cpp
@@ -97,6 +97,12 @@ Counters::onInternalError()
     ++internalErrorCounter_;
 }
 
+std::chrono::seconds
+Counters::uptime() const
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - startupTime_);
+}
+
 boost::json::object
 Counters::report() const
 {

--- a/src/rpc/Counters.h
+++ b/src/rpc/Counters.h
@@ -54,9 +54,10 @@ class Counters
     std::atomic_uint64_t internalErrorCounter_;
 
     std::reference_wrapper<const WorkQueue> workQueue_;
+    std::chrono::time_point<std::chrono::system_clock> startupTime_;
 
 public:
-    Counters(WorkQueue const& wq) : workQueue_(std::cref(wq)){};
+    Counters(WorkQueue const& wq) : workQueue_(std::cref(wq)), startupTime_{std::chrono::system_clock::now()} {};
 
     static Counters
     make_Counters(WorkQueue const& wq)
@@ -93,6 +94,9 @@ public:
 
     void
     onInternalError();
+
+    std::chrono::seconds
+    uptime() const;
 
     boost::json::object
     report() const;

--- a/unittests/util/MockCounters.h
+++ b/unittests/util/MockCounters.h
@@ -37,4 +37,5 @@ struct MockCounters
     MOCK_METHOD(void, onUnknownCommand, (), ());
     MOCK_METHOD(void, onInternalError, (), ());
     MOCK_METHOD(boost::json::object, report, (), (const));
+    MOCK_METHOD(std::chrono::seconds, uptime, (), (const));
 };

--- a/unittests/util/MockETLService.h
+++ b/unittests/util/MockETLService.h
@@ -30,4 +30,5 @@ struct MockETLService
     MOCK_METHOD(std::chrono::time_point<std::chrono::system_clock>, getLastPublish, (), (const));
     MOCK_METHOD(std::uint32_t, lastPublishAgeSeconds, (), (const));
     MOCK_METHOD(std::uint32_t, lastCloseAgeSeconds, (), (const));
+    MOCK_METHOD(bool, isAmendmentBlocked, (), (const));
 };


### PR DESCRIPTION
Adds a few fields to `server_info` that are in `rippled` but were missing in `clio`.