### PR TITLE
Fix connect_timeout request_timeout not work + tsan in RPCServerTestSuite

### DIFF
--- a/src/backend/cassandra/SettingsProvider.cpp
+++ b/src/backend/cassandra/SettingsProvider.cpp
@@ -123,6 +123,7 @@ SettingsProvider::parseSettings() const
     settings.maxConcurrentRequestsThreshold = config_.valueOr<uint32_t>(
         "max_concurrent_requests_threshold",
         (settings.maxReadRequestsOutstanding + settings.maxWriteRequestsOutstanding) / settings.coreConnectionsPerHost);
+
     auto const timeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
     if (timeoutSecond)
         settings.connectionTimeout = std::chrono::milliseconds{*timeoutSecond * 1000};

--- a/src/backend/cassandra/SettingsProvider.cpp
+++ b/src/backend/cassandra/SettingsProvider.cpp
@@ -124,9 +124,13 @@ SettingsProvider::parseSettings() const
         "max_concurrent_requests_threshold",
         (settings.maxReadRequestsOutstanding + settings.maxWriteRequestsOutstanding) / settings.coreConnectionsPerHost);
 
-    auto const timeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
-    if (timeoutSecond)
-        settings.connectionTimeout = std::chrono::milliseconds{*timeoutSecond * 1000};
+    auto const connectTimeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
+    if (connectTimeoutSecond)
+        settings.connectionTimeout = std::chrono::milliseconds{*connectTimeoutSecond * 1000};
+
+    auto const requestTimeoutSecond = config_.maybeValue<uint32_t>("request_timeout");
+    if (requestTimeoutSecond)
+        settings.requestTimeout = std::chrono::milliseconds{*requestTimeoutSecond * 1000};
 
     settings.certificate = parseOptionalCertificate();
     settings.username = config_.maybeValue<std::string>("username");

--- a/src/backend/cassandra/SettingsProvider.cpp
+++ b/src/backend/cassandra/SettingsProvider.cpp
@@ -123,6 +123,9 @@ SettingsProvider::parseSettings() const
     settings.maxConcurrentRequestsThreshold = config_.valueOr<uint32_t>(
         "max_concurrent_requests_threshold",
         (settings.maxReadRequestsOutstanding + settings.maxWriteRequestsOutstanding) / settings.coreConnectionsPerHost);
+    auto const timeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
+    if (timeoutSecond)
+        settings.connectionTimeout = std::chrono::milliseconds{*timeoutSecond * 1000};
 
     settings.certificate = parseOptionalCertificate();
     settings.username = config_.maybeValue<std::string>("username");

--- a/src/backend/cassandra/impl/ExecutionStrategy.h
+++ b/src/backend/cassandra/impl/ExecutionStrategy.h
@@ -77,7 +77,7 @@ public:
     using ResultType = typename HandleType::ResultType;
     using CompletionTokenType = boost::asio::yield_context;
 
-    DefaultExecutionStrategy(Settings settings, HandleType const& handle)
+    DefaultExecutionStrategy(Settings const& settings, HandleType const& handle)
         : maxWriteRequestsOutstanding_{settings.maxWriteRequestsOutstanding}
         , maxReadRequestsOutstanding_{settings.maxReadRequestsOutstanding}
         , work_{ioc_}

--- a/unittests/webserver/RPCServerHandlerTest.cpp
+++ b/unittests/webserver/RPCServerHandlerTest.cpp
@@ -114,7 +114,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPDefaultPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -149,7 +148,6 @@ TEST_F(WebRPCServerHandlerTest, WsNormalPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -189,7 +187,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPForwardedPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -232,7 +229,6 @@ TEST_F(WebRPCServerHandlerTest, WsForwardedPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -279,7 +275,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPErrorPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -320,7 +315,6 @@ TEST_F(WebRPCServerHandlerTest, WsErrorPath)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(45));
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -348,7 +342,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPNotReady)
     EXPECT_CALL(*rpcEngine, notifyNotReady).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -377,7 +370,6 @@ TEST_F(WebRPCServerHandlerTest, WsNotReady)
     EXPECT_CALL(*rpcEngine, notifyNotReady).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -398,10 +390,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPInvalidAPIVersion)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WSInvalidAPIVersion)
