### PR TITLE
Move connection state logic to an earlier point

### DIFF
--- a/src/etl/Source.cpp
+++ b/src/etl/Source.cpp
@@ -40,23 +40,7 @@ using namespace clio;
 static boost::beast::websocket::stream_base::timeout
 make_TimeoutOption()
 {
-    // See #289 for details.
-    // TODO: investigate the issue and find if there is a solution other than
-    // introducing artificial timeouts.
-    if (true)
-    {
-        // The only difference between this and the suggested client role is
-        // that idle_timeout is set to 20 instead of none()
-        auto opt = boost::beast::websocket::stream_base::timeout{};
-        opt.handshake_timeout = std::chrono::seconds(30);
-        opt.idle_timeout = std::chrono::seconds(20);
-        opt.keep_alive_pings = false;
-        return opt;
-    }
-    else
-    {
-        return boost::beast::websocket::stream_base::timeout::suggested(boost::beast::role_type::client);
-    }
+    return boost::beast::websocket::stream_base::timeout::suggested(boost::beast::role_type::client);
 }
 
 void
@@ -142,6 +126,7 @@ PlainSource::onConnect(
     }
     else
     {
+        connected_ = true;
         numFailures_ = 0;
 
         // Websocket stream has it's own timeout system
@@ -172,6 +157,7 @@ SslSource::onConnect(boost::beast::error_code ec, boost::asio::ip::tcp::resolver
     }
     else
     {
+        connected_ = true;
         numFailures_ = 0;
 
         // Websocket stream has it's own timeout system

--- a/src/etl/Source.h
+++ b/src/etl/Source.h
@@ -135,7 +135,6 @@ class SourceImpl : public Source
     std::shared_ptr<NetworkValidatedLedgers> networkValidatedLedgers_;
 
     mutable std::mutex mtx_;
-    std::atomic_bool connected_{false};
 
     // true if this ETL source is forwarding transactions received on the transactions_proposed stream. There are
     // usually multiple ETL sources, so to avoid forwarding the same transaction multiple times, we only forward from
@@ -165,6 +164,7 @@ protected:
 
     std::atomic_bool closing_{false};
     std::atomic_bool paused_{false};
+    std::atomic_bool connected_{false};
 
     SourceHooks hooks_;
 
@@ -261,7 +261,7 @@ public:
                      << "request = " << boost::json::serialize(request);
 
         boost::json::object response;
-        if (!connected_)
+        if (!isConnected())
         {
             log_.error() << "Attempted to proxy but failed to connect to tx";
             return {};
@@ -724,7 +724,6 @@ public:
     handleMessage(size_t size)
     {
         setLastMsgTime();
-        connected_ = true;
 
         try
         {


### PR DESCRIPTION
Seems like boost 1.82 treats the suggested timeout option slightly different than before so the 20 sec idle timeout hack is no longer needed. 
Also the connected state flag was previously set after receiving the initial message from the subscription. While this is probably correct, it's possible that we will not receive the message soon enough and the connection state will remain set to `false` for longer than needed leading to forward requests potentially failing until clio realizes it is connected again. 