### PR TITLE
Add cache loader test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if(tests)
     unittests/etl/ExtractionDataPipeTest.cpp
     unittests/etl/ExtractorTest.cpp
     unittests/etl/TransformerTest.cpp
+    unittests/etl/CacheLoaderTest.cpp
     # RPC
     unittests/rpc/ErrorTests.cpp
     unittests/rpc/BaseTests.cpp
@@ -211,8 +212,8 @@ if(tests)
 
   # TODO: support sanitizers properly
   # Tmp: uncomment for TSAN
-  # target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
-  # target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+   target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+   target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
 
   target_compile_definitions(${TEST_TARGET} PUBLIC UNITTEST_BUILD)
   target_include_directories(${TEST_TARGET} PRIVATE unittests)

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -457,7 +457,7 @@ traverseNFTObjects(
     }
 
     // the object exists and the key is in right range, must be nft page
-    ripple::SLE pageSLE{ripple::SLE{ripple::SerialIter{page->data(), page->size()}, currentPage}};
+    ripple::SLE pageSLE{ripple::SerialIter{page->data(), page->size()}, currentPage};
 
     auto count = 0u;
     // traverse the nft page linked list until the start of the list or reach the limit

--- a/src/rpc/handlers/AccountChannels.h
+++ b/src/rpc/handlers/AccountChannels.h
@@ -99,7 +99,10 @@ public:
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(destination_account), validation::Type<std::string>{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
         };

--- a/src/rpc/handlers/AccountLines.h
+++ b/src/rpc/handlers/AccountLines.h
@@ -102,7 +102,10 @@ public:
             {JS(peer), meta::WithCustomError{validation::AccountValidator, Status(RippledError::rpcACT_MALFORMED)}},
             {JS(ignore_default), validation::Type<bool>{}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
         };

--- a/src/rpc/handlers/AccountNFTs.h
+++ b/src/rpc/handlers/AccountNFTs.h
@@ -76,7 +76,10 @@ public:
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::Uint256HexStringValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
         };
 
         return rpcSpec;

--- a/src/rpc/handlers/AccountObjects.h
+++ b/src/rpc/handlers/AccountObjects.h
@@ -86,7 +86,10 @@ public:
             {JS(account), validation::Required{}, validation::AccountValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>(LIMIT_MIN, LIMIT_MAX)},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>(LIMIT_MIN, LIMIT_MAX)},
             {JS(type),
              validation::Type<std::string>{},
              validation::OneOf<std::string>{

--- a/src/rpc/handlers/AccountOffers.h
+++ b/src/rpc/handlers/AccountOffers.h
@@ -87,7 +87,10 @@ public:
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(marker), validation::AccountMarkerValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}}};
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}}};
 
         return rpcSpec;
     }

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -98,6 +98,7 @@ public:
             {JS(forward), validation::Type<bool>{}},
             {JS(limit),
              validation::Type<uint32_t>{},
+             validation::Min(1u),
              modifiers::Clamp<int32_t>{LIMIT_MIN, std::numeric_limits<int32_t>::max()}},
             {JS(marker),
              meta::WithCustomError{

--- a/src/rpc/handlers/BookOffers.h
+++ b/src/rpc/handlers/BookOffers.h
@@ -96,7 +96,10 @@ public:
             {JS(taker),
              meta::WithCustomError{
                  validation::AccountValidator, Status(RippledError::rpcINVALID_PARAMS, "Invalid field 'taker'")}},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
         };

--- a/src/rpc/handlers/LedgerData.h
+++ b/src/rpc/handlers/LedgerData.h
@@ -92,7 +92,11 @@ public:
             {"out_of_order", validation::Type<bool>{}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>{}},
+            {
+                JS(limit),
+                validation::Type<uint32_t>{},
+                validation::Min(1u),
+            },
             {JS(marker),
              validation::Type<uint32_t, std::string>{},
              meta::IfType<std::string>{validation::Uint256HexStringValidator}},

--- a/src/rpc/handlers/NFTHistory.h
+++ b/src/rpc/handlers/NFTHistory.h
@@ -96,7 +96,10 @@ public:
             {JS(ledger_index_max), validation::Type<int32_t>{}},
             {JS(binary), validation::Type<bool>{}},
             {JS(forward), validation::Type<bool>{}},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(marker),
              meta::WithCustomError{
                  validation::Type<boost::json::object>{}, Status{RippledError::rpcINVALID_PARAMS, "invalidMarker"}},

--- a/src/rpc/handlers/NFTOffersCommon.h
+++ b/src/rpc/handlers/NFTOffersCommon.h
@@ -70,7 +70,10 @@ public:
             {JS(nft_id), validation::Required{}, validation::Uint256HexStringValidator},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>{}, modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>{},
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(marker), validation::Uint256HexStringValidator},
         };
 

--- a/src/rpc/handlers/NoRippleCheck.h
+++ b/src/rpc/handlers/NoRippleCheck.h
@@ -84,7 +84,10 @@ public:
                  Status{RippledError::rpcINVALID_PARAMS, "role field is invalid"}}},
             {JS(ledger_hash), validation::Uint256HexStringValidator},
             {JS(ledger_index), validation::LedgerIndexValidator},
-            {JS(limit), validation::Type<uint32_t>(), modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
+            {JS(limit),
+             validation::Type<uint32_t>(),
+             validation::Min(1u),
+             modifiers::Clamp<int32_t>{LIMIT_MIN, LIMIT_MAX}},
             {JS(transactions), validation::Type<bool>()},
         };
 

--- a/unittests/etl/CacheLoaderTest.cpp
+++ b/unittests/etl/CacheLoaderTest.cpp
@@ -1,0 +1,142 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <backend/LedgerCache.h>
+#include <etl/impl/CacheLoader.h>
+#include <util/Fixtures.h>
+#include <util/MockCache.h>
+
+#include <boost/asio.hpp>
+#include <boost/json.hpp>
+#include <gtest/gtest.h>
+
+namespace json = boost::json;
+using namespace clio::detail;
+using namespace clio;
+using namespace Backend;
+using namespace testing;
+
+constexpr static auto SEQ = 30;
+constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
+
+struct CacheLoaderTest : public MockBackendTest
+{
+    void
+    SetUp() override
+    {
+        MockBackendTest::SetUp();
+        work.emplace(ctx);
+        for (auto i = 0; i < 2; ++i)
+            optThreads.emplace_back([&] { ctx.run(); });
+    }
+
+    void
+    TearDown() override
+    {
+        work.reset();
+        for (auto& optThread : optThreads)
+            if (optThread.joinable())
+                optThread.join();
+        ctx.stop();
+        MockBackendTest::TearDown();
+    }
+
+protected:
+    MockCache cache;
+    Config cfg{json::parse("{}")};
+    std::optional<boost::asio::io_service::work> work;
+    boost::asio::io_context ctx;
+    std::vector<std::thread> optThreads;
+};
+
+namespace {
+
+std::vector<LedgerObject>
+getLatestDiff()
+{
+    return std::vector<LedgerObject>{
+        {.key = ripple::uint256{"05E1EAC2574BE082B00B16F907CE32E6058DEB8F9E81CF34A00E80A5D71FA4FE"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"110872C7196EE6EF7032952F1852B11BB461A96FF2D7E06A8003B4BB30FD130B"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"3B3A84E850C724E914293271785A31D0BFC8B9DD1B6332E527B149AD72E80E18"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"4EC98C5C3F34C44409BC058998CBD64F6AED3FF6C0CAAEC15F7F42DF14EE9F04"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"58CEC9F17733EA7BA68C88E6179B8F207D001EE04D4E0366F958CC04FF6AB834"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"64FB1712146BA604C274CC335C5DE7ADFE52D1F8C3E904A9F9765FE8158A3E01"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"700BE23B1D9EE3E6BF52543D05843D5345B85D9EDB3D33BBD6B4C3A13C54B38E"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"82C297FCBCD634C4424F263D17480AA2F13975DF5846A5BB57246022CEEBE441"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"A2AA4C212DC2CA2C49BF58805F7C63363BC981018A01AC9609A7CBAB2A02CEDF"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"BC0DAE09C0BFBC4A49AA94B849266588BFD6E1F554B184B5788AC55D6E07EB95"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"DCC8759A35CB946511763AA5553A82AA25F20B901C98C9BB74D423BCFAFF5F9D"}, .blob = Blob{'s'}},
+    };
+}
+
+};  // namespace
+
+TEST_F(CacheLoaderTest, FromCache)
+{
+    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    CacheLoader loader{cfg, ctx, mockBackendPtr, cache};
+
+    auto const diffs = getLatestDiff();
+    ON_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).WillByDefault(Return(diffs));
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).Times(32);
+
+    auto const loops = diffs.size() + 1;
+    auto const keysSize = 14;
+    std::mutex g_pages_mutex;
+
+    std::map<std::thread::id, uint32_t> threadKeysMap;
+    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, SEQ, _))
+        .WillByDefault(Invoke([&]() -> std::optional<ripple::uint256> {
+            // mock the result from doFetchSuccessorKey, be aware this function will be called from multiple threads
+            // for each thread, the last 2 items must be end flag and nullopt, otherwise it will loop forever
+            std::lock_guard<std::mutex> guard(g_pages_mutex);
+            threadKeysMap[std::this_thread::get_id()]++;
+
+            if (threadKeysMap[std::this_thread::get_id()] == keysSize - 1)
+            {
+                return lastKey;
+            }
+            else if (threadKeysMap[std::this_thread::get_id()] == keysSize)
+            {
+                threadKeysMap[std::this_thread::get_id()] = 0;
+                return std::nullopt;
+            }
+            else
+            {
+                return ripple::uint256{INDEX1};
+            }
+        }));
+    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(keysSize * loops);
+
+    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(_, SEQ, _))
+        .WillByDefault(Return(std::vector<Blob>{keysSize - 1, Blob{'s'}}));
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(loops);
+
+    EXPECT_CALL(cache, size).Times(AtLeast(1));
+    EXPECT_CALL(cache, update).Times(loops);
+
+    loader.load(SEQ);
+    // Cache loader start a new thread to load the cache, so we need to wait for it to finish
+    auto maxWait = 100;
+    while (maxWait-- != 0 and !cache.isFull())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(cache.isFull());
+}

