### PR TITLE
Expose advanced options from cassandra-cpp-driver thru the config

### DIFF
--- a/cloud-example-config.json
+++ b/cloud-example-config.json
@@ -1,14 +1,22 @@
+/*
+ * This is an example configuration file. Please do not use without modifying to suit your needs.
+ */
 {
     "database": {
         "type": "cassandra",
         "cassandra": {
+            // This option can be used to setup a secure connect bundle connection
             "secure_connect_bundle": "[path/to/zip. ignore if using contact_points]",
+            // The following options are used only if using contact_points
             "contact_points": "[ip. ignore if using secure_connect_bundle]",
             "port": "[port. ignore if using_secure_connect_bundle]",
-            "keyspace": "clio",
+            // Authentication settings
             "username": "[username, if any]",
             "password": "[password, if any]",
-            "max_requests_outstanding": 25000,
+            // Other common settings
+            "keyspace": "clio",
+            "max_write_requests_outstanding": 25000,
+            "max_read_requests_outstanding": 30000,
             "threads": 8
         }
     },

--- a/example-config.json
+++ b/example-config.json
@@ -18,7 +18,7 @@
             // ---
             "max_connections_per_host": 1, // Defaults to 2
             "core_connections_per_host": 1, // Defaults to 2
-            "max_concurrent_requests_threshold": 55000, // Defaults to ((max_read + max_write) / core_connections_per_host)
+            "max_concurrent_requests_threshold": 55000 // Defaults to ((max_read + max_write) / core_connections_per_host)
             //
             // Below options will use defaults from cassandra driver if left unspecified.
             // See https://docs.datastax.com/en/developer/cpp-driver/2.0/api/struct.CassCluster/ for details.

--- a/example-config.json
+++ b/example-config.json
@@ -1,3 +1,6 @@
+/*
+ * This is an example configuration file. Please do not use without modifying to suit your needs.
+ */
 {
     "database": {
         "type": "cassandra",
@@ -9,10 +12,27 @@
             "table_prefix": "",
             "max_write_requests_outstanding": 25000,
             "max_read_requests_outstanding": 30000,
-            "max_connections_per_host": 1, // defaults to 2
-            "core_connections_per_host": 1, // defaults to 2
-            "max_concurrent_requests_threshold": 55000, // defaults to max_read + max_write / core_connections_per_host
-            "threads": 8
+            "threads": 8,
+            //
+            // Advanced options. USE AT OWN RISK:
+            // ---
+            "max_connections_per_host": 1, // Defaults to 2
+            "core_connections_per_host": 1, // Defaults to 2
+            "max_concurrent_requests_threshold": 55000, // Defaults to ((max_read + max_write) / core_connections_per_host)
+            //
+            // Below options will use defaults from cassandra driver if left unspecified.
+            // See https://docs.datastax.com/en/developer/cpp-driver/2.0/api/struct.CassCluster/ for details.
+            // 
+            // "queue_size_event": 1,
+            // "queue_size_io": 2,
+            // "write_bytes_high_water_mark": 3,
+            // "write_bytes_low_water_mark": 4,
+            // "pending_requests_high_water_mark": 5,
+            // "pending_requests_low_water_mark": 6,
+            // "max_requests_per_flush": 7,
+            // "max_concurrent_creation": 8
+            //
+            // ---
         }
     },
     "etl_sources": [
@@ -23,21 +43,24 @@
         }
     ],
     "dos_guard": {
+        // Comma-separated list of IPs to exclude from rate limiting
         "whitelist": [
             "127.0.0.1"
-        ], // comma-separated list of ips to exclude from rate limiting
-        /* The below values are the default values and are only specified here
-         * for documentation purposes. The rate limiter currently limits
-         * connections and bandwidth per ip. The rate limiter looks at the raw
-         * ip of a client connection, and so requests routed through a load
-         * balancer will all have the same ip and be treated as a single client
-         */
-        "max_fetches": 1000000, // max bytes per ip per sweep interval
-        "max_connections": 20, // max connections per ip
-        "max_requests": 20, // max connections per ip
-        "sweep_interval": 1 // time in seconds before resetting bytes per ip count
+        ],
+        //
+        // The below values are the default values and are only specified here
+        // for documentation purposes. The rate limiter currently limits
+        // connections and bandwidth per IP. The rate limiter looks at the raw
+        // IP of a client connection, and so requests routed through a load
+        // balancer will all have the same IP and be treated as a single client.
+        //
+        "max_fetches": 1000000, // Max bytes per IP per sweep interval
+        "max_connections": 20, // Max connections per IP
+        "max_requests": 20, // Max connections per IP per sweep interval
+        "sweep_interval": 1 // Time in seconds before resetting max_fetches and max_requests
     },
     "cache": {
+        // Comma-separated list of peer nodes that Clio can use to download cache from at startup
         "peers": [
             {
                 "ip": "127.0.0.1",
@@ -52,6 +75,8 @@
         // Defaults to 0, which disables the limit.
         "max_queue_size": 500
     },
+    // Overrides log level on a per logging channel.
+    // Defaults to global "log_level" for each unspecified channel.
     "log_channels": [
         {
             "channel": "Backend",
@@ -90,10 +115,10 @@
     "log_tag_style": "uint",
     "extractor_threads": 8,
     "read_only": false,
-    //"start_sequence": [integer] the ledger index to start from,
-    //"finish_sequence": [integer] the ledger index to finish at,
-    //"ssl_cert_file" : "/full/path/to/cert.file",
-    //"ssl_key_file" : "/full/path/to/key.file"
+    // "start_sequence": [integer] the ledger index to start from,
+    // "finish_sequence": [integer] the ledger index to finish at,
+    // "ssl_cert_file" : "/full/path/to/cert.file",
+    // "ssl_key_file" : "/full/path/to/key.file"
     "api_version": {
         "min": 2,
         "max": 2,

--- a/src/backend/cassandra/SettingsProvider.cpp
+++ b/src/backend/cassandra/SettingsProvider.cpp
@@ -124,6 +124,15 @@ SettingsProvider::parseSettings() const
         "max_concurrent_requests_threshold",
         (settings.maxReadRequestsOutstanding + settings.maxWriteRequestsOutstanding) / settings.coreConnectionsPerHost);
 
+    settings.queueSizeIO = config_.maybeValue<uint32_t>("queue_size_io");
+    settings.queueSizeEvent = config_.maybeValue<uint32_t>("queue_size_event");
+    settings.writeBytesHighWatermark = config_.maybeValue<uint32_t>("write_bytes_high_water_mark");
+    settings.writeBytesLowWatermark = config_.maybeValue<uint32_t>("write_bytes_low_water_mark");
+    settings.pendingRequestsHighWatermark = config_.maybeValue<uint32_t>("pending_requests_high_water_mark");
+    settings.pendingRequestsLowWatermark = config_.maybeValue<uint32_t>("pending_requests_low_water_mark");
+    settings.maxRequestsPerFlush = config_.maybeValue<uint32_t>("max_requests_per_flush");
+    settings.maxConcurrentCreation = config_.maybeValue<uint32_t>("max_concurrent_creation");
+
     auto const connectTimeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
     if (connectTimeoutSecond)
         settings.connectionTimeout = std::chrono::milliseconds{*connectTimeoutSecond * 1000};

--- a/src/backend/cassandra/impl/Cluster.h
+++ b/src/backend/cassandra/impl/Cluster.h
@@ -57,6 +57,14 @@ struct Settings
     uint32_t coreConnectionsPerHost = 2u;
     uint32_t maxConcurrentRequestsThreshold =
         (maxWriteRequestsOutstanding + maxReadRequestsOutstanding) / coreConnectionsPerHost;
+    std::optional<uint32_t> queueSizeEvent;
+    std::optional<uint32_t> queueSizeIO;
+    std::optional<uint32_t> writeBytesHighWatermark;
+    std::optional<uint32_t> writeBytesLowWatermark;
+    std::optional<uint32_t> pendingRequestsHighWatermark;
+    std::optional<uint32_t> pendingRequestsLowWatermark;
+    std::optional<uint32_t> maxRequestsPerFlush;
+    std::optional<uint32_t> maxConcurrentCreation;
     std::optional<std::string> certificate;  // ssl context
     std::optional<std::string> username;
     std::optional<std::string> password;

--- a/src/rpc/BookChangesHelper.h
+++ b/src/rpc/BookChangesHelper.h
@@ -164,14 +164,13 @@ private:
             }
             else
             {
-                // TODO: use paranthesized initialization when clang catches up
                 tally_[key] = {
-                    first,   // sideAVolume
-                    second,  // sideBVolume
-                    rate,    // highRate
-                    rate,    // lowRate
-                    rate,    // openRate
-                    rate,    // closeRate
+                    .sideAVolume = first,
+                    .sideBVolume = second,
+                    .highRate = rate,
+                    .lowRate = rate,
+                    .openRate = rate,
+                    .closeRate = rate,
                 };
             }
         }

--- a/unittests/backend/cassandra/SettingsProviderTests.cpp
+++ b/unittests/backend/cassandra/SettingsProviderTests.cpp
@@ -24,6 +24,7 @@
 #include <config/Config.h>
 
 #include <boost/json/parse.hpp>
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <thread>
@@ -50,9 +51,22 @@ TEST_F(SettingsProviderTest, Defaults)
     EXPECT_EQ(settings.enableLog, false);
     EXPECT_EQ(settings.connectionTimeout, std::chrono::milliseconds{10000});
     EXPECT_EQ(settings.requestTimeout, std::chrono::milliseconds{0});
+    EXPECT_EQ(settings.maxWriteRequestsOutstanding, 10'000);
+    EXPECT_EQ(settings.maxReadRequestsOutstanding, 100'000);
+    EXPECT_EQ(settings.maxConnectionsPerHost, 2);
+    EXPECT_EQ(settings.coreConnectionsPerHost, 2);
+    EXPECT_EQ(settings.maxConcurrentRequestsThreshold, (100'000 + 10'000) / 2);
     EXPECT_EQ(settings.certificate, std::nullopt);
     EXPECT_EQ(settings.username, std::nullopt);
     EXPECT_EQ(settings.password, std::nullopt);
+    EXPECT_EQ(settings.queueSizeIO, std::nullopt);
+    EXPECT_EQ(settings.queueSizeEvent, std::nullopt);
+    EXPECT_EQ(settings.writeBytesHighWatermark, std::nullopt);
+    EXPECT_EQ(settings.writeBytesLowWatermark, std::nullopt);
+    EXPECT_EQ(settings.pendingRequestsHighWatermark, std::nullopt);
+    EXPECT_EQ(settings.pendingRequestsLowWatermark, std::nullopt);
+    EXPECT_EQ(settings.maxRequestsPerFlush, std::nullopt);
+    EXPECT_EQ(settings.maxConcurrentCreation, std::nullopt);
 
     auto const* cp = std::get_if<Settings::ContactPoints>(&settings.connectionInfo);
     ASSERT_TRUE(cp != nullptr);
@@ -107,7 +121,7 @@ TEST_F(SettingsProviderTest, DriverOptionCalculation)
     EXPECT_EQ(settings.maxConcurrentRequestsThreshold, 150);  // calculated from above
 }
 
-TEST_F(SettingsProviderTest, DriverOptionSecified)
+TEST_F(SettingsProviderTest, DriverOptionSecifiedMaxConcurrentRequestsThreshold)
 {
     Config cfg{json::parse(R"({
         "contact_points": "123.123.123.123",
@@ -128,6 +142,32 @@ TEST_F(SettingsProviderTest, DriverOptionSecified)
     EXPECT_EQ(settings.maxConcurrentRequestsThreshold, 1234);
 }
 
+TEST_F(SettingsProviderTest, DriverOptionalOptionsSpecified)
+{
+    Config cfg{json::parse(R"({
+        "contact_points": "123.123.123.123",
+        "queue_size_event": 1,
+        "queue_size_io": 2,
+        "write_bytes_high_water_mark": 3,
+        "write_bytes_low_water_mark": 4,
+        "pending_requests_high_water_mark": 5,
+        "pending_requests_low_water_mark": 6,
+        "max_requests_per_flush": 7,
+        "max_concurrent_creation": 8
+    })")};
+    SettingsProvider provider{cfg};
+
+    auto const settings = provider.getSettings();
+    EXPECT_EQ(settings.queueSizeEvent, 1);
+    EXPECT_EQ(settings.queueSizeIO, 2);
+    EXPECT_EQ(settings.writeBytesHighWatermark, 3);
+    EXPECT_EQ(settings.writeBytesLowWatermark, 4);
+    EXPECT_EQ(settings.pendingRequestsHighWatermark, 5);
+    EXPECT_EQ(settings.pendingRequestsLowWatermark, 6);
+    EXPECT_EQ(settings.maxRequestsPerFlush, 7);
+    EXPECT_EQ(settings.maxConcurrentCreation, 8);
+}
+
 TEST_F(SettingsProviderTest, SecureBundleConfig)
 {
     Config cfg{json::parse(R"({"secure_connect_bundle": "bundleData"})")};
@@ -142,11 +182,12 @@ TEST_F(SettingsProviderTest, SecureBundleConfig)
 TEST_F(SettingsProviderTest, CertificateConfig)
 {
     TmpFile file{"certificateData"};
-    Config cfg{json::parse(
-        R"({
-        "contact_points": "127.0.0.1",
-        "certfile": ")" +
-        file.path + "\"}")};
+    Config cfg{json::parse(fmt::format(
+        R"({{
+            "contact_points": "127.0.0.1",
+            "certfile": "{}"
+        }})",
+        file.path))};
     SettingsProvider provider{cfg};
 
     auto const settings = provider.getSettings();


### PR DESCRIPTION
This should be useful for fine-tuning the way Clio interacts with the DB.