### PR TITLE
Fix for failed tests due to conan migration / XRPFees Amendment

### DIFF
--- a/src/backend/BackendInterface.cpp
+++ b/src/backend/BackendInterface.cpp
@@ -308,10 +308,6 @@ BackendInterface::fetchFees(std::uint32_t const seq, boost::asio::yield_context&
     if (sle.getFieldIndex(ripple::sfBaseFee) != -1)
         fees.base = sle.getFieldU64(ripple::sfBaseFee);
 
-    // deprecated?
-    // if (sle.getFieldIndex(ripple::sfReferenceFeeUnits) != -1)
-    //     fees.units = sle.getFieldU32(ripple::sfReferenceFeeUnits);
-
     if (sle.getFieldIndex(ripple::sfReserveBase) != -1)
         fees.reserve = sle.getFieldU32(ripple::sfReserveBase);
 

--- a/src/rpc/handlers/NoRippleCheck.cpp
+++ b/src/rpc/handlers/NoRippleCheck.cpp
@@ -46,8 +46,7 @@ NoRippleCheckHandler::process(NoRippleCheckHandler::Input input, Context const& 
     auto sle = ripple::SLE{it, keylet};
     auto accountSeq = sle.getFieldU32(ripple::sfSequence);
     bool const bDefaultRipple = sle.getFieldU32(ripple::sfFlags) & ripple::lsfDefaultRipple;
-    // TODO: remove if no longer needed
-    // auto const fees = input.transactions ? sharedPtrBackend_->fetchFees(lgrInfo.seq, ctx.yield) : std::nullopt;
+    auto const fees = input.transactions ? sharedPtrBackend_->fetchFees(lgrInfo.seq, ctx.yield) : std::nullopt;
 
     auto output = NoRippleCheckHandler::Output();
 
@@ -58,8 +57,7 @@ NoRippleCheckHandler::process(NoRippleCheckHandler::Input input, Context const& 
         boost::json::object tx;
         tx[JS(Sequence)] = accountSeq;
         tx[JS(Account)] = ripple::toBase58(accountID);
-        // TODO: deprecated?
-        // tx[JS(Fee)] = toBoostJson(fees->units.jsonClipped());
+        tx[JS(Fee)] = toBoostJson(fees->base.jsonClipped());
 
         return tx;
     };

--- a/src/subscriptions/SubscriptionManager.cpp
+++ b/src/subscriptions/SubscriptionManager.cpp
@@ -53,8 +53,6 @@ getLedgerPubMessage(
     pubMsg["ledger_hash"] = to_string(lgrInfo.hash);
     pubMsg["ledger_time"] = lgrInfo.closeTime.time_since_epoch().count();
 
-    // deprecated?
-    // pubMsg["fee_ref"] = RPC::toBoostJson(fees.units.jsonClipped());
     pubMsg["fee_base"] = RPC::toBoostJson(fees.base.jsonClipped());
     pubMsg["reserve_base"] = RPC::toBoostJson(fees.reserve.jsonClipped());
     pubMsg["reserve_inc"] = RPC::toBoostJson(fees.increment.jsonClipped());

--- a/unittests/SubscriptionManagerTest.cpp
+++ b/unittests/SubscriptionManagerTest.cpp
@@ -302,7 +302,6 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerLedger)
         "ledger_index":30,
         "ledger_hash":"4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
         "ledger_time":0,
-        "fee_ref":4,
         "fee_base":1,
         "reserve_base":3,
         "reserve_inc":2
@@ -323,7 +322,6 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerLedger)
         "ledger_index":31,
         "ledger_hash":"4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
         "ledger_time":0,
-        "fee_ref":0,
         "fee_base":0,
         "reserve_base":10,
         "reserve_inc":0,

--- a/unittests/rpc/handlers/NoRippleCheckTest.cpp
+++ b/unittests/rpc/handlers/NoRippleCheckTest.cpp
@@ -616,14 +616,14 @@ TEST_F(RPCNoRippleCheckTest, NormalPathTransactions)
                     {{
                         "Sequence":{},
                         "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                        "Fee":4,
+                        "Fee":1,
                         "TransactionType":"AccountSet",
                         "SetFlag":8
                     }},
                     {{
                         "Sequence":{},
                         "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                        "Fee":4,
+                        "Fee":1,
                         "TransactionType":"TrustSet",
                         "LimitAmount":{{
                             "currency":"USD",
@@ -635,7 +635,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathTransactions)
                     {{
                         "Sequence":{},
                         "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                        "Fee":4,
+                        "Fee":1,
                         "TransactionType":"TrustSet",
                         "LimitAmount":{{
                             "currency":"USD",

--- a/unittests/rpc/handlers/SubscribeTest.cpp
+++ b/unittests/rpc/handlers/SubscribeTest.cpp
@@ -588,7 +588,6 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
             "ledger_index":30,
             "ledger_hash":"4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
             "ledger_time":0,
-            "fee_ref":4,
             "fee_base":1,
             "reserve_base":3,
             "reserve_inc":2
@@ -615,7 +614,6 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
         auto const output = handler.process(input, Context{std::ref(yield), session_});
         ASSERT_TRUE(output);
-        // FIXME: fee_ref is missing now. this is possibly correct. need to confirm:
         EXPECT_EQ(output->as_object(), json::parse(expectedOutput));
         std::this_thread::sleep_for(20ms);
         auto const report = subManager_->report();


### PR DESCRIPTION
These were the tests failing prior to this PR:

[  FAILED  ] SubscriptionManagerSimpleBackendTest.SubscriptionManagerLedger 
[  FAILED  ] RPCNoRippleCheckTest.NormalPathRoleGatewayDefaultRippleUnsetTrustLineNoRippleUnsetHighAccount 
[  FAILED  ] RPCNoRippleCheckTest.NormalPathTransactions 
[  FAILED  ] RPCSubscribeHandlerTest.StreamsLedger

fee_ref and Fees::units have been deprecated under the XRPFees Amendment. These changes reflect that on clio and as a result fixes/passes these tests. 

Note: In the `NormalPath` unit test for `noripple_check`. Fee value was changed from 4 to 1. I've ran all the `noripple_check` automation tests to validate my changes. Automation tests compare outputs from rippled and clio.