--- a/unittests/rpc/BaseTests.cpp
+++ b/unittests/rpc/BaseTests.cpp
@@ -58,9 +58,14 @@ TEST_F(RPCBaseTest, CheckType)
     ASSERT_TRUE(checkType<int32_t>(juint));
     ASSERT_FALSE(checkType<bool>(juint));
 
-    auto const jint = json::value(123);
+    auto jint = json::value(123);
     ASSERT_TRUE(checkType<int32_t>(jint));
     ASSERT_TRUE(checkType<uint32_t>(jint));
+    ASSERT_FALSE(checkType<bool>(jint));
+
+    jint = json::value(-123);
+    ASSERT_TRUE(checkType<int32_t>(jint));
+    ASSERT_FALSE(checkType<uint32_t>(jint));
     ASSERT_FALSE(checkType<bool>(jint));
 
     auto const jbool = json::value(true);
@@ -177,6 +182,38 @@ TEST_F(RPCBaseTest, BetweenValidator)
 
     auto failingInput2 = json::parse(R"({ "amount": 21 })");
     ASSERT_FALSE(spec.process(failingInput2));
+}
+
+TEST_F(RPCBaseTest, MinValidator)
+{
+    auto spec = RpcSpec{
+        {"amount", Min{6}},
+    };
+
+    auto passingInput = json::parse(R"({ "amount": 7 })");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    auto passingInput2 = json::parse(R"({ "amount": 6 })");
+    ASSERT_TRUE(spec.process(passingInput2));
+
+    auto failingInput = json::parse(R"({ "amount": 5 })");
+    ASSERT_FALSE(spec.process(failingInput));
+}
+
+TEST_F(RPCBaseTest, MaxValidator)
+{
+    auto spec = RpcSpec{
+        {"amount", Max{6}},
+    };
+
+    auto passingInput = json::parse(R"({ "amount": 5 })");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    auto passingInput2 = json::parse(R"({ "amount": 6 })");
+    ASSERT_TRUE(spec.process(passingInput2));
+
+    auto failingInput = json::parse(R"({ "amount": 7 })");
+    ASSERT_FALSE(spec.process(failingInput));
 }
 
 TEST_F(RPCBaseTest, OneOfValidator)

--- a/unittests/rpc/handlers/AccountChannelsTest.cpp
+++ b/unittests/rpc/handlers/AccountChannelsTest.cpp
@@ -40,6 +40,60 @@ class RPCAccountChannelsHandlerTest : public HandlerBaseTest
 {
 };
 
+TEST_F(RPCAccountChannelsHandlerTest, LimitNotInt)
+{
+    runSpawn([this](auto yield) {
+        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}", 
+                "limit": "t"
+            }})",
+            ACCOUNT));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCAccountChannelsHandlerTest, LimitNagetive)
+{
+    runSpawn([this](auto yield) {
+        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}", 
+                "limit": -1
+            }})",
+            ACCOUNT));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCAccountChannelsHandlerTest, LimitZero)
+{
+    runSpawn([this](auto yield) {
+        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "account": "{}", 
+                "limit": 0
+            }})",
+            ACCOUNT));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
 TEST_F(RPCAccountChannelsHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](auto yield) {
@@ -51,7 +105,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonHexLedgerHash)
                 "ledger_hash": "xxx"
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -71,7 +125,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonStringLedgerHash)
                 "ledger_hash": 123
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -91,7 +145,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidLedgerIndexString)
                 "ledger_index": "notvalidated"
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -110,7 +164,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerNotString)
                 "marker": 9
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -132,7 +186,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
                 "marker": "123invalid"
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -147,7 +201,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
                 "marker": 401
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -163,7 +217,7 @@ TEST_F(RPCAccountChannelsHandlerTest, AccountInvalidFormat)
         auto const input = json::parse(R"({ 
             "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jp"
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actMalformed");
@@ -179,7 +233,7 @@ TEST_F(RPCAccountChannelsHandlerTest, AccountNotString)
         auto const input = json::parse(R"({ 
             "account": 12
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -206,7 +260,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -232,7 +286,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -256,7 +310,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -284,7 +338,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -309,7 +363,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -338,7 +392,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistAccount)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -414,7 +468,7 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
     });
@@ -466,7 +520,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
                 "limit": 20
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
 
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 20);
@@ -481,7 +535,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
                 "limit": 9
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit?
     });
 
@@ -493,7 +547,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
                 "limit": 401
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit?
     });
 }
@@ -555,7 +609,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
         ACCOUNT3));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 20);
     });
@@ -591,7 +645,7 @@ TEST_F(RPCAccountChannelsHandlerTest, EmptyChannel)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 0);
     });
@@ -676,7 +730,7 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
     });
@@ -744,7 +798,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
         limit));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("marker").as_string().c_str(), fmt::format("{},{}", INDEX1, nextPage));
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 15);
@@ -802,7 +856,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
         nextPage));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE((*output).as_object().if_contains("marker") == nullptr);
         // the first item is the marker itself, so the result will have limit-1
@@ -851,7 +905,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
         AccountChannelsHandler::LIMIT_MIN - 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 2);
         EXPECT_EQ((*output).as_object().at("limit").as_uint64(), AccountChannelsHandler::LIMIT_MIN);
@@ -898,7 +952,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitMoreThanMax)
         AccountChannelsHandler::LIMIT_MAX + 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 2);
         EXPECT_EQ((*output).as_object().at("limit").as_uint64(), AccountChannelsHandler::LIMIT_MAX);

--- a/unittests/rpc/handlers/AccountCurrenciesTest.cpp
+++ b/unittests/rpc/handlers/AccountCurrenciesTest.cpp
@@ -59,7 +59,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
         ACCOUNT));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -83,7 +83,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaIntSequence)
         ACCOUNT));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -110,7 +110,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
         seq));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -137,7 +137,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -204,7 +204,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
         ACCOUNT));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUTPUT));
     });
@@ -244,7 +244,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
     });
 }
@@ -285,7 +285,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderSeq)
         ledgerSeq));
     auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("ledger_index").as_uint64(), ledgerSeq);
     });

--- a/unittests/rpc/handlers/AccountInfoTest.cpp
+++ b/unittests/rpc/handlers/AccountInfoTest.cpp
@@ -106,7 +106,7 @@ TEST_P(AccountInfoParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -132,7 +132,7 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaIntSequence)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -157,7 +157,7 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaStringSequence)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -184,7 +184,7 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -211,7 +211,7 @@ TEST_F(RPCAccountInfoHandlerTest, AccountNotExist)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -239,7 +239,7 @@ TEST_F(RPCAccountInfoHandlerTest, AccountInvalid)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "dbDeserialization");
@@ -274,7 +274,7 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsInvalid)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "dbDeserialization");
@@ -373,7 +373,7 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrue)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -443,7 +443,7 @@ TEST_F(RPCAccountInfoHandlerTest, Flags)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -472,7 +472,7 @@ TEST_F(RPCAccountInfoHandlerTest, IdentAndSignerListsFalse)
         ACCOUNT));
     auto const handler = AnyHandler{AccountInfoHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_FALSE(output->as_object().contains("signer_lists"));
     });

--- a/unittests/rpc/handlers/AccountNFTsTest.cpp
+++ b/unittests/rpc/handlers/AccountNFTsTest.cpp
@@ -115,6 +115,18 @@ generateTestValuesForParametersTest()
             "Invalid parameters.",
         },
         {
+            "LimitNegative",
+            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": -1})",
+            "invalidParams",
+            "Invalid parameters.",
+        },
+        {
+            "LimitZero",
+            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
+            "invalidParams",
+            "Invalid parameters.",
+        },
+        {
             "MarkerNotString",
             R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 123})",
             "invalidParams",
