### PR TITLE
Add cache test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if(tests)
     unittests/etl/ExtractionDataPipeTest.cpp
     unittests/etl/ExtractorTest.cpp
     unittests/etl/TransformerTest.cpp
+    unittests/etl/CacheLoaderTest.cpp
     # RPC
     unittests/rpc/ErrorTests.cpp
     unittests/rpc/BaseTests.cpp
@@ -211,8 +212,8 @@ if(tests)
 
   # TODO: support sanitizers properly
   # Tmp: uncomment for TSAN
-  # target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
-  # target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+   target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+   target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
 
   target_compile_definitions(${TEST_TARGET} PUBLIC UNITTEST_BUILD)
   target_include_directories(${TEST_TARGET} PRIVATE unittests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,8 @@ if(tests)
 
   # TODO: support sanitizers properly
   # Tmp: uncomment for TSAN
-   target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
-   target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+  # target_compile_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
+  # target_link_options(${TEST_TARGET} PRIVATE -fsanitize=thread)
 
   target_compile_definitions(${TEST_TARGET} PUBLIC UNITTEST_BUILD)
   target_include_directories(${TEST_TARGET} PRIVATE unittests)

--- a/unittests/etl/CacheLoaderTest.cpp
+++ b/unittests/etl/CacheLoaderTest.cpp
@@ -17,7 +17,6 @@
 */
 //==============================================================================
 
-#include <backend/LedgerCache.h>
 #include <etl/impl/CacheLoader.h>
 #include <util/Fixtures.h>
 #include <util/MockCache.h>

--- a/unittests/etl/CacheLoaderTest.cpp
+++ b/unittests/etl/CacheLoaderTest.cpp
@@ -1,0 +1,142 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <backend/LedgerCache.h>
+#include <etl/impl/CacheLoader.h>
+#include <util/Fixtures.h>
+#include <util/MockCache.h>
+
+#include <boost/asio.hpp>
+#include <boost/json.hpp>
+#include <gtest/gtest.h>
+
+namespace json = boost::json;
+using namespace clio::detail;
+using namespace clio;
+using namespace Backend;
+using namespace testing;
+
+constexpr static auto SEQ = 30;
+constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
+
+struct CacheLoaderTest : public MockBackendTest
+{
+    void
+    SetUp() override
+    {
+        MockBackendTest::SetUp();
+        work.emplace(ctx);
+        for (auto i = 0; i < 2; ++i)
+            optThreads.emplace_back([&] { ctx.run(); });
+    }
+
+    void
+    TearDown() override
+    {
+        work.reset();
+        for (auto& optThread : optThreads)
+            if (optThread.joinable())
+                optThread.join();
+        ctx.stop();
+        MockBackendTest::TearDown();
+    }
+
+protected:
+    MockCache cache;
+    Config cfg{json::parse("{}")};
+    std::optional<boost::asio::io_service::work> work;
+    boost::asio::io_context ctx;
+    std::vector<std::thread> optThreads;
+};
+
+namespace {
+
+std::vector<LedgerObject>
+getLatestDiff()
+{
+    return std::vector<LedgerObject>{
+        {.key = ripple::uint256{"05E1EAC2574BE082B00B16F907CE32E6058DEB8F9E81CF34A00E80A5D71FA4FE"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"110872C7196EE6EF7032952F1852B11BB461A96FF2D7E06A8003B4BB30FD130B"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"3B3A84E850C724E914293271785A31D0BFC8B9DD1B6332E527B149AD72E80E18"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"4EC98C5C3F34C44409BC058998CBD64F6AED3FF6C0CAAEC15F7F42DF14EE9F04"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"58CEC9F17733EA7BA68C88E6179B8F207D001EE04D4E0366F958CC04FF6AB834"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"64FB1712146BA604C274CC335C5DE7ADFE52D1F8C3E904A9F9765FE8158A3E01"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"700BE23B1D9EE3E6BF52543D05843D5345B85D9EDB3D33BBD6B4C3A13C54B38E"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"82C297FCBCD634C4424F263D17480AA2F13975DF5846A5BB57246022CEEBE441"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"A2AA4C212DC2CA2C49BF58805F7C63363BC981018A01AC9609A7CBAB2A02CEDF"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"BC0DAE09C0BFBC4A49AA94B849266588BFD6E1F554B184B5788AC55D6E07EB95"}, .blob = Blob{'s'}},
+        {.key = ripple::uint256{"DCC8759A35CB946511763AA5553A82AA25F20B901C98C9BB74D423BCFAFF5F9D"}, .blob = Blob{'s'}},
+    };
+}
+
+};  // namespace
+
+TEST_F(CacheLoaderTest, FromCache)
+{
+    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+    CacheLoader loader{cfg, ctx, mockBackendPtr, cache};
+
+    auto const diffs = getLatestDiff();
+    ON_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).WillByDefault(Return(diffs));
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).Times(32);
+
+    auto const loops = diffs.size() + 1;
+    auto const keysSize = 14;
+    std::mutex g_pages_mutex;
+
+    std::map<std::thread::id, uint32_t> threadKeysMap;
+    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, SEQ, _))
+        .WillByDefault(Invoke([&]() -> std::optional<ripple::uint256> {
+            // mock the result from doFetchSuccessorKey, be aware this function will be called from multiple threads
+            // for each thread, the last 2 items must be end flag and nullopt, otherwise it will loop forever
+            std::lock_guard<std::mutex> guard(g_pages_mutex);
+            threadKeysMap[std::this_thread::get_id()]++;
+
+            if (threadKeysMap[std::this_thread::get_id()] == keysSize - 1)
+            {
+                return lastKey;
+            }
+            else if (threadKeysMap[std::this_thread::get_id()] == keysSize)
+            {
+                threadKeysMap[std::this_thread::get_id()] = 0;
+                return std::nullopt;
+            }
+            else
+            {
+                return ripple::uint256{INDEX1};
+            }
+        }));
+    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(keysSize * loops);
+
+    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(_, SEQ, _))
+        .WillByDefault(Return(std::vector<Blob>{keysSize - 1, Blob{'s'}}));
+    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(loops);
+
+    EXPECT_CALL(cache, size).Times(AtLeast(1));
+    EXPECT_CALL(cache, update).Times(loops);
+
+    loader.load(SEQ);
+    // Cache loader start a new thread to load the cache, so we need to wait for it to finish
+    auto maxWait = 100;
+    while (maxWait-- != 0 and !cache.isFull())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(cache.isFull());
+}

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -123,13 +123,14 @@ struct AsyncAsioContextTest : virtual public NoLoggerFixture
     AsyncAsioContextTest()
     {
         work.emplace(ctx);  // make sure ctx does not stop on its own
+        runner.emplace([&] { ctx.run(); });
     }
 
     ~AsyncAsioContextTest()
     {
         work.reset();
-        if (runner.joinable())
-            runner.join();
+        if (runner->joinable())
+            runner->join();
         ctx.stop();
     }
 
