### PR TITLE
Add LOG macro to prevent unnecessary evaluations

### DIFF
--- a/src/data/BackendFactory.h
+++ b/src/data/BackendFactory.h
@@ -39,7 +39,7 @@ std::shared_ptr<BackendInterface>
 make_Backend(boost::asio::io_context& ioc, util::Config const& config)
 {
     static util::Logger log{"Backend"};
-    log.info() << "Constructing BackendInterface";
+    LOG(log.info()) << "Constructing BackendInterface";
 
     auto const readOnly = config.valueOr("read_only", false);
 
@@ -63,7 +63,7 @@ make_Backend(boost::asio::io_context& ioc, util::Config const& config)
         backend->updateRange(rng->maxSequence);
     }
 
-    log.info() << "Constructed BackendInterface Successfully";
+    LOG(log.info()) << "Constructed BackendInterface Successfully";
     return backend;
 }
 }  // namespace data

--- a/src/data/BackendInterface.h
+++ b/src/data/BackendInterface.h
@@ -70,7 +70,7 @@ retryOnTimeout(FnType func, size_t waitMs = 500)
         }
         catch (DatabaseTimeout const&)
         {
-            log.error() << "Database request timed out. Sleeping and retrying ... ";
+            LOG(log.error()) << "Database request timed out. Sleeping and retrying ... ";
             std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
         }
     }