@@ -141,7 +153,7 @@ TEST_P(AccountNFTParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -168,7 +180,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -195,7 +207,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaStringIndex)
         seq));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -222,7 +234,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
         seq));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -249,7 +261,7 @@ TEST_F(RPCAccountNFTsHandlerTest, AccountNotFound)
         ACCOUNT));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -311,7 +323,7 @@ TEST_F(RPCAccountNFTsHandlerTest, NormalPath)
         ACCOUNT));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -348,7 +360,7 @@ TEST_F(RPCAccountNFTsHandlerTest, Limit)
         limit));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_nfts").as_array().size(), 20);
         EXPECT_EQ(output->as_object().at("marker").as_string(), ripple::strHex(firstPage));
@@ -384,7 +396,7 @@ TEST_F(RPCAccountNFTsHandlerTest, Marker)
         PAGE));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_nfts").as_array().size(), 1);
     });
@@ -447,7 +459,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitLessThanMin)
         AccountNFTsHandler::LIMIT_MIN - 1));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -510,7 +522,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitMoreThanMax)
         AccountNFTsHandler::LIMIT_MAX + 1));
     auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });

--- a/unittests/rpc/handlers/AccountObjectsTest.cpp
+++ b/unittests/rpc/handlers/AccountObjectsTest.cpp
@@ -107,6 +107,16 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         AccountObjectsParamTestCaseBundle{
+            "LimitNagetive",
+            R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "limit":-1})",
+            "invalidParams",
+            "Invalid parameters."},
+        AccountObjectsParamTestCaseBundle{
+            "LimitZero",
+            R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "limit":0})",
+            "invalidParams",
+            "Invalid parameters."},
+        AccountObjectsParamTestCaseBundle{
             "MarkerNotString",
             R"({"account":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun", "marker":9})",
             "invalidParams",
@@ -148,7 +158,7 @@ TEST_P(AccountObjectsParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -174,7 +184,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
         ACCOUNT));
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -199,7 +209,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
         ACCOUNT));
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -226,7 +236,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -253,7 +263,7 @@ TEST_F(RPCAccountObjectsHandlerTest, AccountNotExist)
         ACCOUNT));
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -332,7 +342,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -385,7 +395,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Limit)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), limit);
         EXPECT_EQ(output->as_object().at("marker").as_string(), fmt::format("{},{}", INDEX1, 0));
@@ -435,7 +445,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), limit - 1);
         EXPECT_FALSE(output->as_object().contains("marker"));
@@ -496,7 +506,7 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), count * 2);
         EXPECT_EQ(output->as_object().at("marker").as_string(), fmt::format("{},{}", INDEX1, nextpage));
@@ -554,7 +564,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 1);
     });
@@ -610,7 +620,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 0);
     });
@@ -673,7 +683,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 2);
     });
@@ -725,7 +735,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 1);
     });
@@ -792,7 +802,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 0);
     });
@@ -858,7 +868,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithIncompatibleT
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), 0);
     });
@@ -976,7 +986,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -1022,7 +1032,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("account_objects").as_array().size(), 10);
         EXPECT_EQ(
@@ -1075,7 +1085,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("account_objects").as_array().size(), 11);
         //"0000000000000000000000000000000000000000000000000000000000000000,4294967295"
@@ -1158,7 +1168,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("account_objects").as_array().size(), 11 + 3);
         EXPECT_FALSE(output.value().as_object().contains("marker"));
@@ -1219,7 +1229,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("account_objects").as_array().size(), 3);
         EXPECT_FALSE(output.value().as_object().contains("marker"));
@@ -1251,7 +1261,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -1288,7 +1298,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -1369,7 +1379,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("account_objects").as_array().size(), 12);
         // marker not in NFT "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC,0"
@@ -1468,7 +1478,7 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -1520,7 +1530,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTZeroMarkerNotAffectOtherMarker)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("account_objects").as_array().size(), limit);
         EXPECT_EQ(output->as_object().at("marker").as_string(), fmt::format("{},{}", INDEX1, 0));
@@ -1602,7 +1612,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitLessThanMin)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -1683,7 +1693,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitMoreThanMax)
 
     auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });

--- a/unittests/rpc/handlers/AccountOffersTest.cpp
+++ b/unittests/rpc/handlers/AccountOffersTest.cpp
@@ -108,6 +108,18 @@ generateTestValuesForParametersTest()
             "Invalid parameters.",
         },
         {
+            "LimitNegative",
+            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": -1})",
+            "invalidParams",
+            "Invalid parameters.",
+        },
+        {
+            "LimitZero",
+            R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
+            "invalidParams",
+            "Invalid parameters.",
+        },
+        {
             "MarkerNotString",
             R"({"account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 123})",
             "invalidParams",
@@ -134,7 +146,7 @@ TEST_P(AccountOfferParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -161,7 +173,7 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -188,7 +200,7 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaStringIndex)
         seq));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -215,7 +227,7 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaIntIndex)
         seq));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -242,7 +254,7 @@ TEST_F(RPCAccountOffersHandlerTest, AccountNotFound)
         ACCOUNT));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -319,7 +331,7 @@ TEST_F(RPCAccountOffersHandlerTest, DefaultParams)
         ACCOUNT));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -370,7 +382,7 @@ TEST_F(RPCAccountOffersHandlerTest, Limit)
         ACCOUNT));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 10);
         EXPECT_EQ(output->at("marker").as_string(), fmt::format("{},0", INDEX1));
@@ -427,7 +439,7 @@ TEST_F(RPCAccountOffersHandlerTest, Marker)
         startPage));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 19);
         EXPECT_FALSE(output->as_object().contains("marker"));
@@ -465,7 +477,7 @@ TEST_F(RPCAccountOffersHandlerTest, MarkerNotExists)
         startPage));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -521,7 +533,7 @@ TEST_F(RPCAccountOffersHandlerTest, LimitLessThanMin)
         AccountOffersHandler::LIMIT_MIN - 1));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), AccountOffersHandler::LIMIT_MIN);
     });
@@ -575,7 +587,7 @@ TEST_F(RPCAccountOffersHandlerTest, LimitMoreThanMax)
         AccountOffersHandler::LIMIT_MAX + 1));
     auto const handler = AnyHandler{AccountOffersHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), AccountOffersHandler::LIMIT_MAX);
     });

--- a/unittests/rpc/handlers/AccountTxTest.cpp
+++ b/unittests/rpc/handlers/AccountTxTest.cpp
@@ -110,6 +110,16 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         AccountTxParamTestCaseBundle{
+            "limitNegative",
+            R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": -1})",
+            "invalidParams",
+            "Invalid parameters."},
+        AccountTxParamTestCaseBundle{
+            "limitZero",
+            R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
+            "invalidParams",
+            "Invalid parameters."},
+        AccountTxParamTestCaseBundle{
             "MarkerNotObject",
             R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 101})",
             "invalidParams",
@@ -216,7 +226,7 @@ TEST_P(AccountTxParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -309,7 +319,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
             ACCOUNT,
             MINSEQ + 1,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -350,7 +360,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
             ACCOUNT,
             MINSEQ + 1,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -391,7 +401,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
             ACCOUNT,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -432,7 +442,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
             ACCOUNT,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -473,7 +483,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
             ACCOUNT,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -524,7 +534,7 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
             ACCOUNT,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -567,7 +577,7 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
             }})",
             ACCOUNT,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MAXSEQ - 1);
@@ -596,7 +606,7 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
             }})",
             ACCOUNT,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -622,7 +632,7 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
             }})",
             ACCOUNT,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -662,7 +672,7 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
             }})",
             ACCOUNT,
             LEDGERHASH));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MAXSEQ - 1);
@@ -704,7 +714,7 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
                 "ledger_index":"validated"
             }})",
             ACCOUNT));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MAXSEQ);
@@ -745,7 +755,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
             ACCOUNT,
             MINSEQ + 2,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 2);
@@ -786,7 +796,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
             ACCOUNT,
             MINSEQ + 1,
             MAXSEQ - 2));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -794,46 +804,6 @@ TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
         EXPECT_EQ(output->at("transactions").as_array().size(), 1);
         EXPECT_FALSE(output->as_object().contains("limit"));
         EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
-    });
-}
-
-TEST_F(RPCAccountTxHandlerTest, LimitLessThanMin)
-{
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
-    auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
-    auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
-    EXPECT_CALL(
-        *rawBackendPtr,
-        fetchAccountTransactions(
-            testing::_, testing::_, false, testing::Optional(testing::Eq(TransactionsCursor{10, 11})), testing::_))
-        .Times(1);
-
-    runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
-        auto const static input = boost::json::parse(fmt::format(
-            R"({{
-                "account":"{}",
-                "ledger_index_min": {},
-                "ledger_index_max": {},
-                "limit": {},
-                "forward": false,
-                "marker": {{"ledger":10,"seq":11}}
-            }})",
-            ACCOUNT,
-            -1,
-            -1,
-            AccountTxHandler::LIMIT_MIN - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_TRUE(output);
-        EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
-        EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
-        EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
-        EXPECT_EQ(output->at("limit").as_uint64(), AccountTxHandler::LIMIT_MIN);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
-        EXPECT_EQ(output->at("transactions").as_array().size(), 2);
     });
 }
 
