### PR TITLE
Fix synchronous paths

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,7 @@ class Clio(ConanFile):
         'fmt/10.0.0',
         'grpc/1.50.1',
         'openssl/1.1.1u',
-        'xrpl/1.12.0-b2',
+        'xrpl/1.12.0-rc1',
     ]
 
     default_options = {

--- a/src/data/BackendInterface.cpp
+++ b/src/data/BackendInterface.cpp
@@ -223,12 +223,6 @@ BackendInterface::fetchBookOffers(
 }
 
 std::optional<LedgerRange>
-BackendInterface::hardFetchLedgerRange() const
-{
-    return synchronous([this](auto yield) { return hardFetchLedgerRange(yield); });
-}
-
-std::optional<LedgerRange>
 BackendInterface::fetchLedgerRange() const
 {
     std::shared_lock lck(rngMtx_);

--- a/src/data/cassandra/Concepts.h
+++ b/src/data/cassandra/Concepts.h
@@ -67,8 +67,10 @@ concept SomeExecutionStrategy = requires(
     { a.write(std::move(statements)) } -> std::same_as<void>;
     { a.read(token, prepared) } -> std::same_as<ResultOrError>;
     { a.read(token, statement) } -> std::same_as<ResultOrError>;
+    { a.read(statement) } -> std::same_as<ResultOrError>;
     { a.read(token, statements) } -> std::same_as<ResultOrError>;
     { a.readEach(token, statements) } -> std::same_as<std::vector<Result>>;
+    { a.readEach(statements) } -> std::same_as<std::vector<Result>>;
 };
 // clang-format on
 

--- a/src/data/cassandra/Error.h
+++ b/src/data/cassandra/Error.h
@@ -93,7 +93,7 @@ public:
     {
         if (code_ == CASS_ERROR_LIB_NO_HOSTS_AVAILABLE or code_ == CASS_ERROR_LIB_REQUEST_TIMED_OUT or
             code_ == CASS_ERROR_SERVER_UNAVAILABLE or code_ == CASS_ERROR_SERVER_OVERLOADED or
-            code_ == CASS_ERROR_SERVER_READ_TIMEOUT)
+            code_ == CASS_ERROR_SERVER_READ_TIMEOUT or code_ == CASS_ERROR_SERVER_READ_FAILURE)
             return true;
         return false;
     }

--- a/src/data/cassandra/Error.h
+++ b/src/data/cassandra/Error.h
@@ -93,7 +93,7 @@ public:
     {
         if (code_ == CASS_ERROR_LIB_NO_HOSTS_AVAILABLE or code_ == CASS_ERROR_LIB_REQUEST_TIMED_OUT or
             code_ == CASS_ERROR_SERVER_UNAVAILABLE or code_ == CASS_ERROR_SERVER_OVERLOADED or
-            code_ == CASS_ERROR_SERVER_READ_TIMEOUT or code_ == CASS_ERROR_SERVER_READ_FAILURE)
+            code_ == CASS_ERROR_SERVER_READ_TIMEOUT /* or code_ == CASS_ERROR_SERVER_READ_FAILURE */)
             return true;
         return false;
     }

--- a/src/data/cassandra/Handle.h
+++ b/src/data/cassandra/Handle.h
@@ -55,6 +55,7 @@ public:
     using StatementType = Statement;
     using PreparedStatementType = PreparedStatement;
     using ResultType = Result;
+    using ErrorType = Error;
 
     /**
      * @brief Construct a new handle from a @ref detail::Settings object.

--- a/src/data/cassandra/impl/ExecutionStrategy.h
+++ b/src/data/cassandra/impl/ExecutionStrategy.h
@@ -260,7 +260,7 @@ public:
                         // Note: explicit work below needed on linux/gcc11
                         auto executor = boost::asio::get_associated_executor(*sself);
                         boost::asio::post(
-                            boost::asio::get_associated_executor(*sself),
+                            executor,
                             [sself = std::move(sself),
                              res = std::move(res),
                              _ = boost::asio::make_work_guard(executor)]() mutable {
@@ -398,7 +398,7 @@ public:
         futures.reserve(numOutstanding);
 
         auto init = [this, &statements, &futures, &hadError, &numOutstanding]<typename Self>(Self& self) {
-            auto sself = std::make_shared<Self>(std::move(self));  // TODO: see if we can avoid this
+            auto sself = std::make_shared<Self>(std::move(self));
             auto executionHandler = [&hadError, &numOutstanding, sself = std::move(sself)](auto const& res) mutable {
                 if (not res)
                     hadError = true;

--- a/src/data/cassandra/impl/RetryPolicy.h
+++ b/src/data/cassandra/impl/RetryPolicy.h
@@ -46,7 +46,7 @@ public:
     /**
      * @brief Create a new retry policy instance with the io_context provided
      */