@@ -430,7 +420,6 @@ TEST_F(WebRPCServerHandlerTest, WSInvalidAPIVersion)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -458,7 +447,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPBadSyntaxWhenRequestSubscribe)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -474,10 +462,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPMissingCommand)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPCommandNotString)
@@ -492,10 +478,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandNotString)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPCommandIsEmpty)
@@ -510,10 +494,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandIsEmpty)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WsMissingCommand)
@@ -543,7 +525,6 @@ TEST_F(WebRPCServerHandlerTest, WsMissingCommand)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -562,10 +543,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableNotArray)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableEmptyArray)
@@ -583,10 +562,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableEmptyArray)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPInternalError)
@@ -617,7 +594,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPInternalError)
     EXPECT_CALL(*rpcEngine, buildResponse(testing::_)).Times(1).WillOnce(testing::Throw(std::runtime_error("MyError")));
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -650,7 +626,6 @@ TEST_F(WebRPCServerHandlerTest, WsInternalError)
     EXPECT_CALL(*rpcEngine, buildResponse(testing::_)).Times(1).WillOnce(testing::Throw(std::runtime_error("MyError")));
 
     (*handler)(std::move(requestJSON), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -687,7 +662,6 @@ TEST_F(WebRPCServerHandlerTest, HTTPOutDated)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(61));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -727,7 +701,6 @@ TEST_F(WebRPCServerHandlerTest, WsOutdated)
     EXPECT_CALL(*etl, lastCloseAgeSeconds()).WillOnce(testing::Return(61));
 
     (*handler)(std::move(request), session);
-    std::this_thread::sleep_for(200ms);
     EXPECT_EQ(boost::json::parse(session->message), boost::json::parse(response));
 }
 
@@ -799,9 +772,8 @@ TEST_F(WebRPCServerHandlerTest, HTTPRequestNotJson)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
-    rpcEngine->post(
-        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_THAT(session->message, testing::StartsWith(responsePrefix));
+    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WsRequestNotJson)

--- a/unittests/webserver/RPCServerHandlerTest.cpp
+++ b/unittests/webserver/RPCServerHandlerTest.cpp
@@ -399,8 +399,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPInvalidAPIVersion)
 
     (*handler)(std::move(request), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WSInvalidAPIVersion)

--- a/unittests/webserver/RPCServerHandlerTest.cpp
+++ b/unittests/webserver/RPCServerHandlerTest.cpp
@@ -475,8 +475,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPMissingCommand)
 
     (*handler)(std::move(request), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPCommandNotString)

--- a/unittests/webserver/RPCServerHandlerTest.cpp
+++ b/unittests/webserver/RPCServerHandlerTest.cpp
@@ -493,8 +493,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandNotString)
 
     (*handler)(std::move(request), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPCommandIsEmpty)
@@ -510,8 +511,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandIsEmpty)
 
     (*handler)(std::move(request), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WsMissingCommand)
@@ -561,8 +563,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableNotArray)
 
     (*handler)(std::move(requestJSON), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableEmptyArray)
@@ -581,8 +584,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableEmptyArray)
 
     (*handler)(std::move(requestJSON), session);
     std::this_thread::sleep_for(200ms);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_EQ(session->message, response);
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, HTTPInternalError)
@@ -795,8 +799,9 @@ TEST_F(WebRPCServerHandlerTest, HTTPRequestNotJson)
     EXPECT_CALL(*rpcEngine, notifyBadSyntax).Times(1);
 
     (*handler)(std::move(request), session);
+    rpcEngine->post(
+        [this](auto& yield) { EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request); }, "");
     EXPECT_THAT(session->message, testing::StartsWith(responsePrefix));
-    EXPECT_EQ(session->lastStatus, boost::beast::http::status::bad_request);
 }
 
 TEST_F(WebRPCServerHandlerTest, WsRequestNotJson)


### PR DESCRIPTION
1 Fix :WebRPCServerHandlerTest tsan thread problem:
   The issue is the other thread writes the lastStatus while main thread reads it to compare.
2 Fix :Timeout parameter not read