--- a/src/data/cassandra/Schema.h
+++ b/src/data/cassandra/Schema.h
@@ -641,9 +641,9 @@ public:
     void
     prepareStatements(Handle const& handle)
     {
-        log_.info() << "Preparing cassandra statements";
+        LOG(log_.info()) << "Preparing cassandra statements";
         statements_ = std::make_unique<Statements>(settingsProvider_, handle);
-        log_.info() << "Finished preparing statements";
+        LOG(log_.info()) << "Finished preparing statements";
     }
 
     /**

--- a/src/data/cassandra/impl/Cluster.cpp
+++ b/src/data/cassandra/impl/Cluster.cpp
@@ -143,18 +143,18 @@ Cluster::Cluster(Settings const& settings) : ManagedObject{cass_cluster_new(), c
         return maybeValue ? to_string(*maybeValue) : "default";
     };
 
-    log_.info() << "Threads: " << settings.threads;
-    log_.info() << "Max concurrent requests per host: " << settings.maxConcurrentRequestsThreshold;
-    log_.info() << "Max connections per host: " << settings.maxConnectionsPerHost;
-    log_.info() << "Core connections per host: " << settings.coreConnectionsPerHost;
-    log_.info() << "IO queue size: " << queueSize;
-    log_.info() << "Event queue size: " << valueOrDefault(settings.queueSizeEvent);
-    log_.info() << "Write bytes high watermark: " << valueOrDefault(settings.writeBytesHighWatermark);
-    log_.info() << "Write bytes low watermark: " << valueOrDefault(settings.writeBytesLowWatermark);
-    log_.info() << "Pending requests high watermark: " << valueOrDefault(settings.pendingRequestsHighWatermark);
-    log_.info() << "Pending requests low watermark: " << valueOrDefault(settings.pendingRequestsLowWatermark);
-    log_.info() << "Max requests per flush: " << valueOrDefault(settings.maxRequestsPerFlush);
-    log_.info() << "Max concurrent creation: " << valueOrDefault(settings.maxConcurrentCreation);
+    LOG(log_.info()) << "Threads: " << settings.threads;
+    LOG(log_.info()) << "Max concurrent requests per host: " << settings.maxConcurrentRequestsThreshold;
+    LOG(log_.info()) << "Max connections per host: " << settings.maxConnectionsPerHost;
+    LOG(log_.info()) << "Core connections per host: " << settings.coreConnectionsPerHost;
+    LOG(log_.info()) << "IO queue size: " << queueSize;
+    LOG(log_.info()) << "Event queue size: " << valueOrDefault(settings.queueSizeEvent);
+    LOG(log_.info()) << "Write bytes high watermark: " << valueOrDefault(settings.writeBytesHighWatermark);
+    LOG(log_.info()) << "Write bytes low watermark: " << valueOrDefault(settings.writeBytesLowWatermark);
+    LOG(log_.info()) << "Pending requests high watermark: " << valueOrDefault(settings.pendingRequestsHighWatermark);
+    LOG(log_.info()) << "Pending requests low watermark: " << valueOrDefault(settings.pendingRequestsLowWatermark);
+    LOG(log_.info()) << "Max requests per flush: " << valueOrDefault(settings.maxRequestsPerFlush);
+    LOG(log_.info()) << "Max concurrent creation: " << valueOrDefault(settings.maxConcurrentCreation);
 }
 
 void
@@ -178,7 +178,7 @@ Cluster::setupContactPoints(Settings::ContactPoints const& points)
     };
 
     {
-        log_.debug() << "Attempt connection using contact points: " << points.contactPoints;
+        LOG(log_.debug()) << "Attempt connection using contact points: " << points.contactPoints;
         auto const rc = cass_cluster_set_contact_points(*this, points.contactPoints.data());
         throwErrorIfNeeded(rc, "contact_points", points.contactPoints);
     }
@@ -193,7 +193,7 @@ Cluster::setupContactPoints(Settings::ContactPoints const& points)
 void
 Cluster::setupSecureBundle(Settings::SecureConnectionBundle const& bundle)
 {
-    log_.debug() << "Attempt connection using secure bundle";
+    LOG(log_.debug()) << "Attempt connection using secure bundle";
     if (auto const rc = cass_cluster_set_cloud_secure_connection_bundle(*this, bundle.bundle.data()); rc != CASS_OK)
     {
         throw std::runtime_error("Failed to connect using secure connection bundle " + bundle.bundle);
@@ -206,7 +206,7 @@ Cluster::setupCertificate(Settings const& settings)
     if (not settings.certificate)
         return;
 
-    log_.debug() << "Configure SSL context";
+    LOG(log_.debug()) << "Configure SSL context";
     SslContext context = SslContext(*settings.certificate);
     cass_cluster_set_ssl(*this, context);
 }
@@ -217,7 +217,7 @@ Cluster::setupCredentials(Settings const& settings)
     if (not settings.username || not settings.password)
         return;
 
-    log_.debug() << "Set credentials; username: " << settings.username.value();
+    LOG(log_.debug()) << "Set credentials; username: " << settings.username.value();
     cass_cluster_set_credentials(*this, settings.username.value().c_str(), settings.password.value().c_str());
 }
 

--- a/src/data/cassandra/impl/ExecutionStrategy.h
+++ b/src/data/cassandra/impl/ExecutionStrategy.h
@@ -89,8 +89,8 @@ public:
         , handle_{std::cref(handle)}
         , thread_{[this]() { ioc_.run(); }}
     {
-        log_.info() << "Max write requests outstanding is " << maxWriteRequestsOutstanding_
-                    << "; Max read requests outstanding is " << maxReadRequestsOutstanding_;
+        LOG(log_.info()) << "Max write requests outstanding is " << maxWriteRequestsOutstanding_
+                         << "; Max read requests outstanding is " << maxReadRequestsOutstanding_;
     }
 
     ~DefaultExecutionStrategy()
@@ -106,10 +106,10 @@ public:
     void
     sync()
     {
-        log_.debug() << "Waiting to sync all writes...";
+        LOG(log_.debug()) << "Waiting to sync all writes...";
         std::unique_lock<std::mutex> lck(syncMutex_);
         syncCv_.wait(lck, [this]() { return finishedAllWriteRequests(); });
-        log_.debug() << "Sync done.";
+        LOG(log_.debug()) << "Sync done.";
     }
 
     /**
@@ -137,7 +137,7 @@ public:
             }
             else
             {
-                log_.warn() << "Cassandra sync write error, retrying: " << res.error();
+                LOG(log_.warn()) << "Cassandra sync write error, retrying: " << res.error();
                 std::this_thread::sleep_for(std::chrono::milliseconds(5));
             }
         }
@@ -262,7 +262,7 @@ public:
             }
             else
             {
-                log_.error() << "Failed batch read in coroutine: " << res.error();
+                LOG(log_.error()) << "Failed batch read in coroutine: " << res.error();
                 throwErrorIfNeeded(res.error());
             }
         }
@@ -311,7 +311,7 @@ public:
             }
             else
             {
-                log_.error() << "Failed read in coroutine: " << res.error();
+                LOG(log_.error()) << "Failed read in coroutine: " << res.error();
                 throwErrorIfNeeded(res.error());
             }
         }
@@ -400,8 +400,8 @@ private:
             std::unique_lock<std::mutex> lck(throttleMutex_);
             if (!canAddWriteRequest())
             {
-                log_.trace() << "Max outstanding requests reached. "
-                             << "Waiting for other requests to finish";
+                LOG(log_.trace()) << "Max outstanding requests reached. "
+                                  << "Waiting for other requests to finish";
                 throttleCv_.wait(lck, [this]() { return canAddWriteRequest(); });
             }
         }

--- a/src/data/cassandra/impl/RetryPolicy.h
+++ b/src/data/cassandra/impl/RetryPolicy.h
@@ -59,8 +59,8 @@ public:
     shouldRetry([[maybe_unused]] CassandraError err)
     {
         auto const delay = calculateDelay(attempt_);
-        log_.error() << "Cassandra write error: " << err << ", current retries " << attempt_ << ", retrying in "
-                     << delay.count() << " milliseconds";
+        LOG(log_.error()) << "Cassandra write error: " << err << ", current retries " << attempt_ << ", retrying in "
+                          << delay.count() << " milliseconds";
 
         return true;  // keep retrying forever
     }

--- a/src/etl/ETLService.h
+++ b/src/etl/ETLService.h
@@ -150,8 +150,8 @@ public:
      */
     ~ETLService()
     {
-        log_.info() << "onStop called";
-        log_.debug() << "Stopping Reporting ETL";
+        LOG(log_.info()) << "onStop called";
+        LOG(log_.debug()) << "Stopping Reporting ETL";
 
         state_.isStopping = true;
         cacheLoader_.stop();
@@ -159,7 +159,7 @@ public:
         if (worker_.joinable())
             worker_.join();
 
-        log_.debug() << "Joined ETLService worker thread";
+        LOG(log_.debug()) << "Joined ETLService worker thread";
     }
 
     /**

--- a/src/etl/ProbingSource.cpp
+++ b/src/etl/ProbingSource.cpp
@@ -155,7 +155,7 @@ ProbingSource::make_SSLHooks() noexcept
                 {
                     plainSrc_->pause();
                     currentSrc_ = sslSrc_;
-                    log_.info() << "Selected WSS as the main source: " << currentSrc_->toString();
+                    LOG(log_.info()) << "Selected WSS as the main source: " << currentSrc_->toString();
                 }
                 return SourceHooks::Action::PROCEED;
             },
@@ -184,7 +184,7 @@ ProbingSource::make_PlainHooks() noexcept
                 {
                     sslSrc_->pause();
                     currentSrc_ = plainSrc_;
-                    log_.info() << "Selected Plain WS as the main source: " << currentSrc_->toString();
+                    LOG(log_.info()) << "Selected Plain WS as the main source: " << currentSrc_->toString();
                 }
                 return SourceHooks::Action::PROCEED;
             },

--- a/src/etl/Source.cpp
+++ b/src/etl/Source.cpp
@@ -59,8 +59,8 @@ PlainSource::close(bool startAgain)
             derived().ws().async_close(boost::beast::websocket::close_code::normal, [this, startAgain](auto ec) {
                 if (ec)
                 {
-                    log_.error() << " async_close : "
-                                 << "error code = " << ec << " - " << toString();
+                    LOG(log_.error()) << " async_close : "
+                                      << "error code = " << ec << " - " << toString();
                 }
                 closing_ = false;
                 if (startAgain)
@@ -94,8 +94,8 @@ SslSource::close(bool startAgain)
             derived().ws().async_close(boost::beast::websocket::close_code::normal, [this, startAgain](auto ec) {
                 if (ec)
                 {
-                    log_.error() << " async_close : "
-                                 << "error code = " << ec << " - " << toString();
+                    LOG(log_.error()) << " async_close : "
+                                      << "error code = " << ec << " - " << toString();
                 }
                 closing_ = false;
                 if (startAgain)

--- a/src/etl/impl/AsyncData.h
+++ b/src/etl/impl/AsyncData.h
@@ -57,9 +57,9 @@ public:
 
         unsigned char prefix = marker.data()[0];
 
-        log_.debug() << "Setting up AsyncCallData. marker = " << ripple::strHex(marker)
-                     << " . prefix = " << ripple::strHex(std::string(1, prefix))
-                     << " . nextPrefix_ = " << ripple::strHex(std::string(1, nextPrefix_));
+        LOG(log_.debug()) << "Setting up AsyncCallData. marker = " << ripple::strHex(marker)
+                          << " . prefix = " << ripple::strHex(std::string(1, prefix))
+                          << " . nextPrefix_ = " << ripple::strHex(std::string(1, nextPrefix_));
 
         assert(nextPrefix_ > prefix || nextPrefix_ == 0x00);
 
@@ -78,23 +78,23 @@ public:
         bool abort,
         bool cacheOnly = false)
     {
-        log_.trace() << "Processing response. "
-                     << "Marker prefix = " << getMarkerPrefix();
+        LOG(log_.trace()) << "Processing response. "
+                          << "Marker prefix = " << getMarkerPrefix();
         if (abort)
         {
-            log_.error() << "AsyncCallData aborted";
+            LOG(log_.error()) << "AsyncCallData aborted";
             return CallStatus::ERRORED;
         }
         if (!status_.ok())
         {
-            log_.error() << "AsyncCallData status_ not ok: "
-                         << " code = " << status_.error_code() << " message = " << status_.error_message();
+            LOG(log_.error()) << "AsyncCallData status_ not ok: "
+                              << " code = " << status_.error_code() << " message = " << status_.error_message();
             return CallStatus::ERRORED;
         }
         if (!next_->is_unlimited())
         {
-            log_.warn() << "AsyncCallData is_unlimited is false. Make sure "
-                           "secure_gateway is set correctly at the ETL source";
+            LOG(log_.warn()) << "AsyncCallData is_unlimited is false. Make sure "
+                                "secure_gateway is set correctly at the ETL source";
         }
 
         std::swap(cur_, next_);
@@ -118,7 +118,7 @@ public:
         }
 
         auto const numObjects = cur_->ledger_objects().objects_size();
-        log_.debug() << "Writing " << numObjects << " objects";
+        LOG(log_.debug()) << "Writing " << numObjects << " objects";
 
         std::vector<data::LedgerObject> cacheUpdates;
         cacheUpdates.reserve(numObjects);
@@ -145,7 +145,7 @@ public:
             }
         }
         backend.cache().update(cacheUpdates, request_.ledger().sequence(), cacheOnly);
-        log_.debug() << "Wrote " << numObjects << " objects. Got more: " << (more ? "YES" : "NO");
+        LOG(log_.debug()) << "Wrote " << numObjects << " objects. Got more: " << (more ? "YES" : "NO");
 
         return more ? CallStatus::MORE : CallStatus::DONE;
     }

--- a/src/etl/impl/ExtractionDataPipe.h
+++ b/src/etl/impl/ExtractionDataPipe.h
@@ -126,7 +126,7 @@ private:
     std::shared_ptr<QueueType>
     getQueue(uint32_t sequence)
     {
-        log_.debug() << "Grabbing extraction queue for " << sequence << "; start was " << startSequence_;
+        LOG(log_.debug()) << "Grabbing extraction queue for " << sequence << "; start was " << startSequence_;
         return queues_[(sequence - startSequence_) % stride_];
     }
 };

--- a/src/etl/impl/Extractor.h
+++ b/src/etl/impl/Extractor.h
@@ -103,9 +103,9 @@ private:
 
             // TODO: extract this part into a strategy perhaps
             auto const tps = fetchResponse->transactions_list().transactions_size() / time;
-            log_.info() << "Extract phase time = " << time << "; Extract phase tps = " << tps
-                        << "; Avg extract time = " << totalTime / (currentSequence - startSequence_ + 1)
-                        << "; seq = " << currentSequence;
+            LOG(log_.info()) << "Extract phase time = " << time << "; Extract phase tps = " << tps
+                             << "; Avg extract time = " << totalTime / (currentSequence - startSequence_ + 1)
+                             << "; seq = " << currentSequence;
 
             pipe_.get().push(currentSequence, std::move(fetchResponse));
             currentSequence += pipe_.get().getStride();

--- a/src/etl/impl/ForwardCache.cpp
+++ b/src/etl/impl/ForwardCache.cpp
@@ -29,7 +29,7 @@ namespace etl::detail {
 void
 ForwardCache::freshen()
 {
-    log_.trace() << "Freshening ForwardCache";
+    LOG(log_.trace()) << "Freshening ForwardCache";
 
     auto numOutstanding = std::make_shared<std::atomic_uint>(latestForwarded_.size());
 

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -66,11 +66,11 @@ public:
     OptionalGetLedgerResponseType
     fetchData(uint32_t sequence)
     {
-        log_.debug() << "Attempting to fetch ledger with sequence = " << sequence;
+        LOG(log_.debug()) << "Attempting to fetch ledger with sequence = " << sequence;
 
         auto response = loadBalancer_->fetchLedger(sequence, false, false);
         if (response)
-            log_.trace() << "GetLedger reply = " << response->DebugString();
+            LOG(log_.trace()) << "GetLedger reply = " << response->DebugString();
         return response;
     }
 
@@ -87,12 +87,12 @@ public:
     OptionalGetLedgerResponseType
     fetchDataAndDiff(uint32_t sequence)
     {
-        log_.debug() << "Attempting to fetch ledger with sequence = " << sequence;
+        LOG(log_.debug()) << "Attempting to fetch ledger with sequence = " << sequence;
 
         auto response = loadBalancer_->fetchLedger(
             sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() >= sequence);
         if (response)
-            log_.trace() << "GetLedger reply = " << response->DebugString();
+            LOG(log_.trace()) << "GetLedger reply = " << response->DebugString();
 
         return response;
     }

--- a/src/etl/impl/LedgerPublisher.h
+++ b/src/etl/impl/LedgerPublisher.h
@@ -89,7 +89,7 @@ public:
     bool
     publish(uint32_t ledgerSequence, std::optional<uint32_t> maxAttempts)
     {
-        log_.info() << "Attempting to publish ledger = " << ledgerSequence;
+        LOG(log_.info()) << "Attempting to publish ledger = " << ledgerSequence;
         size_t numAttempts = 0;
         while (not state_.get().isStopping)
         {
@@ -97,14 +97,14 @@ public:
 
             if (!range || range->maxSequence < ledgerSequence)
             {
-                log_.debug() << "Trying to publish. Could not find "
-                                "ledger with sequence = "
-                             << ledgerSequence;
+                LOG(log_.debug()) << "Trying to publish. Could not find "
+                                     "ledger with sequence = "
+                                  << ledgerSequence;
 
                 // We try maxAttempts times to publish the ledger, waiting one second in between each attempt.
                 if (maxAttempts && numAttempts >= maxAttempts)
                 {
-                    log_.debug() << "Failed to publish ledger after " << numAttempts << " attempts.";
+                    LOG(log_.debug()) << "Failed to publish ledger after " << numAttempts << " attempts.";
                     return false;
                 }
                 std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -136,11 +136,11 @@ public:
     publish(ripple::LedgerHeader const& lgrInfo)
     {
         boost::asio::post(publishStrand_, [this, lgrInfo = lgrInfo]() {
-            log_.info() << "Publishing ledger " << std::to_string(lgrInfo.seq);
+            LOG(log_.info()) << "Publishing ledger " << std::to_string(lgrInfo.seq);
 
             if (!state_.get().isWriting)
             {
-                log_.info() << "Updating cache";
+                LOG(log_.info()) << "Updating cache";
 
                 std::vector<data::LedgerObject> diff = data::synchronousAndRetryOnTimeout(
                     [&](auto yield) { return backend_->fetchLedgerDiff(lgrInfo.seq, yield); });
@@ -177,10 +177,10 @@ public:
                 subscriptions_->pubBookChanges(lgrInfo, transactions);
 
                 setLastPublishTime();
-                log_.info() << "Published ledger " << std::to_string(lgrInfo.seq);
+                LOG(log_.info()) << "Published ledger " << std::to_string(lgrInfo.seq);
             }
             else
-                log_.info() << "Skipping publishing ledger " << std::to_string(lgrInfo.seq);
+                LOG(log_.info()) << "Skipping publishing ledger " << std::to_string(lgrInfo.seq);
         });
 
         // we track latest publish-requested seq, not necessarily already published

--- a/src/feed/SubscriptionManager.h
+++ b/src/feed/SubscriptionManager.h
@@ -320,7 +320,7 @@ public:
         // We will eventually want to clamp this to be the number of strands,
         // since adding more threads than we have strands won't see any
         // performance benefits
-        log_.info() << "Starting subscription manager with " << numThreads << " workers";
+        LOG(log_.info()) << "Starting subscription manager with " << numThreads << " workers";
 
         workers_.reserve(numThreads);
         for (auto i = numThreads; i > 0; --i)

--- a/src/main/Main.cpp
+++ b/src/main/Main.cpp
@@ -164,15 +164,15 @@ try
     }
 
     LogService::init(config);
-    LogService::info() << "Clio version: " << Build::getClioFullVersionString();
+    LOG(LogService::info()) << "Clio version: " << Build::getClioFullVersionString();
 
     auto const threads = config.valueOr("io_threads", 2);
     if (threads <= 0)
     {
-        LogService::fatal() << "io_threads is less than 1";
+        LOG(LogService::fatal()) << "io_threads is less than 1";
         return EXIT_FAILURE;
     }
-    LogService::info() << "Number of io threads = " << threads;
+    LOG(LogService::info()) << "Number of io threads = " << threads;
 
     // IO context to handle all incoming requests, as well as other things.
     // This is not the only io context in the application.
@@ -224,5 +224,5 @@ try
 }
 catch (std::exception const& e)
 {
-    LogService::fatal() << "Exit on exception: " << e.what();
+    LOG(LogService::fatal()) << "Exit on exception: " << e.what();
 }

--- a/src/rpc/RPCEngine.h
+++ b/src/rpc/RPCEngine.h
@@ -129,7 +129,7 @@ public:
 
         if (backend_->isTooBusy())
         {
-            log_.error() << "Database is too busy. Rejecting request";
+            LOG(log_.error()) << "Database is too busy. Rejecting request";
             notifyTooBusy();  // TODO: should we add ctx.method if we have it?
             return Status{RippledError::rpcTOO_BUSY};
         }
@@ -143,13 +143,13 @@ public:
 
         try
         {
-            perfLog_.debug() << ctx.tag() << " start executing rpc `" << ctx.method << '`';
+            LOG(perfLog_.debug()) << ctx.tag() << " start executing rpc `" << ctx.method << '`';
 
             auto const isAdmin = adminVerifier_.isAdmin(ctx.clientIp);
             auto const context = Context{ctx.yield, ctx.session, isAdmin, ctx.clientIp, ctx.apiVersion};
             auto const v = (*method).process(ctx.params, context);
 
-            perfLog_.debug() << ctx.tag() << " finish executing rpc `" << ctx.method << '`';
+            LOG(perfLog_.debug()) << ctx.tag() << " finish executing rpc `" << ctx.method << '`';
 
             if (v)
                 return v->as_object();
@@ -161,14 +161,14 @@ public:
         }
         catch (data::DatabaseTimeout const& t)
         {
-            log_.error() << "Database timeout";
+            LOG(log_.error()) << "Database timeout";
             notifyTooBusy();
 
             return Status{RippledError::rpcTOO_BUSY};
         }
         catch (std::exception const& ex)
         {
-            log_.error() << ctx.tag() << "Caught exception: " << ex.what();
+            LOG(log_.error()) << ctx.tag() << "Caught exception: " << ex.what();
             notifyInternalError();
 
             return Status{RippledError::rpcINTERNAL};

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -163,9 +163,9 @@ deserializeTxPlusMeta(data::TransactionAndMetadata const& blobs)
         std::stringstream meta;
         std::copy(blobs.transaction.begin(), blobs.transaction.end(), std::ostream_iterator<unsigned char>(txn));
         std::copy(blobs.metadata.begin(), blobs.metadata.end(), std::ostream_iterator<unsigned char>(meta));
-        gLog.error() << "Failed to deserialize transaction. txn = " << txn.str() << " - meta = " << meta.str()
-                     << " txn length = " << std::to_string(blobs.transaction.size())
-                     << " meta length = " << std::to_string(blobs.metadata.size());
+        LOG(gLog.error()) << "Failed to deserialize transaction. txn = " << txn.str() << " - meta = " << meta.str()
+                          << " txn length = " << std::to_string(blobs.transaction.size())
+                          << " meta length = " << std::to_string(blobs.metadata.size());
         throw e;
     }
 }
@@ -654,12 +654,12 @@ traverseOwnedNodes(
     }
     auto end = std::chrono::system_clock::now();
 
-    gLog.debug() << "Time loading owned directories: "
-                 << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " milliseconds";
+    LOG(gLog.debug()) << "Time loading owned directories: "
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " milliseconds";
 
     auto [objects, timeDiff] = util::timed([&]() { return backend.fetchLedgerObjects(keys, sequence, yield); });
 
-    gLog.debug() << "Time loading owned entries: " << timeDiff << " milliseconds";
+    LOG(gLog.debug()) << "Time loading owned entries: " << timeDiff << " milliseconds";
 
     for (auto i = 0u; i < objects.size(); ++i)
     {
@@ -1133,7 +1133,7 @@ postProcessOrderBook(
         }
         catch (std::exception const& e)
         {
-            gLog.error() << "caught exception: " << e.what();
+            LOG(gLog.error()) << "caught exception: " << e.what();
         }
     }
     return jsonOffers;

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -240,11 +240,11 @@ logDuration(web::Context const& ctx, T const& dur)
         serialize(util::removeSecret(ctx.params)));
 
     if (seconds > 10)
-        log.error() << ctx.tag() << msg;
+        LOG(log.error()) << ctx.tag() << msg;
     else if (seconds > 1)
-        log.warn() << ctx.tag() << msg;
+        LOG(log.warn()) << ctx.tag() << msg;
     else
-        log.info() << ctx.tag() << msg;
+        LOG(log.info()) << ctx.tag() << msg;
 }
 
 }  // namespace rpc

--- a/src/rpc/WorkQueue.h
+++ b/src/rpc/WorkQueue.h
@@ -72,7 +72,7 @@ public:
         auto const numThreads = config.valueOr<uint32_t>("workers", std::thread::hardware_concurrency());
         auto const maxQueueSize = serverConfig.valueOr<uint32_t>("max_queue_size", 0);  // 0 is no limit
 
-        log.info() << "Number of workers = " << numThreads << ". Max queue size = " << maxQueueSize;
+        LOG(log.info()) << "Number of workers = " << numThreads << ". Max queue size = " << maxQueueSize;
         return WorkQueue{numThreads, maxQueueSize};
     }
 
@@ -92,7 +92,8 @@ public:
     {
         if (curSize_ >= maxSize_ && !isWhiteListed)
         {
-            log_.warn() << "Queue is full. rejecting job. current size = " << curSize_ << "; max size = " << maxSize_;
+            LOG(log_.warn()) << "Queue is full. rejecting job. current size = " << curSize_
+                             << "; max size = " << maxSize_;
             return false;
         }
 
@@ -108,7 +109,7 @@ public:
 
                 ++queued_;
                 durationUs_ += wait;
-                log_.info() << "WorkQueue wait time = " << wait << " queue size = " << curSize_;
+                LOG(log_.info()) << "WorkQueue wait time = " << wait << " queue size = " << curSize_;
 
                 func(yield);
                 --curSize_;

--- a/src/rpc/common/impl/APIVersionParser.h
+++ b/src/rpc/common/impl/APIVersionParser.h
@@ -51,9 +51,9 @@ public:
         auto checkRange = [this](uint32_t version, std::string label) {
             if (std::clamp(version, API_VERSION_MIN, API_VERSION_MAX) != version)
             {
-                log_.error() << "API version settings issue detected: " << label << " version with value " << version
-                             << " is outside of supported range " << API_VERSION_MIN << "-" << API_VERSION_MAX
-                             << "; Falling back to hardcoded values.";
+                LOG(log_.error()) << "API version settings issue detected: " << label << " version with value "
+                                  << version << " is outside of supported range " << API_VERSION_MIN << "-"
+                                  << API_VERSION_MAX << "; Falling back to hardcoded values.";
 
                 defaultVersion_ = API_VERSION_DEFAULT;
                 minVersion_ = API_VERSION_MIN;
@@ -66,8 +66,8 @@ public:
         checkRange(maxVersion, "maximum");
 #endif
 
-        log_.info() << "API version settings: [min = " << minVersion_ << "; max = " << maxVersion_
-                    << "; default = " << defaultVersion_ << "]";
+        LOG(log_.info()) << "API version settings: [min = " << minVersion_ << "; max = " << maxVersion_
+                         << "; default = " << defaultVersion_ << "]";
     }
 
     ProductionAPIVersionParser(util::Config const& config);

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -87,7 +87,7 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
         return sharedPtrBackend_->fetchAccountTransactions(*accountID, limit, input.forward, cursor, ctx.yield);
     });
 
-    log_.info() << "db fetch took " << timeDiff << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
+    LOG(log_.info()) << "db fetch took " << timeDiff << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
 
     auto const [blobs, retCursor] = txnsAndCursor;
     Output response;
@@ -106,7 +106,7 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
         }
         else if (txnPlusMeta.ledgerSequence > maxIndex && !input.forward)
         {
-            log_.debug() << "Skipping over transactions from incomplete ledger";
+            LOG(log_.debug()) << "Skipping over transactions from incomplete ledger";
             continue;
         }
 

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -150,8 +150,8 @@ LedgerDataHandler::process(Input input, Context const& ctx) const
     }
 
     auto const end = std::chrono::system_clock::now();
-    log_.debug() << "Number of results = " << results.size() << " fetched in "
-                 << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << " microseconds";
+    LOG(log_.debug()) << "Number of results = " << results.size() << " fetched in "
+                      << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << " microseconds";
 
     output.states.reserve(results.size());
 
@@ -180,8 +180,8 @@ LedgerDataHandler::process(Input input, Context const& ctx) const
         output.cacheFull = sharedPtrBackend_->cache().isFull();
 
     auto const end2 = std::chrono::system_clock::now();
-    log_.debug() << "Number of results = " << results.size() << " serialized in "
-                 << std::chrono::duration_cast<std::chrono::microseconds>(end2 - end).count() << " microseconds";
+    LOG(log_.debug()) << "Number of results = " << results.size() << " serialized in "
+                      << std::chrono::duration_cast<std::chrono::microseconds>(end2 - end).count() << " microseconds";
 
     return output;
 }

--- a/src/rpc/handlers/NFTHistory.cpp
+++ b/src/rpc/handlers/NFTHistory.cpp
@@ -86,7 +86,7 @@ NFTHistoryHandler::process(NFTHistoryHandler::Input input, Context const& ctx) c
 
     auto const [txnsAndCursor, timeDiff] = util::timed(
         [&]() { return sharedPtrBackend_->fetchNFTTransactions(tokenID, limit, input.forward, cursor, ctx.yield); });
-    log_.info() << "db fetch took " << timeDiff << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
+    LOG(log_.info()) << "db fetch took " << timeDiff << " milliseconds - num blobs = " << txnsAndCursor.txns.size();
 
     Output response;
     auto const [blobs, retCursor] = txnsAndCursor;
@@ -105,7 +105,7 @@ NFTHistoryHandler::process(NFTHistoryHandler::Input input, Context const& ctx) c
         }
         else if (txnPlusMeta.ledgerSequence > maxIndex && !input.forward)
         {
-            log_.debug() << "Skipping over transactions from incomplete ledger";
+            LOG(log_.debug()) << "Skipping over transactions from incomplete ledger";
             continue;
         }
 

--- a/src/util/config/Config.cpp
+++ b/src/util/config/Config.cpp
@@ -183,7 +183,8 @@ ConfigReader::open(std::filesystem::path path)
     }
     catch (std::exception const& e)
     {
-        util::LogService::error() << "Could not read configuration file from '" << path.string() << "': " << e.what();
+        LOG(util::LogService::error()) << "Could not read configuration file from '" << path.string()
+                                       << "': " << e.what();
     }
 
     return Config{};

--- a/src/util/log/Logger.cpp
+++ b/src/util/log/Logger.cpp
@@ -139,7 +139,7 @@ LogService::init(util::Config const& config)
     }
 
     core->set_filter(min_severity);
-    LogService::info() << "Default log level = " << defaultSeverity;
+    LOG(LogService::info()) << "Default log level = " << defaultSeverity;
 }
 
 Logger::Pump

--- a/src/util/log/Logger.h
+++ b/src/util/log/Logger.h
@@ -89,6 +89,16 @@ using SourceLocationType = SourceLocation;
 #endif
 
 /**
+ * @brief Skips evaluation of expensive argument lists if the given logger is disabled for the required severity level.
+ */
+#define LOG(x) \
+    if (!x)    \
+    {          \
+    }          \
+    else       \
+        x
+
+/**
  * @brief Custom severity levels for @ref util::Logger.
  */
 enum class Severity {
@@ -158,8 +168,7 @@ class Logger final
         operator=(Pump&&) = delete;
 
         /**
-         * @brief Perfectly forwards any incoming data into the underlying
-         * boost::log pump if the pump is available. nop otherwise.
+         * @brief Perfectly forwards any incoming data into the underlying boost::log pump if the pump is available.
          *
          * @tparam T Type of data to pump
          * @param data The data to pump
@@ -172,6 +181,14 @@ class Logger final
             if (pump_)
                 pump_->stream() << std::forward<T>(data);
             return *this;
+        }
+
+        /**
+         * @return true if logger is enabled; false otherwise
+         */
+        operator bool() const
+        {
+            return pump_.has_value();
         }
 
     private:

--- a/src/web/Context.h
+++ b/src/web/Context.h
@@ -76,7 +76,7 @@ struct Context : util::Taggable
         , clientIp(clientIp)
     {
         static util::Logger perfLog{"Performance"};
-        perfLog.debug() << tag() << "new Context created";
+        LOG(perfLog.debug()) << tag() << "new Context created";
     }
 
     Context(Context&&) = default;

--- a/src/web/DOSGuard.h
+++ b/src/web/DOSGuard.h
@@ -129,8 +129,8 @@ public:
                 auto [transferedByte, requests] = ipState_.at(ip);
                 if (transferedByte > maxFetches_ || requests > maxRequestCount_)
                 {
-                    log_.warn() << "Dosguard: Client surpassed the rate limit. ip = " << ip
-                                << " Transfered Byte: " << transferedByte << "; Requests: " << requests;
+                    LOG(log_.warn()) << "Dosguard: Client surpassed the rate limit. ip = " << ip
+                                     << " Transfered Byte: " << transferedByte << "; Requests: " << requests;
                     return false;
                 }
             }
