### PR TITLE
added new RPC Handler "version"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(tests)
     unittests/rpc/handlers/AccountObjectsTest.cpp
     unittests/rpc/handlers/BookChangesTest.cpp
     unittests/rpc/handlers/LedgerTest.cpp
+    unittests/rpc/handlers/VersionHandlerTest.cpp
     # Backend
     unittests/backend/BackendFactoryTest.cpp
     unittests/backend/cassandra/BaseTests.cpp

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -201,8 +201,8 @@ try
 
     auto workQueue = WorkQueue::make_WorkQueue(config);
     auto counters = RPC::Counters::make_Counters(workQueue);
-    auto const handlerProvider =
-        std::make_shared<RPC::detail::ProductionHandlerProvider const>(backend, subscriptions, balancer, etl, counters);
+    auto const handlerProvider = std::make_shared<RPC::detail::ProductionHandlerProvider const>(
+        backend, subscriptions, balancer, etl, counters, config);
     auto const rpcEngine = RPC::RPCEngine::make_RPCEngine(
         config, backend, subscriptions, balancer, etl, dosGuard, workQueue, counters, handlerProvider);
 

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -27,10 +27,6 @@
 #include <algorithm>
 #include <string>
 
-namespace RPC {
-class VersionHandler;
-};
-
 namespace RPC::detail {
 
 class ProductionAPIVersionParser : public APIVersionParser
@@ -79,7 +75,23 @@ public:
     util::Expected<uint32_t, std::string>
     parse(boost::json::object const& request) const override;
 
-    friend class RPC::VersionHandler;
+    inline int
+    getDefaultVersion() const
+    {
+        return defaultVersion_;
+    }
+
+    inline int
+    getMinVersion() const
+    {
+        return minVersion_;
+    }
+
+    inline int
+    getMaxVersion() const
+    {
+        return maxVersion_;
+    }
 };
 
 }  // namespace RPC::detail

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -75,19 +75,19 @@ public:
     util::Expected<uint32_t, std::string>
     parse(boost::json::object const& request) const override;
 
-    inline int
+    inline uint32_t
     getDefaultVersion() const
     {
         return defaultVersion_;
     }
 
-    inline int
+    inline uint32_t
     getMinVersion() const
     {
         return minVersion_;
     }
 
-    inline int
+    inline uint32_t
     getMaxVersion() const
     {
         return maxVersion_;

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -27,6 +27,10 @@
 #include <algorithm>
 #include <string>
 
+namespace RPC {
+class VersionHandler;
+};
+
 namespace RPC::detail {
 
 class ProductionAPIVersionParser : public APIVersionParser
@@ -74,6 +78,8 @@ public:
 
     util::Expected<uint32_t, std::string>
     parse(boost::json::object const& request) const override;
+
+    friend class RPC::VersionHandler;
 };
 
 }  // namespace RPC::detail

--- a/src/rpc/common/impl/HandlerProvider.cpp
+++ b/src/rpc/common/impl/HandlerProvider.cpp
@@ -51,6 +51,7 @@
 #include <rpc/handlers/TransactionEntry.h>
 #include <rpc/handlers/Tx.h>
 #include <rpc/handlers/Unsubscribe.h>
+#include <rpc/handlers/VersionHandler.h>
 
 namespace RPC::detail {
 
@@ -59,7 +60,8 @@ ProductionHandlerProvider::ProductionHandlerProvider(
     std::shared_ptr<SubscriptionManager> const& subscriptionManager,
     std::shared_ptr<LoadBalancer> const& balancer,
     std::shared_ptr<ETLService const> const& etl,
-    Counters const& counters)
+    Counters const& counters,
+    clio::Config const& config)
     : handlerMap_{
           {"account_channels", {AccountChannelsHandler{backend}}},
           {"account_currencies", {AccountCurrenciesHandler{backend}}},
@@ -89,6 +91,7 @@ ProductionHandlerProvider::ProductionHandlerProvider(
           {"tx", {TxHandler{backend}}},
           {"subscribe", {SubscribeHandler{backend, subscriptionManager}}},
           {"unsubscribe", {UnsubscribeHandler{backend, subscriptionManager}}},
+          {"version", {VersionHandler{config}}},
       }
 {
 }

--- a/src/rpc/common/impl/HandlerProvider.h
+++ b/src/rpc/common/impl/HandlerProvider.h
@@ -54,7 +54,8 @@ public:
         std::shared_ptr<SubscriptionManager> const& subscriptionManager,
         std::shared_ptr<LoadBalancer> const& balancer,
         std::shared_ptr<ETLService const> const& etl,
-        Counters const& counters);
+        Counters const& counters,
+        clio::Config const& config);
 
     bool
     contains(std::string const& method) const override;