@@ -137,9 +138,9 @@ struct AsyncAsioContextTest : virtual public NoLoggerFixture
     stop()
     {
         work.reset();
+        if (runner->joinable())
+            runner->join();
         ctx.stop();
-        if (runner.joinable())
-            runner.join();
     }
 
 protected:
@@ -147,7 +148,7 @@ protected:
 
 private:
     std::optional<boost::asio::io_service::work> work;
-    std::thread runner{[this] { ctx.run(); }};
+    std::optional<std::thread> runner;
 };
 
 /**

--- a/unittests/util/MockCache.h
+++ b/unittests/util/MockCache.h
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2023, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include <backend/Types.h>
+
+#include <gmock/gmock.h>
+
+struct MockCache
+{
+private:
+    std::atomic_bool full_ = false;
+
+public:
+    MOCK_METHOD(void, update, (std::vector<Backend::LedgerObject> const& a, uint32_t b, bool c), ());
+
+    MOCK_METHOD(std::optional<Backend::Blob>, get, (ripple::uint256 const& a, uint32_t b), (const));
+
+    MOCK_METHOD(std::optional<Backend::LedgerObject>, getSuccessor, (ripple::uint256 const& a, uint32_t b), (const));
+
+    MOCK_METHOD(std::optional<Backend::LedgerObject>, getPredecessor, (ripple::uint256 const& a, uint32_t b), (const));
+
+    MOCK_METHOD(void, setDisabled, (), ());
+
+    void
+    setFull()
+    {
+        full_ = true;
+    }
+
+    MOCK_METHOD(uint32_t, latestLedgerSequence, (), (const));
+
+    bool
+    isFull() const
+    {
+        return full_;
+    }
+
+    MOCK_METHOD(size_t, size, (), (const));
+
+    MOCK_METHOD(float, getObjectHitRate, (), (const));
+
+    MOCK_METHOD(float, getSuccessorHitRate, (), (const));
+};

--- a/unittests/util/MockCache.h
+++ b/unittests/util/MockCache.h
@@ -25,10 +25,6 @@
 
 struct MockCache
 {
-private:
-    std::atomic_bool full_ = false;
-
-public:
     MOCK_METHOD(void, update, (std::vector<Backend::LedgerObject> const& a, uint32_t b, bool c), ());
 
     MOCK_METHOD(std::optional<Backend::Blob>, get, (ripple::uint256 const& a, uint32_t b), (const));
@@ -39,19 +35,11 @@ public:
 
     MOCK_METHOD(void, setDisabled, (), ());
 
-    void
-    setFull()
-    {
-        full_ = true;
-    }
+    MOCK_METHOD(void, setFull, (), ());
+
+    MOCK_METHOD(bool, isFull, (), (const));
 
     MOCK_METHOD(uint32_t, latestLedgerSequence, (), (const));
-
-    bool
-    isFull() const
-    {
-        return full_;
-    }
 
     MOCK_METHOD(size_t, size, (), (const));
 

--- a/unittests/webserver/ServerTest.cpp
+++ b/unittests/webserver/ServerTest.cpp
@@ -192,8 +192,21 @@ TEST_F(WebServerTest, Http)
 {
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     auto const res = HttpSyncClient::syncPost("localhost", "8888", R"({"Hello":1})");
     EXPECT_EQ(res, R"({"Hello":1})");
 }
@@ -202,8 +215,21 @@ TEST_F(WebServerTest, Ws)
 {
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebSocketSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto const res = wsClient.syncPost(R"({"Hello":1})");
@@ -215,8 +241,21 @@ TEST_F(WebServerTest, HttpInternalError)
 {
     auto e = std::make_shared<ExceptionExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<ExceptionExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     auto const res = HttpSyncClient::syncPost("localhost", "8888", R"({})");
     EXPECT_EQ(
         res,
@@ -227,8 +266,21 @@ TEST_F(WebServerTest, WsInternalError)
 {
     auto e = std::make_shared<ExceptionExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<ExceptionExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebSocketSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto const res = wsClient.syncPost(R"({"id":"id1"})");
@@ -242,8 +294,21 @@ TEST_F(WebServerTest, WsInternalErrorNotJson)
 {
     auto e = std::make_shared<ExceptionExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<ExceptionExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebSocketSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto const res = wsClient.syncPost("not json");
@@ -259,8 +324,21 @@ TEST_F(WebServerTest, Https)
     auto sslCtx = parseCertsForTest();
     auto const ctxSslRef = sslCtx ? std::optional<std::reference_wrapper<ssl::context>>{sslCtx.value()} : std::nullopt;
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, ctxSslRef, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, ctxSslRef, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     auto const res = HttpsSyncClient::syncPost("localhost", "8888", R"({"Hello":1})");
     EXPECT_EQ(res, R"({"Hello":1})");
 }
@@ -272,8 +350,21 @@ TEST_F(WebServerTest, Wss)
     auto const ctxSslRef = sslCtx ? std::optional<std::reference_wrapper<ssl::context>>{sslCtx.value()} : std::nullopt;
 
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
-    boost::asio::dispatch(
-        ctx.get_executor(), [&]() mutable { server = Server::make_HttpServer(cfg, ctx, ctxSslRef, dosGuard, e); });
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
+    boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
+        server = Server::make_HttpServer(cfg, ctx, ctxSslRef, dosGuard, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebServerSslSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto const res = wsClient.syncPost(R"({"Hello":1})");
@@ -285,9 +376,21 @@ TEST_F(WebServerTest, HttpRequestOverload)
 {
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
     boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
         server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuardOverload, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
     });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     auto res = HttpSyncClient::syncPost("localhost", "8888", R"({})");
     EXPECT_EQ(res, "{}");
     res = HttpSyncClient::syncPost("localhost", "8888", R"({})");
@@ -300,9 +403,21 @@ TEST_F(WebServerTest, WsRequestOverload)
 {
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
     boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
         server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuardOverload, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
     });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebSocketSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto res = wsClient.syncPost(R"({})");
@@ -322,9 +437,21 @@ TEST_F(WebServerTest, HttpPayloadOverload)
     std::string const s100(100, 'a');
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
     boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
         server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuardOverload, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
     });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     auto const res = HttpSyncClient::syncPost("localhost", "8888", fmt::format(R"({{"payload":"{}"}})", s100));
     EXPECT_EQ(
         res,
@@ -336,9 +463,21 @@ TEST_F(WebServerTest, WsPayloadOverload)
     std::string const s100(100, 'a');
     auto e = std::make_shared<EchoExecutor>();
     auto server = std::shared_ptr<Server::HttpServer<EchoExecutor>>();
+    std::mutex m;
+    std::condition_variable cv;
+    bool ready = false;
     boost::asio::dispatch(ctx.get_executor(), [&]() mutable {
         server = Server::make_HttpServer(cfg, ctx, std::nullopt, dosGuardOverload, e);
+        {
+            std::lock_guard lk(m);
+            ready = true;
+        }
+        cv.notify_one();
     });
+    {
+        std::unique_lock lk(m);
+        cv.wait(lk, [&] { return ready; });
+    }
     WebSocketSyncClient wsClient;
     wsClient.connect("localhost", "8888");
     auto const res = wsClient.syncPost(fmt::format(R"({{"payload":"{}"}})", s100));


### PR DESCRIPTION
1 Add cache loader unittest

2 Suppress the TSAN warning for webserver unittest.
The acceptor is created in main thread, but main thread is not in io context.
Main thread will run the client to send the request. So we fix it by posting the creation to io context.
```
WARNING: ThreadSanitizer: data race (pid=76354)
  Read of size 1 at 0x00010a801638 by thread T1:
    #0 boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&) kqueue_reactor.ipp:487 (clio_tests:arm64+0x10003c2b0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #1 boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&) kqueue_reactor.ipp:438 (clio_tests:arm64+0x10003c0e0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #2 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) scheduler.ipp:477 (clio_tests:arm64+0x10003e300) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #3 boost::asio::detail::scheduler::run(boost::system::error_code&) scheduler.ipp:210 (clio_tests:arm64+0x10003df1c) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #4 boost::asio::io_context::run() io_context.ipp:64 (clio_tests:arm64+0x1000507b8) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #5 void* std::__1::__thread_proxy[abi:v15006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, WebServerTest::WebServerTest()::'lambda'()>>(void*) thread:301 (clio_tests:arm64+0x100a3b7d8) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)

  Previous write of size 1 at 0x00010a801638 by main thread (mutexes: write M0):
    #0 boost::asio::detail::conditionally_enabled_mutex::conditionally_enabled_mutex(bool) conditionally_enabled_mutex.hpp:109 (clio_tests:arm64+0x10003cdf4) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #1 boost::asio::detail::kqueue_reactor::allocate_descriptor_state() kqueue_reactor.ipp:566 (clio_tests:arm64+0x1001719ec) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #2 Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>::Server(boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>>, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, util::TagDecoratorFactory, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) Server.h:152 (clio_tests:arm64+0x100a86f2c) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #3 std::__1::shared_ptr<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> std::__1::allocate_shared[abi:v15006]<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>, std::__1::allocator<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>>, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>, util::TagDecoratorFactory, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&, void>(std::__1::allocator<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> const&, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp>&&, util::TagDecoratorFactory&&, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) shared_ptr.h:953 (clio_tests:arm64+0x100a864e0) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #4 std::__1::shared_ptr<Server::Server<Server::HttpSession, Server::SslHttpSession, EchoExecutor>> Server::make_HttpServer<EchoExecutor>(clio::Config const&, boost::asio::io_context&, std::__1::optional<std::__1::reference_wrapper<boost::asio::ssl::context>> const&, clio::BasicDOSGuard<clio::IntervalSweepHandler>&, std::__1::shared_ptr<EchoExecutor> const&) Server.h:238 (clio_tests:arm64+0x100a2f804) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #5 WebServerTest_Ws_Test::TestBody() ServerTest.cpp:204 (clio_tests:arm64+0x100a2f068) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #6 virtual thunk to WebServerTest_Ws_Test::TestBody() ServerTest.cpp (clio_tests:arm64+0x100a30554) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #7 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null>:139557568 (clio_tests:arm64+0x101aedf64) (BuildId: cf775a0c2d013f95b6e4585a23171f1e32000000200000000100000000000d00)
    #8 <null> <null> (0x00019e01ff28)
```