### PR TITLE
Link libstd++ and gcc lib statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(clio)
 # ========================================================================== #
 #                                   Options                                  #
 # ========================================================================== #
-option (verbose   "Verbose build"                                     FALSE) 
+option (verbose   "Verbose build"                                     FALSE)
 option (tests     "Build tests"                                       FALSE)
 option (docs      "Generate doxygen docs"                             FALSE)
 option (coverage  "Build test coverage report"                        FALSE)
@@ -135,7 +135,8 @@ target_sources (clio PRIVATE
 
 # Clio server
 add_executable (clio_server src/main/Main.cpp)
-target_link_libraries (clio_server PUBLIC clio)
+target_link_libraries (clio_server PRIVATE clio)
+target_link_options(clio_server PRIVATE -static-libgcc -static-libstdc++)
 
 # Unittesting
 if (tests)
@@ -219,7 +220,7 @@ if (tests)
   # See https://github.com/google/googletest/issues/3475
   gtest_discover_tests (clio_tests DISCOVERY_TIMEOUT 10)
 
-  # Fix for dwarf5 bug on ci 
+  # Fix for dwarf5 bug on ci
   target_compile_options (clio PUBLIC -gdwarf-4)
 
   target_compile_definitions (${TEST_TARGET} PUBLIC UNITTEST_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ target_link_libraries (clio_server PRIVATE clio)
 target_link_options(clio_server
   PRIVATE
     $<$<AND:$<NOT:$<BOOL:${APPLE}>>,$<NOT:$<BOOL:${san}>>>:-static-libstdc++ -static-libgcc>
-
+)
 
 # Unittesting
 if (tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,10 @@ target_sources (clio PRIVATE
 # Clio server
 add_executable (clio_server src/main/Main.cpp)
 target_link_libraries (clio_server PRIVATE clio)
-target_link_options(clio_server PRIVATE -static-libgcc -static-libstdc++)
+target_link_options(clio_server
+  PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${APPLE}>>,$<NOT:$<BOOL:${san}>>>:-static-libstdc++ -static-libgcc>
+
 
 # Unittesting
 if (tests)


### PR DESCRIPTION
Clio is built with GCC11 and some libraries won't be present on Ubuntu 20.04 or Debian 11.

Error:
```
./rip/clio_server: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by ./rip/clio_server-stripped)
./rip/clio_server: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by ./rip/clio_server-stripped)
./rip/clio_server: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by ./rip/clio_server-stripped)
```
```

emel@focal:~/dev/clio (develop)$ rm -rf build/clio_server 

emel@focal:~/dev/clio (develop)$ grep -n "libgcc" CMakeLists.txt 
130:#target_link_options(clio_server PRIVATE -static-libgcc -static-libstdc++)

emel@focal:~/dev/clio (develop)$ cmake --build build --parallel $(($(nproc) - 2))
-- Using Conan toolchain: /home/emel/dev/clio/build/build/generators/conan_toolchain.cmake
...
-- Configuring done
-- Generating done
-- Build files have been written to: /home/emel/dev/clio/build
Scanning dependencies of target clio
[  1%] Building CXX object CMakeFiles/clio.dir/src/main/impl/Build.cpp.o
[  3%] Linking CXX static library libclio.a
[ 96%] Built target clio
[ 98%] Linking CXX executable clio_server
[100%] Built target clio_server

emel@focal:~/dev/clio (develop)$ docker run --rm -it -v $PWD/build:/clio ubuntu:20.04 /clio/clio_server --version
/clio/clio_server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /clio/clio_server)
/clio/clio_server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /clio/clio_server)
/clio/clio_server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by /clio/clio_server)

emel@focal:~/dev/clio (develop)$ sed -i '130s/^#//' CMakeLists.txt 

emel@focal:~/dev/clio (develop)$ cmake --build build --parallel $(($(nproc) - 2))
-- Using Conan toolchain: /home/emel/dev/clio/build/build/generators/conan_toolchain.cmake
...
-- Configuring done
-- Generating done
-- Build files have been written to: /home/emel/dev/clio/build
Scanning dependencies of target clio
[  1%] Building CXX object CMakeFiles/clio.dir/src/main/impl/Build.cpp.o
[  3%] Linking CXX static library libclio.a
[ 96%] Built target clio
[ 98%] Linking CXX executable clio_server
[100%] Built target clio_server

emel@focal:~/dev/clio (develop)$ docker run --rm -it -v $PWD/build:/clio ubuntu:20.04 /clio/clio_server --version
clio-20230823231044-develop-d62330f
```