@@ -1056,7 +1026,7 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs)
             ACCOUNT,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, boost::json::parse(OUT));
     });

--- a/unittests/rpc/handlers/BookChangesTest.cpp
+++ b/unittests/rpc/handlers/BookChangesTest.cpp
@@ -89,7 +89,7 @@ TEST_P(BookChangesParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -110,7 +110,7 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaIntSequence)
     auto const static input = boost::json::parse(R"({"ledger_index":30})");
     auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -130,7 +130,7 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaStringSequence)
     auto const static input = boost::json::parse(R"({"ledger_index":"30"})");
     auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -155,7 +155,7 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -206,7 +206,7 @@ TEST_F(RPCBookChangesHandlerTest, NormalPath)
 
     auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(json::parse("{}"), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse("{}"), Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });

--- a/unittests/rpc/handlers/BookOffersTest.cpp
+++ b/unittests/rpc/handlers/BookOffersTest.cpp
@@ -73,7 +73,7 @@ TEST_P(RPCBookOffersParameterTest, CheckError)
     auto bundle = GetParam();
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(json::parse(bundle.testJson), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse(bundle.testJson), Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), bundle.expectedError);
@@ -290,6 +290,38 @@ generateParameterBookOffersTestBundles()
             "invalidParams",
             "Invalid parameters."},
         ParameterTestBundle{
+            "LimitNagetive",
+            R"({
+                "taker_pays" : 
+                {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_gets" : 
+                {
+                    "currency" : "XRP"
+                },
+                "limit": -1
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
+            "LimitZero",
+            R"({
+                "taker_pays" : 
+                {
+                    "currency" : "CNY",
+                    "issuer" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                },
+                "taker_gets" : 
+                {
+                    "currency" : "XRP"
+                },
+                "limit": 0
+            })",
+            "invalidParams",
+            "Invalid parameters."},
+        ParameterTestBundle{
             "LedgerIndexInvalid",
             R"({
                 "taker_pays" : 
@@ -486,7 +518,7 @@ TEST_P(RPCBookOffersNormalPathTest, CheckOutput)
 
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(json::parse(bundle.inputJson), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse(bundle.inputJson), Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value(), json::parse(bundle.expectedJson));
     });
@@ -1091,7 +1123,7 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaIntSequence)
         ACCOUNT));
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -1124,7 +1156,7 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaSequence)
         ACCOUNT));
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -1159,7 +1191,7 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaHash)
         ACCOUNT));
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -1232,81 +1264,9 @@ TEST_F(RPCBookOffersHandlerTest, Limit)
         ACCOUNT));
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("offers").as_array().size(), 5);
-    });
-}
-
-TEST_F(RPCBookOffersHandlerTest, LimitLessThanMin)
-{
-    auto const seq = 300;
-    auto const rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);   // min
-    mockBackendPtr->updateRange(seq);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    // return valid ledgerinfo
-    auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, seq);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(seq, _)).WillByDefault(Return(ledgerinfo));
-
-    auto const issuer = GetAccountIDWithString(ACCOUNT);
-    // return valid book dir
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(1);
-
-    auto const getsXRPPaysUSDBook = getBookBase(std::get<ripple::Book>(
-        RPC::parseBook(ripple::to_currency("USD"), issuer, ripple::xrpCurrency(), ripple::xrpAccount())));
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(getsXRPPaysUSDBook, seq, _))
-        .WillByDefault(Return(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}));
-
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(5);
-    auto const indexes = std::vector<ripple::uint256>(10, ripple::uint256{INDEX2});
-
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, seq, _))
-        .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes, INDEX1).getSerializer().peekData()));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, seq, _))
-        .WillByDefault(Return(CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX1, 2).getSerializer().peekData()));
-
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, seq, _))
-        .WillByDefault(Return(CreateFeeSettingBlob(1, 2, 3, 4, 0)));
-
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(issuer).key, seq, _))
-        .WillByDefault(Return(
-            CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2, TRANSFERRATEX2).getSerializer().peekData()));
-
-    auto const gets10XRPPays20USDOffer = CreateOfferLedgerObject(
-        ACCOUNT2,
-        10,
-        20,
-        ripple::to_string(ripple::xrpCurrency()),
-        ripple::to_string(ripple::to_currency("USD")),
-        toBase58(ripple::xrpAccount()),
-        ACCOUNT,
-        PAYS20USDGETS10XRPBOOKDIR);
-
-    std::vector<Blob> bbs(10, gets10XRPPays20USDOffer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
-
-    auto const static input = boost::json::parse(fmt::format(
-        R"({{
-            "taker_gets": 
-            {{
-                "currency": "XRP"
-            }},
-            "taker_pays": 
-            {{
-                "currency": "USD",
-                "issuer": "{}"
-            }},
-            "limit": {}
-        }})",
-        ACCOUNT,
-        BookOffersHandler::LIMIT_MIN - 1));
-    auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
-    runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_TRUE(output);
-        EXPECT_EQ(output.value().as_object().at("offers").as_array().size(), BookOffersHandler::LIMIT_MIN);
     });
 }
 
@@ -1376,7 +1336,7 @@ TEST_F(RPCBookOffersHandlerTest, LimitMoreThanMax)
         BookOffersHandler::LIMIT_MAX + 1));
     auto const handler = AnyHandler{BookOffersHandler{mockBackendPtr}};
     runSpawn([&](boost::asio::yield_context yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().as_object().at("offers").as_array().size(), BookOffersHandler::LIMIT_MAX);
     });

--- a/unittests/rpc/handlers/DefaultProcessorTests.cpp
+++ b/unittests/rpc/handlers/DefaultProcessorTests.cpp
@@ -49,7 +49,7 @@ TEST_F(RPCDefaultProcessorTest, ValidInput)
         EXPECT_CALL(handler, spec(_)).WillOnce(ReturnRef(spec));
         EXPECT_CALL(handler, process(Eq(data), _)).WillOnce(Return(data));
 
-        auto const ret = processor(handler, input, Context{std::ref(yield)});
+        auto const ret = processor(handler, input, Context{yield});
         ASSERT_TRUE(ret);  // no error
     });
 }
@@ -64,7 +64,7 @@ TEST_F(RPCDefaultProcessorTest, NoInputVaildCall)
         auto const input = json::parse(R"({})");
         EXPECT_CALL(handler, process(_)).WillOnce(Return(data));
 
-        auto const ret = processor(handler, input, Context{std::ref(yield)});
+        auto const ret = processor(handler, input, Context{yield});
         ASSERT_TRUE(ret);  // no error
     });
 }
@@ -79,7 +79,7 @@ TEST_F(RPCDefaultProcessorTest, InvalidInput)
         auto const spec = RpcSpec{{"something", Required{}}};
         EXPECT_CALL(handler, spec(_)).WillOnce(ReturnRef(spec));
 
-        auto const ret = processor(handler, input, Context{std::ref(yield)});
+        auto const ret = processor(handler, input, Context{yield});
         ASSERT_FALSE(ret);  // returns error
     });
 }

--- a/unittests/rpc/handlers/DepositAuthorizedTest.cpp
+++ b/unittests/rpc/handlers/DepositAuthorizedTest.cpp
@@ -172,7 +172,7 @@ TEST_P(DepositAuthorizedParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
 
         ASSERT_FALSE(output);
 
@@ -203,7 +203,7 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaIntSequence)
             ACCOUNT2,
             RANGEMAX));
 
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -233,7 +233,7 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaStringSequence)
             ACCOUNT2,
             RANGEMAX));
 
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -263,7 +263,7 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaHash)
             ACCOUNT2,
             LEDGERHASH));
 
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -298,7 +298,7 @@ TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_FALSE(output);
 
@@ -338,7 +338,7 @@ TEST_F(RPCDepositAuthorizedTest, DestinationAccountDoesNotExist)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_FALSE(output);
 
@@ -385,7 +385,7 @@ TEST_F(RPCDepositAuthorizedTest, AccountsAreEqual)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
@@ -434,7 +434,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsNoDepositAuthFlag)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
@@ -484,7 +484,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsFals
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
@@ -534,7 +534,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsTrue
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));

--- a/unittests/rpc/handlers/GatewayBalancesTest.cpp
+++ b/unittests/rpc/handlers/GatewayBalancesTest.cpp
@@ -68,7 +68,7 @@ TEST_P(ParameterTest, CheckError)
     auto bundle = GetParam();
     auto const handler = AnyHandler{GatewayBalancesHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(json::parse(bundle.testJson), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse(bundle.testJson), Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), bundle.expectedError);
