### PR TITLE
Better clangd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *clio*.log
 build*/
 .build
+.cache
 .vscode
 .python-version
 CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option (coverage  "Build test coverage report"                        FALSE)
 option (packaging "Create distribution packages"                      FALSE)
 # ========================================================================== #
 set (san "" CACHE STRING "Add sanitizer instrumentation")
+set (CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set_property (CACHE san PROPERTY STRINGS ";undefined;memory;address;thread")
 # ========================================================================== #
 


### PR DESCRIPTION
Clangd requires file `build/compile_commands.json` to be able to index project and provide features like "Find usages". I added the option to urn on generating the file by `cmake`.
Also clangd creates local `.cache` directory so I made git to ignore it.

Fixed #839 