### PR TITLE
Fix for empty log lines

### DIFF
--- a/src/util/log/Logger.h
+++ b/src/util/log/Logger.h
@@ -90,13 +90,15 @@ using SourceLocationType = SourceLocation;
 
 /**
  * @brief Skips evaluation of expensive argument lists if the given logger is disabled for the required severity level.
+ *
+ * Note: Currently this introduces potential shadowing (unlikely).
  */
-#define LOG(x) \
-    if (!x)    \
-    {          \
-    }          \
-    else       \
-        x
+#define LOG(x)                                 \
+    if (auto clio_pump__ = x; not clio_pump__) \
+    {                                          \
+    }                                          \
+    else                                       \
+        clio_pump__
 
 /**
  * @brief Custom severity levels for @ref util::Logger.


### PR DESCRIPTION
#823 introduced a problem with an extra empty log line for each time we use LOG. This is because `logger.debug()` and the like return by value and the LOG macro did not take that into account.
There would be a better way to fix this with another proxy object but sadly boost.log does not give us a way to ask whether the filter would pass the given severity for the channel or not.. it only provides a way to try and open a log record which can return an `empty` record which means the log line is going to be discarded.