@@ -199,7 +199,7 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaStringIndex)
                 }})",
                 ACCOUNT,
                 seq)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -227,7 +227,7 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaIntIndex)
                 }})",
                 ACCOUNT,
                 seq)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -255,7 +255,7 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaHash)
                 }})",
                 ACCOUNT,
                 LEDGERHASH)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -287,7 +287,7 @@ TEST_F(RPCGatewayBalancesHandlerTest, AccountNotFound)
                     "account": "{}"
                 }})",
                 ACCOUNT)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -334,7 +334,7 @@ TEST_F(RPCGatewayBalancesHandlerTest, InvalidHotWallet)
                 }})",
                 ACCOUNT,
                 ACCOUNT2)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidHotWallet");
@@ -406,7 +406,7 @@ TEST_P(NormalPathTest, CheckOutput)
                 }})",
                 ACCOUNT,
                 bundle.hotwallet)),
-            Context{std::ref(yield)});
+            Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value(), json::parse(bundle.expectedJson));
     });

--- a/unittests/rpc/handlers/LedgerEntryTest.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTest.cpp
@@ -552,7 +552,7 @@ TEST_P(LedgerEntryParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerEntryHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -592,7 +592,7 @@ TEST_P(IndexTest, InvalidIndexUint256)
                 "{}": "invalid"
             }})",
             index));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -611,7 +611,7 @@ TEST_P(IndexTest, InvalidIndexNotString)
                 "{}": 123
             }})",
             index));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -642,7 +642,7 @@ TEST_F(RPCLedgerEntryTest, LedgerEntryNotFound)
                 "account_root": "{}"
             }})",
             ACCOUNT));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "entryNotFound");
@@ -917,7 +917,7 @@ TEST_P(RPCLedgerEntryNormalPathTest, NormalPath)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerEntryHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value().at("ledger_hash").as_string(), LEDGERHASH);
         EXPECT_EQ(output.value().at("ledger_index").as_uint64(), RANGEMAX);
@@ -972,7 +972,7 @@ TEST_F(RPCLedgerEntryTest, BinaryFalse)
                 "payment_channel": "{}"
             }})",
             INDEX1));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
     });
@@ -1001,7 +1001,7 @@ TEST_F(RPCLedgerEntryTest, UnexpectedLedgerType)
                 "check": "{}"
             }})",
             INDEX1));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "unexpectedLedgerType");
@@ -1026,7 +1026,7 @@ TEST_F(RPCLedgerEntryTest, LedgerNotExistViaIntSequence)
             }})",
             INDEX1,
             RANGEMAX));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -1052,7 +1052,7 @@ TEST_F(RPCLedgerEntryTest, LedgerNotExistViaStringSequence)
             }})",
             INDEX1,
             RANGEMAX));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -1078,7 +1078,7 @@ TEST_F(RPCLedgerEntryTest, LedgerNotExistViaHash)
             }})",
             INDEX1,
             LEDGERHASH));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");

--- a/unittests/rpc/handlers/LedgerRangeTest.cpp
+++ b/unittests/rpc/handlers/LedgerRangeTest.cpp
@@ -40,7 +40,7 @@ TEST_F(RPCLedgerRangeTest, LedgerRangeMinMaxSame)
         mockBackendPtr->updateRange(RANGEMIN);
         auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         auto const json = output.value();
         EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);
@@ -55,7 +55,7 @@ TEST_F(RPCLedgerRangeTest, LedgerRangeFullySet)
         mockBackendPtr->updateRange(RANGEMAX);
         auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         auto const json = output.value();
         EXPECT_EQ(json.at("ledger_index_min").as_uint64(), RANGEMIN);

--- a/unittests/rpc/handlers/LedgerTest.cpp
+++ b/unittests/rpc/handlers/LedgerTest.cpp
@@ -168,7 +168,7 @@ TEST_P(LedgerParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -192,7 +192,7 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaIntSequence)
                 "ledger_index": {}
             }})",
             RANGEMAX));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -216,7 +216,7 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaStringSequence)
                 "ledger_index": "{}"
             }})",
             RANGEMAX));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -240,7 +240,7 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaHash)
                 "ledger_hash": "{}"
             }})",
             LEDGERHASH));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -282,7 +282,7 @@ TEST_F(RPCLedgerHandlerTest, Default)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
         auto const req = json::parse("{}");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         // remove human readable time, it is sightly different cross the platform
         EXPECT_EQ(output->as_object().at("ledger").as_object().erase("close_time_human"), 1);
@@ -309,7 +309,7 @@ TEST_F(RPCLedgerHandlerTest, NotSupportedFieldsDefaultValue)
                 "accounts": false,
                 "queue": false
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
     });
 }
@@ -327,7 +327,7 @@ TEST_F(RPCLedgerHandlerTest, QueryViaLedgerIndex)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
         auto const req = json::parse(R"({"ledger_index": 15})");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().contains("ledger"));
     });
@@ -346,7 +346,7 @@ TEST_F(RPCLedgerHandlerTest, QueryViaLedgerHash)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
         auto const req = json::parse(fmt::format(R"({{"ledger_hash": "{}" }})", INDEX1));
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().contains("ledger"));
     });
@@ -378,7 +378,7 @@ TEST_F(RPCLedgerHandlerTest, BinaryTrue)
             R"({
                 "binary": true
             })");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -430,7 +430,7 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandBinary)
                 "expand": true,
                 "transactions": true
             })");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -520,7 +520,7 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinary)
                 "expand": true,
                 "transactions": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         // remove human readable time, it is sightly different cross the platform
         EXPECT_EQ(output->as_object().at("ledger").as_object().erase("close_time_human"), 1);
@@ -548,7 +548,7 @@ TEST_F(RPCLedgerHandlerTest, TransactionsNotExpand)
             R"({
                 "transactions": true
             })");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(
             output->as_object().at("ledger").at("transactions"),
@@ -605,7 +605,7 @@ TEST_F(RPCLedgerHandlerTest, DiffNotBinary)
             R"({
                 "diff": true
             })");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("ledger").at("diff"), json::parse(expectedOut));
     });
@@ -650,7 +650,7 @@ TEST_F(RPCLedgerHandlerTest, DiffBinary)
                 "diff": true,
                 "binary": true
             })");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("ledger").at("diff"), json::parse(expectedOut));
     });
@@ -741,7 +741,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsEmtpy)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         // remove human readable time, it is sightly different cross the platform
         EXPECT_EQ(output->as_object().at("ledger").as_object().erase("close_time_human"), 1);
@@ -851,7 +851,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryFalse)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         // remove human readable time, it is sightly different cross the platform
         EXPECT_EQ(output->as_object().at("ledger").as_object().erase("close_time_human"), 1);
@@ -921,7 +921,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -957,7 +957,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsIssuerIsSelf)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_FALSE(output->as_object()["ledger"].as_object()["transactions"].as_array()[0].as_object().contains(
             "owner_funds"));
@@ -1026,7 +1026,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOut));
     });
@@ -1074,7 +1074,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(
             output->as_object()["ledger"]
@@ -1138,7 +1138,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsIgnoreFreezeLine)
                 "transactions": true,
                 "owner_funds": true
             })");
-        auto output = handler.process(req, Context{std::ref(yield)});
+        auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(
             output->as_object()["ledger"]

--- a/unittests/rpc/handlers/NFTBuyOffersTest.cpp
+++ b/unittests/rpc/handlers/NFTBuyOffersTest.cpp
@@ -48,12 +48,66 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonHexLedgerHash)
                 "ledger_hash": "xxx"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
         EXPECT_EQ(err.at("error_message").as_string(), "ledger_hashMalformed");
+    });
+}
+
+TEST_F(RPCNFTBuyOffersHandlerTest, LimitNotInt)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": "xxx"
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCNFTBuyOffersHandlerTest, LimitNegative)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": -1
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCNFTBuyOffersHandlerTest, LimitZero)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": 0
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
     });
 }
 
@@ -67,7 +121,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonStringLedgerHash)
                 "ledger_hash": 123
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -86,7 +140,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, InvalidLedgerIndexString)
                 "ledger_index": "notvalidated"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -103,7 +157,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NFTIDInvalidFormat)
         auto const input = json::parse(R"({ 
             "nft_id": "00080000B4F4AFC5FBCBD76873F18006173D2193467D3EE7"
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -119,7 +173,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NFTIDNotString)
         auto const input = json::parse(R"({ 
             "nft_id": 12
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -146,7 +200,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -172,7 +226,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -200,7 +254,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -225,7 +279,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -253,7 +307,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NoNFT)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTBuyOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "objectNotFound");
@@ -271,7 +325,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, MarkerNotString)
                 "marker": 9
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -292,7 +346,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, InvalidMarker)
                 "marker": "123invalid"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -307,7 +361,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, InvalidMarker)
                 "marker": 250
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -366,7 +420,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, DefaultParameters)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -410,7 +464,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -471,7 +525,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -534,7 +588,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
                 "limit": 50
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -551,7 +605,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
                 "limit": 49
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit somehow?
     });
 
@@ -563,7 +617,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
                 "limit": 501
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit somehow?
     });
 }