@@ -139,8 +139,8 @@ public:
             {
                 if (it->second > maxConnCount_)
                 {
-                    log_.warn() << "Dosguard: Client surpassed the rate limit. ip = " << ip
-                                << " Concurrent connection: " << it->second;
+                    LOG(log_.warn()) << "Dosguard: Client surpassed the rate limit. ip = " << ip
+                                     << " Concurrent connection: " << it->second;
                     return false;
                 }
             }

--- a/src/web/RPCServerHandler.h
+++ b/src/web/RPCServerHandler.h
@@ -87,7 +87,7 @@ public:
         try
         {
             auto req = boost::json::parse(request).as_object();
-            perfLog_.debug() << connection->tag() << "Adding to work queue";
+            LOG(perfLog_.debug()) << connection->tag() << "Adding to work queue";
 
             if (not connection->upgraded and not req.contains("params"))
                 req["params"] = boost::json::array({boost::json::object{}});
@@ -116,7 +116,7 @@ public:
         }
         catch (std::exception const& ex)
         {
-            perfLog_.error() << connection->tag() << "Caught exception: " << ex.what();
+            LOG(perfLog_.error()) << connection->tag() << "Caught exception: " << ex.what();
             rpcEngine_->notifyInternalError();
             throw;
         }
@@ -144,9 +144,9 @@ private:
         boost::json::object&& request,
         std::shared_ptr<web::ConnectionBase> const& connection)
     {
-        log_.info() << connection->tag() << (connection->upgraded ? "ws" : "http")
-                    << " received request from work queue: " << util::removeSecret(request)
-                    << " ip = " << connection->clientIp;
+        LOG(log_.info()) << connection->tag() << (connection->upgraded ? "ws" : "http")
+                         << " received request from work queue: " << util::removeSecret(request)
+                         << " ip = " << connection->clientIp;
 
         try
         {
@@ -181,8 +181,8 @@ private:
             if (!context)
             {
                 auto const err = context.error();
-                perfLog_.warn() << connection->tag() << "Could not create Web context: " << err;
-                log_.warn() << connection->tag() << "Could not create Web context: " << err;
+                LOG(perfLog_.warn()) << connection->tag() << "Could not create Web context: " << err;
+                LOG(log_.warn()) << connection->tag() << "Could not create Web context: " << err;
 
                 // we count all those as BadSyntax - as the WS path would.
                 // Although over HTTP these will yield a 400 status with a plain text response (for most).
@@ -202,8 +202,8 @@ private:
                 response = web::detail::ErrorHelper(connection, request).composeError(*status);
                 auto const responseStr = boost::json::serialize(response);
 
-                perfLog_.debug() << context->tag() << "Encountered error: " << responseStr;
-                log_.debug() << context->tag() << "Encountered error: " << responseStr;
+                LOG(perfLog_.debug()) << context->tag() << "Encountered error: " << responseStr;
+                LOG(log_.debug()) << context->tag() << "Encountered error: " << responseStr;
             }
             else
             {
@@ -260,8 +260,8 @@ private:
         {
             // note: while we are catching this in buildResponse too, this is here to make sure
             // that any other code that may throw is outside of buildResponse is also worked around.
-            perfLog_.error() << connection->tag() << "Caught exception: " << ex.what();
-            log_.error() << connection->tag() << "Caught exception: " << ex.what();
+            LOG(perfLog_.error()) << connection->tag() << "Caught exception: " << ex.what();
+            LOG(log_.error()) << connection->tag() << "Caught exception: " << ex.what();
 
             rpcEngine_->notifyInternalError();
             return web::detail::ErrorHelper(connection, request).sendInternalError();

--- a/src/web/Server.h
+++ b/src/web/Server.h
@@ -95,7 +95,7 @@ public:
         if (ec == boost::asio::ssl::error::stream_truncated)
             return;
 
-        log_.info() << "Detector failed (" << message << "): " << ec.message();
+        LOG(log_.info()) << "Detector failed (" << message << "): " << ec.message();
     }
 
     /** @brief Initiate the detection. */
@@ -205,7 +205,7 @@ public:
         acceptor_.bind(endpoint, ec);
         if (ec)
         {
-            log_.error() << "Failed to bind to endpoint: " << endpoint << ". message: " << ec.message();
+            LOG(log_.error()) << "Failed to bind to endpoint: " << endpoint << ". message: " << ec.message();
             throw std::runtime_error(
                 fmt::format("Failed to bind to endpoint: {}:{}", endpoint.address().to_string(), endpoint.port()));
         }
@@ -213,7 +213,7 @@ public:
         acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
         if (ec)
         {
-            log_.error() << "Failed to listen at endpoint: " << endpoint << ". message: " << ec.message();
+            LOG(log_.error()) << "Failed to listen at endpoint: " << endpoint << ". message: " << ec.message();
             throw std::runtime_error(
                 fmt::format("Failed to listen at endpoint: {}:{}", endpoint.address().to_string(), endpoint.port()));
         }

--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -121,7 +121,7 @@ protected:
         if (!ec_ && ec != boost::asio::error::operation_aborted)
         {
             ec_ = ec;
-            perfLog_.info() << tag() << ": " << what << ": " << ec.message();
+            LOG(perfLog_.info()) << tag() << ": " << what << ": " << ec.message();
             boost::beast::get_lowest_layer(derived().stream()).socket().close(ec);
         }
     }
@@ -139,13 +139,13 @@ public:
         , dosGuard_(dosGuard)
         , handler_(handler)
     {
-        perfLog_.debug() << tag() << "http session created";
+        LOG(perfLog_.debug()) << tag() << "http session created";
         dosGuard_.get().increment(ip);
     }
 
     virtual ~HttpBase()
     {
-        perfLog_.debug() << tag() << "http session closed";
+        LOG(perfLog_.debug()) << tag() << "http session closed";
         if (not upgraded)
             dosGuard_.get().decrement(this->clientIp);
     }
@@ -204,7 +204,7 @@ public:
                 boost::json::serialize(rpc::makeError(rpc::RippledError::rpcSLOW_DOWN))));
         }
 
