### PR TITLE
Add log to better debug DB workload

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -654,8 +654,10 @@ traverseOwnedNodes(
     }
     auto end = std::chrono::system_clock::now();
 
-    LOG(gLog.debug()) << "Time loading owned directories: "
-                      << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << " milliseconds";
+    LOG(gLog.debug()) << fmt::format(
+        "Time loading owned directories: {} milliseconds, entries size: {}",
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count(),
+        keys.size());
 
     auto [objects, timeDiff] = util::timed([&]() { return backend.fetchLedgerObjects(keys, sequence, yield); });
 


### PR DESCRIPTION
We may issue lots of db requests through this call. The last week , we observed that even the requests traffic not change much, the db access increased vastly. 
We will change this part for better db throttling in future (but not in 2.0). So this PR adds the number of objects in the log for bettering understanding clio behavior from log.
The log will be like 
"
src/rpc/RPCHelpers.cpp:657 [2023-09-08 15:11:26.352054] RPC:DBG Time loading owned directories: 28361 milliseconds, entries size: 200051
"