--- a/src/rpc/handlers/VersionHandler.h
+++ b/src/rpc/handlers/VersionHandler.h
@@ -75,7 +75,8 @@ private:
                  {"first", output.minVersion},
                  {"last", output.maxVersion},
                  {"good", output.currVersion},
-             }}};
+             }},
+        };
     }
 };
 

--- a/src/rpc/handlers/VersionHandler.h
+++ b/src/rpc/handlers/VersionHandler.h
@@ -1,0 +1,94 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <cassert>
+#include <rpc/Errors.h>
+#include <rpc/RPCHelpers.h>
+#include <rpc/common/APIVersion.h>
+#include <rpc/common/Types.h>
+#include <rpc/common/impl/APIVersionParser.h>
+
+namespace RPC {
+
+/**
+ * @brief The version command returns the min,max and current api Version we are using
+ *
+ */
+class VersionHandler
+{
+    RPC::detail::ProductionAPIVersionParser apiVersionParser_;
+
+public:
+    struct InfoSection
+    {
+        uint32_t minVersion;
+        uint32_t maxVersion;
+        uint32_t currVersion;
+    };
+
+    struct Output
+    {
+        InfoSection info;
+    };
+
+    explicit VersionHandler(clio::Config const& config)
+        : apiVersionParser_(
+              config.valueOr("default", API_VERSION_DEFAULT),
+              config.valueOr("min", API_VERSION_MIN),
+              config.valueOr("max", API_VERSION_MAX))
+    {
+    }
+
+    using Result = HandlerReturnType<Output>;
+
+    Result
+    process([[maybe_unused]] Context const& ctx) const
+    {
+        using namespace RPC;
+
+        auto output = Output{};
+        output.info.currVersion = apiVersionParser_.defaultVersion_;
+        output.info.minVersion = apiVersionParser_.minVersion_;
+        output.info.maxVersion = apiVersionParser_.maxVersion_;
+        return output;
+    }
+
+private:
+    friend void
+    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, Output const& output)
+    {
+        using boost::json::value_from;
+
+        jv = {{"version", value_from(output.info)}};
+    }
+
+    friend void
+    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, InfoSection const& info)
+    {
+        jv = {
+            {"first", info.minVersion},
+            {"last", info.maxVersion},
+            {"good", info.currVersion},
+        };
+    }
+};
+
+}  // namespace RPC

--- a/src/rpc/handlers/VersionHandler.h
+++ b/src/rpc/handlers/VersionHandler.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <rpc/Errors.h>
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/APIVersion.h>
@@ -37,16 +36,11 @@ class VersionHandler
     RPC::detail::ProductionAPIVersionParser apiVersionParser_;
 
 public:
-    struct InfoSection
+    struct Output
     {
         uint32_t minVersion;
         uint32_t maxVersion;
         uint32_t currVersion;
-    };
-
-    struct Output
-    {
-        InfoSection info;
     };
 
     explicit VersionHandler(clio::Config const& config)
@@ -65,9 +59,9 @@ public:
         using namespace RPC;
 
         auto output = Output{};