-        log_.info() << tag() << "Received request from ip = " << clientIp << " - posting to WorkQueue";
+        LOG(log_.info()) << tag() << "Received request from ip = " << clientIp << " - posting to WorkQueue";
 
         try
         {

--- a/src/web/impl/WsBase.h
+++ b/src/web/impl/WsBase.h
@@ -63,7 +63,7 @@ protected:
         if (!ec_ && ec != boost::asio::error::operation_aborted)
         {
             ec_ = ec;
-            perfLog_.info() << tag() << ": " << what << ": " << ec.message();
+            LOG(perfLog_.info()) << tag() << ": " << what << ": " << ec.message();
             boost::beast::get_lowest_layer(derived().ws()).socket().close(ec);
             (*handler_)(ec, derived().shared_from_this());
         }
@@ -79,12 +79,12 @@ public:
         : ConnectionBase(tagFactory, ip), buffer_(std::move(buffer)), dosGuard_(dosGuard), handler_(handler)
     {
         upgraded = true;
-        perfLog_.debug() << tag() << "session created";
+        LOG(perfLog_.debug()) << tag() << "session created";
     }
 
     virtual ~WsBase()
     {
-        perfLog_.debug() << tag() << "session closed";
+        LOG(perfLog_.debug()) << tag() << "session closed";
         dosGuard_.get().decrement(clientIp);
     }
 
@@ -193,7 +193,7 @@ public:
         if (ec)
             return wsFail(ec, "accept");
 
-        perfLog_.info() << tag() << "accepting new connection";
+        LOG(perfLog_.info()) << tag() << "accepting new connection";
 
         doRead();
     }