-    ExponentialBackoffRetryPolicy(boost::asio::io_context& ioc) : timer_{boost::asio::make_strand(ioc)}
+    ExponentialBackoffRetryPolicy(boost::asio::io_context& ioc) : timer_{ioc}
     {
     }
 
@@ -75,10 +75,7 @@ public:
     retry(Fn&& fn)
     {
         timer_.expires_after(calculateDelay(attempt_++));
-        timer_.async_wait([fn = std::forward<Fn>(fn)]([[maybe_unused]] const auto& err) {
-            // todo: deal with cancellation (thru err)
-            fn();
-        });
+        timer_.async_wait([fn = std::forward<Fn>(fn)](auto) { fn(); });
     }
 
     /**

--- a/src/etl/Source.cpp
+++ b/src/etl/Source.cpp
@@ -46,7 +46,7 @@ void
 PlainSource::close(bool startAgain)
 {
     timer_.cancel();
-    boost::asio::post(strand_, [this, startAgain]() {
+    boost::asio::post(ioc_.get(), [this, startAgain]() {
         if (closing_)
             return;
 
@@ -64,14 +64,14 @@ PlainSource::close(bool startAgain)
                 closing_ = false;
                 if (startAgain)
                 {
-                    ws_ = std::make_unique<StreamType>(strand_);
+                    ws_ = std::make_unique<StreamType>(boost::asio::make_strand(ioc_.get()));
                     run();
                 }
             });
         }
         else if (startAgain)
         {
-            ws_ = std::make_unique<StreamType>(strand_);
+            ws_ = std::make_unique<StreamType>(boost::asio::make_strand(ioc_.get()));
             run();
         }
     });
@@ -81,7 +81,7 @@ void
 SslSource::close(bool startAgain)
 {
     timer_.cancel();
-    boost::asio::post(strand_, [this, startAgain]() {
+    boost::asio::post(ioc_.get(), [this, startAgain]() {
         if (closing_)
             return;
 
@@ -98,14 +98,14 @@ SslSource::close(bool startAgain)
                 closing_ = false;
                 if (startAgain)
                 {
-                    ws_ = std::make_unique<StreamType>(strand_, *sslCtx_);
+                    ws_ = std::make_unique<StreamType>(boost::asio::make_strand(ioc_.get()), *sslCtx_);
                     run();
                 }
             });
         }
         else if (startAgain)
         {
-            ws_ = std::make_unique<StreamType>(strand_, *sslCtx_);
+            ws_ = std::make_unique<StreamType>(boost::asio::make_strand(ioc_.get()), *sslCtx_);
             run();
         }
     });

--- a/src/feed/SubscriptionManager.cpp
+++ b/src/feed/SubscriptionManager.cpp
@@ -186,6 +186,7 @@ SubscriptionManager::pubTransaction(data::TransactionAndMetadata const& blobs, r
         {
             ripple::STAmount ownerFunds;
             auto fetchFundsSynchronous = [&]() {
+                // TODO: data::synchronous is potentially dangerous, can get stuck sometimes on async_compose
                 data::synchronous([&](boost::asio::yield_context yield) {
                     ownerFunds = rpc::accountFunds(*backend_, lgrInfo.seq, amount, account, yield);
                 });

--- a/unittests/data/cassandra/impl/FakesAndMocks.h
+++ b/unittests/data/cassandra/impl/FakesAndMocks.h
@@ -31,6 +31,10 @@ struct FakeResult
 {
 };
 
+struct FakeError
+{
+};
+
 struct FakeResultOrError
 {
     CassandraError err{"<default>", CASS_OK};
@@ -95,6 +99,7 @@ struct MockHandle
     using StatementType = FakeStatement;
     using PreparedStatementType = FakePreparedStatement;
     using ResultType = FakeResult;
+    using ErrorType = FakeError;
 
     MOCK_METHOD(
         FutureWithCallbackType,

--- a/unittests/etl/CacheLoaderTests.cpp
+++ b/unittests/etl/CacheLoaderTests.cpp
@@ -92,8 +92,8 @@ TEST_F(CacheLoaderTest, FromCache)
     CacheLoader loader{cfg, ctx, mockBackendPtr, cache};
 
     auto const diffs = getLatestDiff();
-    ON_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).WillByDefault(Return(diffs));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff(_, _)).Times(32);
+    ON_CALL(*rawBackendPtr, syncFetchLedgerDiff(_)).WillByDefault(Return(diffs));
+    EXPECT_CALL(*rawBackendPtr, syncFetchLedgerDiff(_)).Times(32);
 
     auto const loops = diffs.size() + 1;
     auto const keysSize = 14;

--- a/unittests/util/MockBackend.h
+++ b/unittests/util/MockBackend.h
@@ -124,6 +124,8 @@ struct MockBackend : public BackendInterface
 
     MOCK_METHOD(std::optional<LedgerRange>, hardFetchLedgerRange, (boost::asio::yield_context), (const, override));
 
+    MOCK_METHOD(std::optional<LedgerRange>, hardFetchLedgerRange, (), (const, override));
+
     MOCK_METHOD(void, writeLedger, (ripple::LedgerInfo const&, std::string&&), (override));
 
     MOCK_METHOD(void, writeLedgerObject, (std::string&&, std::uint32_t const, std::string&&), (override));

--- a/unittests/util/MockBackend.h
+++ b/unittests/util/MockBackend.h
@@ -36,6 +36,8 @@ struct MockBackend : public BackendInterface
         (std::uint32_t const, boost::asio::yield_context),
         (const, override));
 
+    MOCK_METHOD(std::optional<ripple::LedgerInfo>, syncFetchLedgerBySequence, (std::uint32_t const), (const, override));
+
     MOCK_METHOD(
         std::optional<ripple::LedgerInfo>,
         fetchLedgerByHash,
@@ -61,6 +63,12 @@ struct MockBackend : public BackendInterface
         (const, override));
 
     MOCK_METHOD(
+        std::vector<TransactionAndMetadata>,
+        syncFetchTransactions,
+        (std::vector<ripple::uint256> const&),
+        (const, override));
+
+    MOCK_METHOD(
         TransactionsAndCursor,
         fetchAccountTransactions,
         (ripple::AccountID const&,
@@ -77,9 +85,21 @@ struct MockBackend : public BackendInterface
         (const, override));
 
     MOCK_METHOD(
+        std::vector<TransactionAndMetadata>,
+        syncFetchAllTransactionsInLedger,
+        (std::uint32_t const),
+        (const, override));
+
+    MOCK_METHOD(
         std::vector<ripple::uint256>,
         fetchAllTransactionHashesInLedger,
         (std::uint32_t const, boost::asio::yield_context),
+        (const, override));
+
+    MOCK_METHOD(
+        std::vector<ripple::uint256>,
+        syncFetchAllTransactionHashesInLedger,
+        (std::uint32_t const),
         (const, override));
 
     MOCK_METHOD(
@@ -105,9 +125,21 @@ struct MockBackend : public BackendInterface
         (const, override));
 
     MOCK_METHOD(
+        std::vector<Blob>,
+        doSyncFetchLedgerObjects,
+        (std::vector<ripple::uint256> const&, std::uint32_t const),
+        (const, override));
+
+    MOCK_METHOD(
         std::optional<Blob>,
         doFetchLedgerObject,
         (ripple::uint256 const&, std::uint32_t const, boost::asio::yield_context),
+        (const, override));
+
+    MOCK_METHOD(
+        std::optional<Blob>,
+        doSyncFetchLedgerObject,
+        (ripple::uint256 const&, std::uint32_t const),
         (const, override));
 
     MOCK_METHOD(
@@ -115,6 +147,8 @@ struct MockBackend : public BackendInterface
         fetchLedgerDiff,
         (std::uint32_t const, boost::asio::yield_context),
         (const, override));
+
+    MOCK_METHOD(std::vector<LedgerObject>, syncFetchLedgerDiff, (std::uint32_t const), (const, override));
 
     MOCK_METHOD(
         std::optional<ripple::uint256>,


### PR DESCRIPTION
We have the `data::synhronous` function that is used to call coroutine-based code synchronously. 
While it is a nice idea that allows for less code duplication it's both not most efficient and more importantly it seems to be broken since we moved to boost 1.82 (used to work fine with boost 1.75).

A bunch of testing revealed that 
- There appears to be no issue with the `FutureWithCallback` and how we use it with `async_compose` - for each request there is always exactly one callback invocation whether the result is an error or some data from the DB; unless
- When used thru `synchronous`, sometimes `async_compose` will not return and the thread that is using `synchronous` gets stuck entirely

This PR currently adds `sync` versions of some of the coroutine-based functions that were used thru `synchronous`. The change appears to help the situation (have not seen the freezing behaviour yet but this could change when perf testing).