@@ -603,7 +657,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, LimitLessThanMin)
         NFTBuyOffersHandler::LIMIT_MIN - 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), NFTBuyOffersHandler::LIMIT_MIN);
@@ -646,7 +700,7 @@ TEST_F(RPCNFTBuyOffersHandlerTest, LimitMoreThanMax)
         NFTBuyOffersHandler::LIMIT_MAX + 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTBuyOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), NFTBuyOffersHandler::LIMIT_MAX);

--- a/unittests/rpc/handlers/NFTHistoryTest.cpp
+++ b/unittests/rpc/handlers/NFTHistoryTest.cpp
@@ -109,6 +109,16 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         NFTHistoryParamTestCaseBundle{
+            "limitNagetive",
+            R"({"nft_id":"00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004", "limit": -1})",
+            "invalidParams",
+            "Invalid parameters."},
+        NFTHistoryParamTestCaseBundle{
+            "limitZero",
+            R"({"nft_id":"00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004", "limit": 0})",
+            "invalidParams",
+            "Invalid parameters."},
+        NFTHistoryParamTestCaseBundle{
             "MarkerNotObject",
             R"({"nft_id":"00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004", "marker": 101})",
             "invalidParams",
@@ -205,7 +215,7 @@ TEST_P(NFTHistoryParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -268,7 +278,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardTrue)
             NFTID,
             MINSEQ + 1,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -309,7 +319,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalse)
             NFTID,
             MINSEQ + 1,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -346,7 +356,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
             NFTID,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -387,7 +397,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
             NFTID,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -428,7 +438,7 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrue)
             NFTID,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -479,7 +489,7 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
             NFTID,
             -1,
             -1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
@@ -522,7 +532,7 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
             }})",
             NFTID,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MAXSEQ - 1);
@@ -551,7 +561,7 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerIntIndex)
             }})",
             NFTID,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -577,7 +587,7 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerStringIndex)
             }})",
             NFTID,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -617,7 +627,7 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
             }})",
             NFTID,
             LEDGERHASH));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MAXSEQ - 1);
@@ -658,7 +668,7 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
             NFTID,
             MINSEQ + 2,
             MAXSEQ - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 2);
@@ -699,7 +709,7 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
             NFTID,
             MINSEQ + 1,
             MAXSEQ - 2));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
@@ -707,49 +717,6 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
         EXPECT_EQ(output->at("transactions").as_array().size(), 1);
         EXPECT_FALSE(output->as_object().contains("limit"));
         EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
-    });
-}
-
-TEST_F(RPCNFTHistoryHandlerTest, LimitLessThanMin)
-{
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
-    auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
-    auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
-    EXPECT_CALL(
-        *rawBackendPtr,
-        fetchNFTTransactions(
-            testing::_,
-            testing::_,
-            false,
-            testing::Optional(testing::Eq(TransactionsCursor{MAXSEQ - 1, INT32_MAX})),
-            testing::_))
-        .Times(1);
-
-    runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
-        auto const static input = boost::json::parse(fmt::format(
-            R"({{
-                "nft_id":"{}",
-                "ledger_index_min": {},
-                "ledger_index_max": {},
-                "forward": false,
-                "limit": {}
-            }})",
-            NFTID,
-            MINSEQ + 1,
-            MAXSEQ - 1,
-            NFTHistoryHandler::LIMIT_MIN - 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_TRUE(output);
-        EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
-        EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
-        EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ - 1);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
-        EXPECT_EQ(output->at("transactions").as_array().size(), 2);
-        EXPECT_EQ(output->as_object().at("limit").as_uint64(), NFTHistoryHandler::LIMIT_MIN);
     });
 }
 
@@ -785,7 +752,7 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitMoreThanMax)
             MINSEQ + 1,
             MAXSEQ - 1,
             NFTHistoryHandler::LIMIT_MAX + 1));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("nft_id").as_string(), NFTID);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);

--- a/unittests/rpc/handlers/NFTInfoTest.cpp
+++ b/unittests/rpc/handlers/NFTInfoTest.cpp
@@ -47,7 +47,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonHexLedgerHash)
                 "ledger_hash": "xxx"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -66,7 +66,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonStringLedgerHash)
                 "ledger_hash": 123
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -85,7 +85,7 @@ TEST_F(RPCNFTInfoHandlerTest, InvalidLedgerIndexString)
                 "ledger_index": "notvalidated"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -102,7 +102,7 @@ TEST_F(RPCNFTInfoHandlerTest, NFTIDInvalidFormat)
         auto const input = json::parse(R"({ 
             "nft_id": "00080000B4F4AFC5FBCBD76873F18006173D2193467D3EE7"
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -118,7 +118,7 @@ TEST_F(RPCNFTInfoHandlerTest, NFTIDNotString)
         auto const input = json::parse(R"({ 
             "nft_id": 12
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -145,7 +145,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -171,7 +171,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerStringIndex)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -195,7 +195,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIntIndex)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -223,7 +223,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -248,7 +248,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIndex2)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -277,7 +277,7 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistNFT)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTInfoHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "objectNotFound");
@@ -320,7 +320,7 @@ TEST_F(RPCNFTInfoHandlerTest, DefaultParameters)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTInfoHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
     });
@@ -362,7 +362,7 @@ TEST_F(RPCNFTInfoHandlerTest, BurnedNFT)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTInfoHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
     });
@@ -403,7 +403,7 @@ TEST_F(RPCNFTInfoHandlerTest, NotBurnedNFTWithoutURI)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTInfoHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
     });
@@ -444,7 +444,7 @@ TEST_F(RPCNFTInfoHandlerTest, NFTWithExtraFieldsSet)
         NFTID2));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTInfoHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
     });

--- a/unittests/rpc/handlers/NFTSellOffersTest.cpp
+++ b/unittests/rpc/handlers/NFTSellOffersTest.cpp
@@ -38,6 +38,60 @@ class RPCNFTSellOffersHandlerTest : public HandlerBaseTest
 {
 };
 
+TEST_F(RPCNFTSellOffersHandlerTest, LimitNotInt)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": "xxx"
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCNFTSellOffersHandlerTest, LimitNegative)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": -1
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
+TEST_F(RPCNFTSellOffersHandlerTest, LimitZero)
+{
+    runSpawn([this](boost::asio::yield_context yield) {
+        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const input = json::parse(fmt::format(
+            R"({{ 
+                "nft_id": "{}", 
+                "limit": 0
+            }})",
+            NFTID));
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_FALSE(output);
+
+        auto const err = RPC::makeError(output.error());
+        EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+    });
+}
+
 TEST_F(RPCNFTSellOffersHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](boost::asio::yield_context yield) {
@@ -48,7 +102,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonHexLedgerHash)
                 "ledger_hash": "xxx"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -67,7 +121,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonStringLedgerHash)
                 "ledger_hash": 123
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -86,7 +140,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, InvalidLedgerIndexString)
                 "ledger_index": "notvalidated"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -103,7 +157,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NFTIDInvalidFormat)
         auto const input = json::parse(R"({ 
             "nft_id": "00080000B4F4AFC5FBCBD76873F18006173D2193467D3EE7"
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -119,7 +173,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NFTIDNotString)
         auto const input = json::parse(R"({ 
             "nft_id": 12
         })");
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -146,7 +200,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -172,7 +226,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -200,7 +254,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -225,7 +279,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
         NFTID));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -253,7 +307,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NoNFT)
         LEDGERHASH));
     runSpawn([&, this](boost::asio::yield_context yield) {
         auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "objectNotFound");
@@ -271,7 +325,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, MarkerNotString)
                 "marker": 9
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -292,7 +346,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, InvalidMarker)
                 "marker": "123invalid"
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -307,7 +361,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, InvalidMarker)
                 "marker": 250
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -366,7 +420,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -410,7 +464,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -471,7 +525,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
         NFTID));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -534,7 +588,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
                 "limit": 50
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), 50);
@@ -551,7 +605,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
                 "limit": 49
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit?
     });
 
@@ -563,7 +617,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
                 "limit": 501
             }})",
             NFTID));
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);  // todo: check limit?
     });
 }
@@ -603,7 +657,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
         NFTSellOffersHandler::LIMIT_MIN - 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), NFTSellOffersHandler::LIMIT_MIN);