@@ -218,7 +218,7 @@ public:
         if (ec)
             return wsFail(ec, "read");
 
-        perfLog_.info() << tag() << "Received request from ip = " << this->clientIp;
+        LOG(perfLog_.info()) << tag() << "Received request from ip = " << this->clientIp;
 
         auto sendError = [this](auto error, std::string&& requestStr) {
             auto e = rpc::makeError(error);

--- a/unittests/LoggerTests.cpp
+++ b/unittests/LoggerTests.cpp
@@ -57,6 +57,23 @@ TEST_F(LoggerTest, Filtering)
     checkEqual("Trace:TRC Trace line logged for 'Trace' component");
 }
 
+TEST_F(LoggerTest, LOGMacro)
+{
+    Logger log{"General"};
+
+    auto computeCalled = false;
+    auto compute = [&computeCalled]() {
+        computeCalled = true;
+        return "computed";
+    };
+
+    LOG(log.trace()) << compute();
+    EXPECT_FALSE(computeCalled);
+
+    log.trace() << compute();
+    EXPECT_TRUE(computeCalled);
+}
+
 TEST_F(NoLoggerTest, Basic)
 {
     Logger log{"Trace"};

--- a/unittests/etl/CacheLoaderTests.cpp
+++ b/unittests/etl/CacheLoaderTests.cpp
@@ -127,7 +127,6 @@ TEST_F(CacheLoaderTest, FromCache)
         .WillByDefault(Return(std::vector<Blob>{keysSize - 1, Blob{'s'}}));
     EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(loops);
 
-    EXPECT_CALL(cache, size).Times(AtLeast(1));
     EXPECT_CALL(cache, update).Times(loops);
     EXPECT_CALL(cache, isFull).Times(1);
 


### PR DESCRIPTION
This is basically copying what JLOG in `rippled` is doing. It's a trick that saves us evaluating potentially expensive argument lists used for logging on levels that we rarely enable on servers (trace and the like). 