-        output.info.currVersion = apiVersionParser_.defaultVersion_;
-        output.info.minVersion = apiVersionParser_.minVersion_;
-        output.info.maxVersion = apiVersionParser_.maxVersion_;
+        output.currVersion = apiVersionParser_.getDefaultVersion();
+        output.minVersion = apiVersionParser_.getMinVersion();
+        output.maxVersion = apiVersionParser_.getMaxVersion();
         return output;
     }
 
@@ -75,19 +69,13 @@ private:
     friend void
     tag_invoke(boost::json::value_from_tag, boost::json::value& jv, Output const& output)
     {
-        using boost::json::value_from;
-
-        jv = {{"version", value_from(output.info)}};
-    }
-
-    friend void
-    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, InfoSection const& info)
-    {
         jv = {
-            {"first", info.minVersion},
-            {"last", info.maxVersion},
-            {"good", info.currVersion},
-        };
+            {"version",
+             {
+                 {"first", output.minVersion},
+                 {"last", output.maxVersion},
+                 {"good", output.currVersion},
+             }}};
     }
 };
 

--- a/unittests/rpc/handlers/VersionHandlerTest.cpp
+++ b/unittests/rpc/handlers/VersionHandlerTest.cpp
@@ -17,10 +17,12 @@
 */
 //==============================================================================
 
-#include <rpc/common/AnyHandler.h>
-#include <rpc/handlers/VersionHandler.h>
 #include <util/Fixtures.h>
 #include <util/TestObject.h>
+
+#include <rpc/common/AnyHandler.h>
+#include <rpc/handlers/VersionHandler.h>
+
 
 constexpr static auto DEFAULT_API_VERSION = 3u;
 constexpr static auto MIN_API_VERSION = 2u;
@@ -47,7 +49,7 @@ TEST_F(RPCVersionHandlerTest, Default)
 
     runSpawn([&](auto& yield) {
         auto const handler = AnyHandler{VersionHandler{cfg}};
-        RPC::ReturnType const output = handler.process(static_cast<json::value>(cfg), Context{std::ref(yield)});
+        auto const output = handler.process(static_cast<json::value>(cfg), Context{std::ref(yield)});
         ASSERT_TRUE(output);
 
         // check all against all the correct values

--- a/unittests/rpc/handlers/VersionHandlerTest.cpp
+++ b/unittests/rpc/handlers/VersionHandlerTest.cpp
@@ -1,0 +1,64 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <rpc/common/AnyHandler.h>
+#include <rpc/handlers/VersionHandler.h>
+#include <util/Fixtures.h>
+#include <util/TestObject.h>
+
+constexpr static auto DEFAULT_API_VERSION = 3u;
+constexpr static auto MIN_API_VERSION = 2u;
+constexpr static auto MAX_API_VERSION = 10u;
+
+using namespace RPC;
+namespace json = boost::json;
+
+class RPCVersionHandlerTest : public HandlerBaseTest
+{
+};
+
+TEST_F(RPCVersionHandlerTest, Default)
+{
+    clio::Config cfg{json::parse(fmt::format(
+        R"({{
+            "min": {},
+            "max": {},
+            "default": {}
+        }})",
+        MIN_API_VERSION,
+        MAX_API_VERSION,
+        DEFAULT_API_VERSION))};
+
+    runSpawn([&](auto& yield) {
+        auto const handler = AnyHandler{VersionHandler{cfg}};
+        RPC::ReturnType const output = handler.process(static_cast<json::value>(cfg), Context{std::ref(yield)});
+        ASSERT_TRUE(output);
+
+        // check all against all the correct values
+        auto const& result = output.value().as_object();
+        EXPECT_TRUE(result.contains("version"));
+        auto const& info = result.at("version").as_object();
+        EXPECT_TRUE(info.contains("first"));
+        EXPECT_TRUE(info.contains("last"));
+        EXPECT_TRUE(info.contains("good"));
+        EXPECT_EQ(info.at("first"), 2u);
+        EXPECT_EQ(info.at("last"), 10u);
+        EXPECT_EQ(info.at("good"), 3u);
+    });
+}


### PR DESCRIPTION
Added a new RPC Handler named "version". This will show the version api formatted exactly how rippled does it. 