@@ -646,7 +700,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitMoreThanMax)
         NFTSellOffersHandler::LIMIT_MAX + 1));
     runSpawn([&, this](auto yield) {
         auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("offers").as_array().size(), NFTSellOffersHandler::LIMIT_MAX);

--- a/unittests/rpc/handlers/NoRippleCheckTest.cpp
+++ b/unittests/rpc/handlers/NoRippleCheckTest.cpp
@@ -115,6 +115,24 @@ generateTestValuesForParametersTest()
             "invalidParams",
             "Invalid parameters."},
         NoRippleParamTestCaseBundle{
+            "LimitNegative",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "role": "gateway",
+                "limit": -1
+             })",
+            "invalidParams",
+            "Invalid parameters."},
+        NoRippleParamTestCaseBundle{
+            "LimitZero",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "role": "gateway",
+                "limit": 0
+             })",
+            "invalidParams",
+            "Invalid parameters."},
+        NoRippleParamTestCaseBundle{
             "TransactionsNotBool",
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -138,7 +156,7 @@ TEST_P(NoRippleCheckParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -166,7 +184,7 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaHash)
         LEDGERHASH));
     auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -194,7 +212,7 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaIntIndex)
         seq));
     auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -222,7 +240,7 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaStringIndex)
         seq));
     auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
     runSpawn([&](auto yield) {
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -251,7 +269,7 @@ TEST_F(RPCNoRippleCheckTest, AccountNotExist)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "actNotFound");
@@ -313,7 +331,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleUserDefaultRippleSetTrustLineNoRipple
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -371,7 +389,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleUserDefaultRippleUnsetTrustLineNoRipp
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -432,7 +450,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleSetTrustLineNoRip
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -490,7 +508,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleUnsetTrustLineNoR
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
     });
@@ -541,7 +559,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleUnsetTrustLineNoR
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("transactions").as_array().size(), 1);
         EXPECT_EQ(output->as_object().at("problems").as_array().size(), 1);
@@ -593,7 +611,7 @@ TEST_F(RPCNoRippleCheckTest, NormalPathLimit)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("problems").as_array().size(), 1);
     });
@@ -695,61 +713,9 @@ TEST_F(RPCNoRippleCheckTest, NormalPathTransactions)
         LEDGERHASH));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(expectedOutput));
-    });
-}
-
-TEST_F(RPCNoRippleCheckTest, LimitLessThanMin)
-{
-    constexpr auto seq = 30;
-    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-    auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, seq);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    // fetch account object return valid account with DefaultRippleSet flag
-
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject)
-        .WillByDefault(Return(CreateAccountRootObject(ACCOUNT, ripple::lsfDefaultRipple, 2, 200, 2, INDEX1, 2)
-                                  .getSerializer()
-                                  .peekData()));
-    auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
-    auto const ownerDirKk = ripple::keylet::ownerDir(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, seq, _))
-        .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
-
-    auto const line1 = CreateRippleStateLedgerObject(
-        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, ripple::lsfLowNoRipple);
-
-    auto const line2 = CreateRippleStateLedgerObject(
-        ACCOUNT, "USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, ripple::lsfLowNoRipple);
-
-    std::vector<Blob> bbs;
-    bbs.push_back(line1.getSerializer().peekData());
-    bbs.push_back(line2.getSerializer().peekData());
-
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
-
-    auto const input = json::parse(fmt::format(
-        R"({{
-            "account": "{}",
-            "ledger_hash": "{}",
-            "role": "gateway",
-            "limit": {}
-        }})",
-        ACCOUNT,
-        LEDGERHASH,
-        NoRippleCheckHandler::LIMIT_MIN - 1));
-    runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
-        ASSERT_TRUE(output);
-        EXPECT_EQ(output->as_object().at("problems").as_array().size(), NoRippleCheckHandler::LIMIT_MIN);
     });
 }
 
@@ -799,7 +765,7 @@ TEST_F(RPCNoRippleCheckTest, LimitMoreThanMax)
         NoRippleCheckHandler::LIMIT_MAX + 1));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NoRippleCheckHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("problems").as_array().size(), NoRippleCheckHandler::LIMIT_MAX);
     });

--- a/unittests/rpc/handlers/PingTest.cpp
+++ b/unittests/rpc/handlers/PingTest.cpp
@@ -32,7 +32,7 @@ TEST_F(RPCPingHandlerTest, Default)
 {
     runSpawn([](auto yield) {
         auto const handler = AnyHandler{PingHandler{}};
-        auto const output = handler.process(boost::json::parse(R"({})"), Context{std::ref(yield)});
+        auto const output = handler.process(boost::json::parse(R"({})"), Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.value(), boost::json::parse(R"({})"));
     });

--- a/unittests/rpc/handlers/ServerInfoTest.cpp
+++ b/unittests/rpc/handlers/ServerInfoTest.cpp
@@ -150,7 +150,7 @@ TEST_F(RPCServerInfoHandlerTest, NoLedgerInfoErrorsOutWithInternal)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
 
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
@@ -177,7 +177,7 @@ TEST_F(RPCServerInfoHandlerTest, NoFeesErrorsOutWithInternal)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
 
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
@@ -218,7 +218,7 @@ TEST_F(RPCServerInfoHandlerTest, DefaultOutputIsPresent)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield), {}, false, CLIENTIP});
+        auto const output = handler.process(req, Context{yield, {}, false, CLIENTIP});
 
         validateNormalOutput(output);
 
@@ -262,7 +262,7 @@ TEST_F(RPCServerInfoHandlerTest, AmendmentBlockedIsPresentIfSet)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield), {}, false, CLIENTIP});
+        auto const output = handler.process(req, Context{yield, {}, false, CLIENTIP});
 
         validateNormalOutput(output);
 
@@ -317,7 +317,7 @@ TEST_F(RPCServerInfoHandlerTest, AdminSectionPresentWhenAdminFlagIsSet)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield), {}, true});
+        auto const output = handler.process(req, Context{yield, {}, true});
 
         validateNormalOutput(output);
         validateAdminOutput(output);
@@ -379,7 +379,7 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesPresent)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield), {}, true});
+        auto const output = handler.process(req, Context{yield, {}, true});
 
         validateNormalOutput(output);
         validateAdminOutput(output);
@@ -437,7 +437,7 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesMissingNoExceptionThrown)
 
     runSpawn([&](auto yield) {
         auto const req = json::parse("{}");
-        auto const output = handler.process(req, Context{std::ref(yield), {}, true});
+        auto const output = handler.process(req, Context{yield, {}, true});
 
         validateNormalOutput(output);
         validateAdminOutput(output);

--- a/unittests/rpc/handlers/SubscribeTest.cpp
+++ b/unittests/rpc/handlers/SubscribeTest.cpp
@@ -540,7 +540,7 @@ TEST_P(SubscribeParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -552,7 +552,7 @@ TEST_F(RPCSubscribeHandlerTest, EmptyResponse)
 {
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(json::parse(R"({})"), Context{std::ref(yield), session_});
+        auto const output = handler.process(json::parse(R"({})"), Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -567,7 +567,7 @@ TEST_F(RPCSubscribeHandlerTest, StreamsWithoutLedger)
         })");
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
         std::this_thread::sleep_for(20ms);
@@ -612,7 +612,7 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
         })");
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object(), json::parse(expectedOutput));
         std::this_thread::sleep_for(20ms);
@@ -632,7 +632,7 @@ TEST_F(RPCSubscribeHandlerTest, Accounts)
         ACCOUNT2));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
         std::this_thread::sleep_for(20ms);
@@ -653,7 +653,7 @@ TEST_F(RPCSubscribeHandlerTest, AccountsProposed)
         ACCOUNT2));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
         std::this_thread::sleep_for(20ms);
@@ -685,7 +685,7 @@ TEST_F(RPCSubscribeHandlerTest, JustBooks)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
         std::this_thread::sleep_for(20ms);
@@ -717,7 +717,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSet)
         ACCOUNT));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
         std::this_thread::sleep_for(20ms);
@@ -880,7 +880,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
         ACCOUNT);
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("bids").as_array().size(), 10);
         EXPECT_EQ(output->as_object().at("asks").as_array().size(), 10);
@@ -1020,7 +1020,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("offers").as_array().size(), 10);
         EXPECT_EQ(output->as_object().at("offers").as_array()[0].as_object(), json::parse(expectedOffer));

--- a/unittests/rpc/handlers/TestHandlerTests.cpp
+++ b/unittests/rpc/handlers/TestHandlerTests.cpp
@@ -45,7 +45,7 @@ TEST_F(RPCTestHandlerTest, HandlerSuccess)
             "limit": 10
         })");
 
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
 
         auto const val = output.value();
@@ -57,7 +57,7 @@ TEST_F(RPCTestHandlerTest, NoInputHandlerSuccess)
 {
     runSpawn([](auto yield) {
         auto const handler = AnyHandler{NoInputHandlerFake{}};
-        auto const output = handler.process(json::parse(R"({})"), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse(R"({})"), Context{yield});
         ASSERT_TRUE(output);
 
         auto const val = output.value();
@@ -74,7 +74,7 @@ TEST_F(RPCTestHandlerTest, HandlerErrorHandling)
             "limit": 10
         })");
 
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -94,7 +94,7 @@ TEST_F(RPCTestHandlerTest, HandlerInnerErrorHandling)
         })");
 
         // validation succeeds but handler itself returns error
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());

--- a/unittests/rpc/handlers/TransactionEntryTest.cpp
+++ b/unittests/rpc/handlers/TransactionEntryTest.cpp
@@ -42,7 +42,7 @@ TEST_F(RPCTransactionEntryHandlerTest, TxHashNotProvide)
 {
     runSpawn([this](auto yield) {
         auto const handler = AnyHandler{TransactionEntryHandler{mockBackendPtr}};
-        auto const output = handler.process(json::parse("{}"), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse("{}"), Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "fieldNotFoundTransaction");
@@ -54,7 +54,7 @@ TEST_F(RPCTransactionEntryHandlerTest, TxHashWrongFormat)
 {
     runSpawn([this](auto yield) {
         auto const handler = AnyHandler{TransactionEntryHandler{mockBackendPtr}};
-        auto const output = handler.process(json::parse(R"({"tx_hash":"123"})"), Context{std::ref(yield)});
+        auto const output = handler.process(json::parse(R"({"tx_hash":"123"})"), Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
@@ -79,7 +79,7 @@ TEST_F(RPCTransactionEntryHandlerTest, NonExistLedgerViaLedgerHash)
         TXNID));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TransactionEntryHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -104,7 +104,7 @@ TEST_F(RPCTransactionEntryHandlerTest, NonExistLedgerViaLedgerIndex)
         TXNID));
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TransactionEntryHandler{mockBackendPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield)});
+        auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "lgrNotFound");
@@ -129,7 +129,7 @@ TEST_F(RPCTransactionEntryHandlerTest, TXNotFound)
                 "tx_hash": "{}"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "transactionNotFound");
@@ -162,7 +162,7 @@ TEST_F(RPCTransactionEntryHandlerTest, LedgerSeqNotMatch)
                 "ledger_index": "30"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), "transactionNotFound");
@@ -240,7 +240,7 @@ TEST_F(RPCTransactionEntryHandlerTest, NormalPath)
             }})",
             TXNID,
             tx.ledgerSequence));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(OUTPUT), *output);
     });

--- a/unittests/rpc/handlers/TxTest.cpp
+++ b/unittests/rpc/handlers/TxTest.cpp
@@ -51,7 +51,7 @@ TEST_F(RPCTxTest, ExcessiveLgrRange)
                 "max_ledger":1002
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -72,7 +72,7 @@ TEST_F(RPCTxTest, InvalidLgrRange)
                 "min_ledger": 10
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -95,7 +95,7 @@ TEST_F(RPCTxTest, TxnNotFound)
                 "transaction": "{}"
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -122,7 +122,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllFalse)
                 "max_ledger":1000
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -150,7 +150,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllTrue)
                 "max_ledger":1000
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
 
         auto const err = RPC::makeError(output.error());
@@ -215,7 +215,7 @@ TEST_F(RPCTxTest, DefaultParameter)
                 "transaction": "{}"
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
     });
@@ -249,7 +249,7 @@ TEST_F(RPCTxTest, ReturnBinary)
                 "binary": true
                 }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
     });
@@ -327,7 +327,7 @@ TEST_F(RPCTxTest, MintNFT)
                 "transaction": "{}"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
     });
@@ -349,7 +349,7 @@ TEST_F(RPCTxTest, NFTAcceptOffer)
                 "transaction": "{}"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->at("meta").at("nftoken_id").as_string(), NFTID);
     });
@@ -372,7 +372,7 @@ TEST_F(RPCTxTest, NFTCancelOffer)
                 "transaction": "{}"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
 
         for (auto const& id : output->at("meta").at("nftoken_ids").as_array())
@@ -401,7 +401,7 @@ TEST_F(RPCTxTest, NFTCreateOffer)
                 "transaction": "{}"
             }})",
             TXNID));
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->at("meta").at("offer_id").as_string() == NFTID2);
     });

--- a/unittests/rpc/handlers/UnsubscribeTest.cpp
+++ b/unittests/rpc/handlers/UnsubscribeTest.cpp
@@ -495,7 +495,7 @@ TEST_P(UnsubscribeParameterTest, InvalidParams)
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
         auto const req = json::parse(testBundle.testJson);
-        auto const output = handler.process(req, Context{std::ref(yield)});
+        auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
         auto const err = RPC::makeError(output.error());
         EXPECT_EQ(err.at("error").as_string(), testBundle.expectedError);
@@ -507,7 +507,7 @@ TEST_F(RPCUnsubscribeTest, EmptyResponse)
 {
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(json::parse(R"({})"), Context{std::ref(yield), session_});
+        auto const output = handler.process(json::parse(R"({})"), Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -531,7 +531,7 @@ TEST_F(RPCUnsubscribeTest, Streams)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -553,7 +553,7 @@ TEST_F(RPCUnsubscribeTest, Accounts)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -577,7 +577,7 @@ TEST_F(RPCUnsubscribeTest, AccountsProposed)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -612,7 +612,7 @@ TEST_F(RPCUnsubscribeTest, Books)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });
@@ -645,7 +645,7 @@ TEST_F(RPCUnsubscribeTest, SingleBooks)
 
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
-        auto const output = handler.process(input, Context{std::ref(yield), session_});
+        auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
     });

--- a/unittests/rpc/handlers/VersionHandlerTest.cpp
+++ b/unittests/rpc/handlers/VersionHandlerTest.cpp
@@ -48,7 +48,7 @@ TEST_F(RPCVersionHandlerTest, Default)
 
     runSpawn([&](auto yield) {
         auto const handler = AnyHandler{VersionHandler{cfg}};
-        auto const output = handler.process(static_cast<json::value>(cfg), Context{std::ref(yield)});
+        auto const output = handler.process(static_cast<json::value>(cfg), Context{yield});
         ASSERT_TRUE(output);
 
         // check all against all the correct values

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -123,13 +123,14 @@ struct AsyncAsioContextTest : virtual public NoLoggerFixture
     AsyncAsioContextTest()
     {
         work.emplace(ctx);  // make sure ctx does not stop on its own
+        runner.emplace([&] { ctx.run(); });
     }
 
     ~AsyncAsioContextTest()
     {
         work.reset();
-        if (runner.joinable())
-            runner.join();
+        if (runner->joinable())
+            runner->join();
         ctx.stop();
     }
 
@@ -137,9 +138,9 @@ struct AsyncAsioContextTest : virtual public NoLoggerFixture
     stop()
     {
         work.reset();
+        if (runner->joinable())
+            runner->join();
         ctx.stop();
-        if (runner.joinable())
-            runner.join();
     }
 
 protected:
@@ -147,7 +148,7 @@ protected:
 
 private:
     std::optional<boost::asio::io_service::work> work;
-    std::thread runner{[this] { ctx.run(); }};
+    std::optional<std::thread> runner;
 };
 
 /**


### PR DESCRIPTION
1 Add cache loader unittest

2 Suppress the TSAN warning for webserver unittest.
The acceptor is created in main thread, but main thread is not in io context. 
Main thread will run the client to send the request. So we fix it by posting the creation to io context.
```
WARNING: ThreadSanitizer: data race (pid=76354)
  Read of size 1 at 0x00010a801638 by thread T1:
    #0 boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&) kqueue_reactor.ipp:487 (clio_tests:arm64+0x10003c2b0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #1 boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&) kqueue_reactor.ipp:438 (clio_tests:arm64+0x10003c0e0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #2 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) scheduler.ipp:477 (clio_tests:arm64+0x10003e300) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #3 boost::asio::detail::scheduler::run(boost::system::error_code&) scheduler.ipp:210 (clio_tests:arm64+0x10003df1c) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #4 boost::asio::io_context::run() io_context.ipp:64 (clio_tests:arm64+0x1000507b8) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #5 void* std::__1::__thread_proxy[abi:v15006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, WebServerTest::WebServerTest()::'lambda'()>>(void*) thread:301 (clio_tests:arm64+0x100a3b7d8) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)

  Previous write of size 1 at 0x00010a801638 by main thread (mutexes: write M0):
    #0 boost::asio::detail::conditionally_enabled_mutex::conditionally_enabled_mutex(bool) conditionally_enabled_mutex.hpp:109 (clio_tests:arm64+0x10003cdf4) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #1 boost::asio::detail::kqueue_reactor::allocate_descriptor_state() kqueue_reactor.ipp:566 (clio_tests:arm64+0x1001719ec) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #2 Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>::Server(boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>>, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, util::TagDecoratorFactory, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) Server.h:152 (clio_tests:arm64+0x100a86f2c) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #3 std::__1::shared_ptr<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> std::__1::allocate_shared[abi:v15006]<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>, std::__1::allocator<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>>, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, util::TagDecoratorFactory, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&, void>(std::__1::allocator<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> const&, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>&&, util::TagDecoratorFactory&&, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) shared_ptr.h:953 (clio_tests:arm64+0x100a864e0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #4 std::__1::shared_ptr<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> Server::make_HttpServer<EchoExecutor>(clio::Config const&, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) Server.h:238 (clio_tests:arm64+0x100a2f804) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #5 WebServerTest_Ws_Test::TestBody() ServerTest.cpp:204 (clio_tests:arm64+0x100a2f068) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #6 virtual thunk to WebServerTest_Ws_Test::TestBody() ServerTest.cpp (clio_tests:arm64+0x100a30554) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #7 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null>:139557568 (clio_tests:arm64+0x101aedf64) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #8 <null> <null> (0x00019e01ff28)
```