### PR TITLE
AccountTx filtering by transaction type

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,7 @@ class Clio(ConanFile):
         'fmt/10.0.0',
         'grpc/1.50.1',
         'openssl/1.1.1u',
-        'xrpl/1.12.0-b2',
+        'xrpl/1.12.0',
     ]
 
     default_options = {

--- a/src/rpc/JS.h
+++ b/src/rpc/JS.h
@@ -19,10 +19,15 @@
 
 #pragma once
 
+#include <util/JsonUtils.h>
+
 #include <ripple/protocol/jss.h>
 
 /** @brief Helper macro for borrowing from ripple::jss static (J)son (S)trings. */
 #define JS(x) ripple::jss::x.c_str()
+
+/** @brief Access the lower case copy of a static (J)son (S)tring. */
+#define JSL(x) util::toLower(JS(x))
 
 /** @brief Provides access to (SF)ield name (S)trings. */
 #define SFS(x) ripple::x.jsonName.c_str()

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -141,6 +141,7 @@ accountFromStringStrict(std::string const& account)
     else
         return {};
 }
+
 std::pair<std::shared_ptr<ripple::STTx const>, std::shared_ptr<ripple::STObject const>>
 deserializeTxPlusMeta(data::TransactionAndMetadata const& blobs)
 {

--- a/src/rpc/common/Modifiers.h
+++ b/src/rpc/common/Modifiers.h
@@ -22,6 +22,9 @@
 #include <rpc/common/Concepts.h>
 #include <rpc/common/Specs.h>
 #include <rpc/common/Types.h>
+#include <util/JsonUtils.h>
+
+#include <string_view>
 
 namespace rpc::modifiers {
 
@@ -64,6 +67,39 @@ public:
         auto const oldValue = value_to<Type>(value.as_object().at(key.data()));
         value.as_object()[key.data()] = std::clamp<Type>(oldValue, min_, max_);
 
+        return {};
+    }
+};
+
+/**
+ * @brief Convert input string to lower case.
+ *
+ * Note: the conversion is only performed if the input value is a string.
+ */
+struct ToLower final
+{
+    /**
+     * @brief Construct the modifier.
+     */
+    explicit ToLower() = default;
+
+    /**
+     * @brief Update the input string to lower case.
+     *
+     * @param value The JSON value representing the outer object
+     * @param key The key used to retrieve the modified value from the outer object
+     * @return Possibly an error
+     */
+    [[nodiscard]] MaybeError
+    modify(boost::json::value& value, std::string_view key) const
+    {
+        if (not value.is_object() or not value.as_object().contains(key.data()))
+            return {};  // ignore. field does not exist, let 'required' fail instead
+
+        if (not value.as_object().at(key.data()).is_string())
+            return {};  // ignore for non-string types
+
+        value.as_object()[key.data()] = util::toLower(value.as_object().at(key.data()).as_string().c_str());
         return {};
     }
 };

--- a/src/rpc/common/Modifiers.h
+++ b/src/rpc/common/Modifiers.h
@@ -79,11 +79,6 @@ public:
 struct ToLower final
 {
     /**
-     * @brief Construct the modifier.
-     */
-    explicit ToLower() = default;
-
-    /**
      * @brief Update the input string to lower case.
      *
      * @param value The JSON value representing the outer object

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -21,6 +21,7 @@
 
 namespace rpc {
 
+// found here : https://xrpl.org/ledger_entry.html#:~:text=valid%20fields%20are%3A-,index,-account_root
 std::unordered_map<std::string, ripple::LedgerEntryType> const AccountObjectsHandler::TYPESMAP{
     {"state", ripple::ltRIPPLE_STATE},
     {"ticket", ripple::ltTICKET},

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -155,8 +155,10 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
             obj[JS(tx)] = std::move(txn);
 
             auto objTransactionType = obj[JS(tx)].as_object()[JS(TransactionType)];
+            auto it = TYPESMAP.find(objTransactionType.as_string());
+
             // if transactionType does not match
-            if (input.transactionType.has_value() &&
+            if (input.transactionType.has_value() && it != TYPESMAP.end() &&
                 AccountTxHandler::TYPESMAP.at(objTransactionType.as_string()) != input.transactionType.value())
                 continue;
 

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -24,12 +24,14 @@
 namespace rpc {
 
 // found here : https://xrpl.org/transaction-types.html
+// TODO [https://github.com/XRPLF/clio/issues/856]: add AMMBid, AMMCreate, AMMDelete, AMMDeposit, AMMVote, AMMWithdraw
 std::unordered_map<std::string, ripple::TxType> const AccountTxHandler::TYPESMAP{
     {JSL(AccountSet), ripple::ttACCOUNT_SET},
     {JSL(AccountDelete), ripple::ttACCOUNT_DELETE},
     {JSL(CheckCancel), ripple::ttCHECK_CANCEL},
     {JSL(CheckCash), ripple::ttCHECK_CASH},
     {JSL(CheckCreate), ripple::ttCHECK_CREATE},
+    {JSL(Clawback), ripple::ttCLAWBACK},
     {JSL(DepositPreauth), ripple::ttDEPOSIT_PREAUTH},
     {JSL(EscrowCancel), ripple::ttESCROW_CANCEL},
     {JSL(EscrowCreate), ripple::ttESCROW_CREATE},

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -154,11 +154,11 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
             obj[JS(meta)] = std::move(meta);
             obj[JS(tx)] = std::move(txn);
 
-            auto objTransactionType = obj[JS(tx)].as_object()[JS(TransactionType)];
-            auto it = TYPESMAP.find(objTransactionType.as_string());
+            const auto objTransactionType = obj[JS(tx)].as_object()[JS(TransactionType)];
 
             // if transactionType does not match
-            if (input.transactionType.has_value() && it != TYPESMAP.end() &&
+            if (input.transactionType.has_value() &&
+                AccountTxHandler::TYPESMAP.contains(objTransactionType.as_string()) &&
                 AccountTxHandler::TYPESMAP.at(objTransactionType.as_string()) != input.transactionType.value())
                 continue;
 

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -24,31 +24,40 @@ namespace rpc {
 
 // found here : https://xrpl.org/transaction-types.html
 std::unordered_map<std::string_view, ripple::TxType> const AccountTxHandler::TYPESMAP{
-    {"AccountSet", ripple::ttACCOUNT_SET},
-    {"AccountDelete", ripple::ttACCOUNT_DELETE},
-    {"CheckCancel", ripple::ttCHECK_CANCEL},
-    {"CheckCash", ripple::ttCHECK_CASH},
-    {"CheckCreate", ripple::ttCHECK_CREATE},
-    {"DepositPreauth", ripple::ttDEPOSIT_PREAUTH},
-    {"EscrowCancel", ripple::ttESCROW_CANCEL},
-    {"EscrowCreate", ripple::ttESCROW_CREATE},
-    {"EscrowFinish", ripple::ttESCROW_FINISH},
-    {"NFTokenAcceptOffer", ripple::ttNFTOKEN_ACCEPT_OFFER},
-    {"NFTokenBurn", ripple::ttNFTOKEN_BURN},
-    {"NFTokenCancelOffer", ripple::ttNFTOKEN_CANCEL_OFFER},
-    {"NFTokenCreateOffer", ripple::ttNFTOKEN_CREATE_OFFER},
-    {"NFTokenMint", ripple::ttNFTOKEN_MINT},
-    {"OfferCancel", ripple::ttOFFER_CANCEL},
-    {"OfferCreate", ripple::ttOFFER_CREATE},
-    {"Payment", ripple::ttPAYMENT},
-    {"PaymentChannelClaim", ripple::ttPAYCHAN_CLAIM},
-    {"PaymentChannelCreate", ripple::ttCHECK_CREATE},
-    {"PaymentChannelFund", ripple::ttPAYCHAN_FUND},
-    {"SetRegularKey", ripple::ttREGULAR_KEY_SET},
-    {"SignerListSet", ripple::ttSIGNER_LIST_SET},
-    {"TicketCreate", ripple::ttTICKET_CREATE},
-    {"TrustSet", ripple::ttTRUST_SET},
+    {JS(AccountSet), ripple::ttACCOUNT_SET},
+    {JS(AccountDelete), ripple::ttACCOUNT_DELETE},
+    {JS(CheckCancel), ripple::ttCHECK_CANCEL},
+    {JS(CheckCash), ripple::ttCHECK_CASH},
+    {JS(CheckCreate), ripple::ttCHECK_CREATE},
+    {JS(DepositPreauth), ripple::ttDEPOSIT_PREAUTH},
+    {JS(EscrowCancel), ripple::ttESCROW_CANCEL},
+    {JS(EscrowCreate), ripple::ttESCROW_CREATE},
+    {JS(EscrowFinish), ripple::ttESCROW_FINISH},
+    {JS(NFTokenAcceptOffer), ripple::ttNFTOKEN_ACCEPT_OFFER},
+    {JS(NFTokenBurn), ripple::ttNFTOKEN_BURN},
+    {JS(NFTokenCancelOffer), ripple::ttNFTOKEN_CANCEL_OFFER},
+    {JS(NFTokenCreateOffer), ripple::ttNFTOKEN_CREATE_OFFER},
+    {JS(NFTokenMint), ripple::ttNFTOKEN_MINT},
+    {JS(OfferCancel), ripple::ttOFFER_CANCEL},
+    {JS(OfferCreate), ripple::ttOFFER_CREATE},
+    {JS(Payment), ripple::ttPAYMENT},
+    {JS(PaymentChannelClaim), ripple::ttPAYCHAN_CLAIM},
+    {JS(PaymentChannelCreate), ripple::ttCHECK_CREATE},
+    {JS(PaymentChannelFund), ripple::ttPAYCHAN_FUND},
+    {JS(SetRegularKey), ripple::ttREGULAR_KEY_SET},
+    {JS(SignerListSet), ripple::ttSIGNER_LIST_SET},
+    {JS(TicketCreate), ripple::ttTICKET_CREATE},
+    {JS(TrustSet), ripple::ttTRUST_SET},
 };
+
+// TODO: should be std::views::keys when clang supports it
+std::unordered_set<std::string_view> const AccountTxHandler::TYPES_KEYS = [] {
+    std::unordered_set<std::string_view> keys;
+    std::transform(TYPESMAP.begin(), TYPESMAP.end(), std::inserter(keys, keys.begin()), [](auto const& pair) {
+        return pair.first;
+    });
+    return keys;
+}();
 
 // TODO: this is currently very similar to nft_history but its own copy for time
 // being. we should aim to reuse common logic in some way in the future.

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -41,6 +41,8 @@ class AccountTxHandler
 
     static std::unordered_map<std::string_view, ripple::TxType> const TYPESMAP;
 
+    static const std::unordered_set<std::string_view> TYPES_KEYS;
+
 public:
     // no max limit
     static auto constexpr LIMIT_MIN = 1;
@@ -113,33 +115,12 @@ public:
                  {JS(seq), validation::Required{}, validation::Type<uint32_t>{}},
              }},
             {JS(TransactionType),
-             validation::Type<std::string>{},
-             validation::OneOf<std::string>{
-                 "AccountSet",
-                 "AccountDelete",
-                 "CheckCancel",
-                 "CheckCash",
-                 "CheckCreate",
-                 "DepositPreauth",
-                 "EscrowCancel",
-                 "EscrowCreate",
-                 "EscrowFinish",
-                 "NFTokenAcceptOffer",
-                 "NFTokenBurn",
-                 "NFTokenCancelOffer",
-                 "NFTokenCreateOffer",
-                 "NFTokenMint",
-                 "OfferCancel",
-                 "OfferCreate",
-                 "Payment",
-                 "PaymentChannelClaim",
-                 "PaymentChannelCreate",
-                 "PaymentChannelFund",
-                 "SetRegularKey",
-                 "SignerListSet",
-                 "TicketCreate",
-                 "TrustSet",
-             }},
+             meta::WithCustomError{
+                 validation::Type<std::string>{},
+                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}},
+             meta::WithCustomError{
+                 validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend()),
+                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type'."}}},
         };
 
         return rpcSpec;

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -39,8 +39,8 @@ class AccountTxHandler
     util::Logger log_{"RPC"};
     std::shared_ptr<BackendInterface> sharedPtrBackend_;
 
-    static std::unordered_map<std::string_view, ripple::TxType> const TYPESMAP;
-    static const std::unordered_set<std::string_view> TYPES_KEYS;
+    static std::unordered_map<std::string, ripple::TxType> const TYPESMAP;
+    static const std::unordered_set<std::string> TYPES_KEYS;
 
 public:
     // no max limit
@@ -114,8 +114,9 @@ public:
                  {JS(seq), validation::Required{}, validation::Type<uint32_t>{}},
              }},
             {
-                JS(TransactionType),
+                "tx_type",
                 validation::Type<std::string>{},
+                modifiers::ToLower{},
                 validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend()),
             },
         };

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -39,6 +39,8 @@ class AccountTxHandler
     util::Logger log_{"RPC"};
     std::shared_ptr<BackendInterface> sharedPtrBackend_;
 
+    static std::unordered_map<std::string_view, ripple::TxType> const TYPESMAP;
+
 public:
     // no max limit
     static auto constexpr LIMIT_MIN = 1;
@@ -77,6 +79,7 @@ public:
         bool forward = false;
         std::optional<uint32_t> limit;
         std::optional<Marker> marker;
+        std::optional<ripple::TxType> transactionType;
     };
 
     using Result = HandlerReturnType<Output>;
@@ -108,6 +111,34 @@ public:
              meta::Section{
                  {JS(ledger), validation::Required{}, validation::Type<uint32_t>{}},
                  {JS(seq), validation::Required{}, validation::Type<uint32_t>{}},
+             }},
+            {JS(TransactionType),
+             validation::Type<std::string>{},
+             validation::OneOf<std::string>{
+                 "AccountSet",
+                 "AccountDelete",
+                 "CheckCancel",
+                 "CheckCash",
+                 "CheckCreate",
+                 "DepositPreauth",
+                 "EscrowCancel",
+                 "EscrowCreate",
+                 "EscrowFinish",
+                 "NFTokenAcceptOffer",
+                 "NFTokenBurn",
+                 "NFTokenCancelOffer",
+                 "NFTokenCreateOffer",
+                 "NFTokenMint",
+                 "OfferCancel",
+                 "OfferCreate",
+                 "Payment",
+                 "PaymentChannelClaim",
+                 "PaymentChannelCreate",
+                 "PaymentChannelFund",
+                 "SetRegularKey",
+                 "SignerListSet",
+                 "TicketCreate",
+                 "TrustSet",
              }},
         };
 

--- a/src/rpc/handlers/AccountTx.h
+++ b/src/rpc/handlers/AccountTx.h
@@ -40,7 +40,6 @@ class AccountTxHandler
     std::shared_ptr<BackendInterface> sharedPtrBackend_;
 
     static std::unordered_map<std::string_view, ripple::TxType> const TYPESMAP;
-
     static const std::unordered_set<std::string_view> TYPES_KEYS;
 
 public:
@@ -114,13 +113,11 @@ public:
                  {JS(ledger), validation::Required{}, validation::Type<uint32_t>{}},
                  {JS(seq), validation::Required{}, validation::Type<uint32_t>{}},
              }},
-            {JS(TransactionType),
-             meta::WithCustomError{
-                 validation::Type<std::string>{},
-                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}},
-             meta::WithCustomError{
-                 validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend()),
-                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type'."}}},
+            {
+                JS(TransactionType),
+                validation::Type<std::string>{},
+                validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend()),
+            },
         };
 
         return rpcSpec;

--- a/src/util/JsonUtils.h
+++ b/src/util/JsonUtils.h
@@ -21,12 +21,21 @@
 
 #include <boost/json.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 
 /**
  * @brief This namespace contains various utilities.
  */
 namespace util {
+
+inline std::string
+toLower(std::string str)
+{
+    std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return std::tolower(c); });
+    return str;
+}
 
 /**
  * @brief Removes any detected secret information from a response JSON object.

--- a/unittests/rpc/BaseTests.cpp
+++ b/unittests/rpc/BaseTests.cpp
@@ -568,3 +568,25 @@ TEST_F(RPCBaseTest, ClampingModifier)
     ASSERT_TRUE(spec.process(passingInput3));
     ASSERT_EQ(passingInput3.at("amount").as_uint64(), 20u);  // clamped
 }
+
+TEST_F(RPCBaseTest, ToLowerModifier)
+{
+    auto spec = RpcSpec{
+        {"str", ToLower{}},
+    };
+
+    auto passingInput = json::parse(R"({ "str": "TesT" })");
+    ASSERT_TRUE(spec.process(passingInput));
+    ASSERT_EQ(passingInput.at("str").as_string(), "test");
+
+    auto passingInput2 = json::parse(R"({ "str2": "TesT" })");
+    ASSERT_TRUE(spec.process(passingInput2));  // no str no problem
+
+    auto passingInput3 = json::parse(R"({ "str": "already lower case" })");
+    ASSERT_TRUE(spec.process(passingInput3));
+    ASSERT_EQ(passingInput3.at("str").as_string(), "already lower case");
+
+    auto passingInput4 = json::parse(R"({ "str": "" })");
+    ASSERT_TRUE(spec.process(passingInput4));  // empty str no problem
+    ASSERT_EQ(passingInput4.at("str").as_string(), "");
+}

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -324,7 +324,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ - 1);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
         EXPECT_FALSE(output->as_object().contains("limit"));
     });
@@ -365,7 +365,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ + 1);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ - 1);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
         EXPECT_FALSE(output->as_object().contains("limit"));
     });
@@ -406,7 +406,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
         EXPECT_FALSE(output->as_object().contains("limit"));
     });
@@ -447,7 +447,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
         EXPECT_FALSE(output->as_object().contains("limit"));
     });
@@ -488,7 +488,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
         EXPECT_EQ(output->at("account").as_string(), ACCOUNT);
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
         EXPECT_EQ(
             output->at("transactions").as_array()[0].as_object().at("meta").as_string(),
@@ -540,7 +540,7 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
         EXPECT_EQ(output->at("ledger_index_min").as_uint64(), MINSEQ);
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
         EXPECT_EQ(output->at("limit").as_uint64(), 2);
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
         EXPECT_EQ(output->at("transactions").as_array().size(), 2);
     });
 }
@@ -803,7 +803,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ - 2);
         EXPECT_EQ(output->at("transactions").as_array().size(), 1);
         EXPECT_FALSE(output->as_object().contains("limit"));
-        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger":12,"seq":34})"));
+        EXPECT_EQ(output->at("marker").as_object(), json::parse(R"({"ledger": 12, "seq": 34})"));
     });
 }
 
@@ -909,8 +909,8 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs)
                                         "date": 2
                                     },
                                     "validated": true
-                                    },
-                                    {
+                                },
+                                {
                                     "meta": 
                                     {
                                         "AffectedNodes": 
@@ -1064,7 +1064,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "AccountSet"
+                "tx_type": "AccountSet"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1072,7 +1072,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "AccountDelete"
+                "tx_type": "AccountDelete"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1080,7 +1080,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "CheckCancel"
+                "tx_type": "CheckCancel"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1088,7 +1088,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "CheckCash"
+                "tx_type": "CheckCash"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1096,7 +1096,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "CheckCreate"
+                "tx_type": "CheckCreate"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1104,7 +1104,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "DepositPreauth"
+                "tx_type": "DepositPreauth"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1112,7 +1112,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "EscrowCancel"
+                "tx_type": "EscrowCancel"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1120,7 +1120,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "EscrowCreate"
+                "tx_type": "EscrowCreate"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1128,7 +1128,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "EscrowFinish"
+                "tx_type": "EscrowFinish"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1136,7 +1136,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "NFTokenAcceptOffer"
+                "tx_type": "NFTokenAcceptOffer"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1144,7 +1144,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "NFTokenBurn"
+                "tx_type": "NFTokenBurn"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1152,7 +1152,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "NFTokenCancelOffer"
+                "tx_type": "NFTokenCancelOffer"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1160,7 +1160,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "NFTokenCreateOffer"
+                "tx_type": "NFTokenCreateOffer"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1168,7 +1168,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "NFTokenMint"
+                "tx_type": "NFTokenMint"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1176,7 +1176,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "OfferCancel"
+                "tx_type": "OfferCancel"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1184,7 +1184,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "OfferCreate"
+                "tx_type": "OfferCreate"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1192,7 +1192,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "Payment"
+                "tx_type": "Payment"
             })",
             R"([
                 {
@@ -1240,7 +1240,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "PaymentChannelClaim"
+                "tx_type": "PaymentChannelClaim"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1248,7 +1248,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "PaymentChannelCreate"
+                "tx_type": "PaymentChannelCreate"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1256,7 +1256,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "PaymentChannelFund"
+                "tx_type": "PaymentChannelFund"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1264,7 +1264,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "SetRegularKey"
+                "tx_type": "SetRegularKey"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1272,7 +1272,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "SignerListSet"
+                "tx_type": "SignerListSet"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1280,7 +1280,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "TicketCreate"
+                "tx_type": "TicketCreate"
             })",
             "[]"},
         AccountTxTransactionBundle{
@@ -1288,7 +1288,7 @@ generateTransactionTypeTestValues()
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
-                "TransactionType": "TrustSet"
+                "tx_type": "TrustSet"
             })",
             "[]"},
     };

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -1100,6 +1100,14 @@ generateTransactionTypeTestValues()
             })",
             "[]"},
         AccountTxTransactionBundle{
+            "Clawback",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "tx_type": "Clawback"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
             "DepositPreauth",
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -1334,7 +1334,7 @@ TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
 
         auto transactions = output->at("transactions").as_array();
         // parse to json object
-        boost::json::value jsonObject = boost::json::parse(testBundle.result);
+        json::value jsonObject = json::parse(testBundle.result);
 
         EXPECT_EQ(jsonObject, transactions);
     });

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -1197,7 +1197,7 @@ generateTransactionTypeTestValues()
             R"([
                 {
                 "meta": {
-                "AffectedNodes": [
+                    "AffectedNodes": [
                     {
                         "ModifiedNode": {
                             "FinalFields": {
@@ -1215,27 +1215,26 @@ generateTransactionTypeTestValues()
                             },
                             "LedgerEntryType": "AccountRoot"
                         }
-                    }
-                    ],
-                "TransactionIndex": 0,
-                "TransactionResult": "tesSUCCESS",
-                "delivered_amount": "unavailable"
-            },
-            "tx": {
-                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                "Amount": "1",
-                "Destination": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
-                "Fee": "1",
-                "Sequence": 32,
-                "SigningPubKey": "74657374",
-                "TransactionType": "Payment",
-                "hash": "51D2AAA6B8E4E16EF22F6424854283D8391B56875858A711B8CE4D5B9A422CC2",
-                "ledger_index": 30,
-                "date": 1
-            },
-            "validated": true
-            }
-        ])"},
+                    }],
+                    "TransactionIndex": 0,
+                    "TransactionResult": "tesSUCCESS",
+                    "delivered_amount": "unavailable"
+                },
+                "tx": {
+                    "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                    "Amount": "1",
+                    "Destination": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+                    "Fee": "1",
+                    "Sequence": 32,
+                    "SigningPubKey": "74657374",
+                    "TransactionType": "Payment",
+                    "hash": "51D2AAA6B8E4E16EF22F6424854283D8391B56875858A711B8CE4D5B9A422CC2",
+                    "ledger_index": 30,
+                    "date": 1
+                },
+                "validated": true
+                }
+            ])"},
         AccountTxTransactionBundle{
             "PaymentChannelClaim",
             R"({
@@ -1311,18 +1310,11 @@ TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
-        fetchAccountTransactions(
-            testing::_,
-            testing::_,
-            false,
-            testing::Optional(testing::Eq(TransactionsCursor{MAXSEQ, INT32_MAX})),
-            testing::_))
+        *rawBackendPtr, fetchAccountTransactions(_, _, false, Optional(Eq(TransactionsCursor{MAXSEQ, INT32_MAX})), _))
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-
     ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
 
     auto const testBundle = GetParam();
@@ -1330,12 +1322,10 @@ TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
-        ASSERT_TRUE(output);
+        EXPECT_TRUE(output);
 
-        auto transactions = output->at("transactions").as_array();
-        // parse to json object
-        json::value jsonObject = json::parse(testBundle.result);
-
+        auto const transactions = output->at("transactions").as_array();
+        auto const jsonObject = json::parse(testBundle.result);
         EXPECT_EQ(jsonObject, transactions);
     });
 }

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -311,7 +311,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": true
@@ -352,7 +352,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": false
@@ -393,7 +393,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": true
@@ -434,7 +434,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": false
@@ -475,7 +475,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "binary": true
@@ -524,7 +524,7 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "limit": 2,
@@ -572,8 +572,8 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
-                "ledger_index":{}
+                "account": "{}",
+                "ledger_index": {}
             }})",
             ACCOUNT,
             MAXSEQ - 1));
@@ -601,8 +601,8 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
-                "ledger_index":{}
+                "account": "{}",
+                "ledger_index": {}
             }})",
             ACCOUNT,
             MAXSEQ - 1));
@@ -627,8 +627,8 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
-                "ledger_index":"{}"
+                "account": "{}",
+                "ledger_index": "{}"
             }})",
             ACCOUNT,
             MAXSEQ - 1));
@@ -667,8 +667,8 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
-                "ledger_hash":"{}"
+                "account": "{}",
+                "ledger_hash": "{}"
             }})",
             ACCOUNT,
             LEDGERHASH));
@@ -710,8 +710,8 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
-                "ledger_index":"validated"
+                "account": "{}",
+                "ledger_index": "validated"
             }})",
             ACCOUNT));
         auto const output = handler.process(input, Context{yield});
@@ -721,61 +721,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
         EXPECT_EQ(output->at("ledger_index_max").as_uint64(), MAXSEQ);
         EXPECT_FALSE(output->as_object().contains("limit"));
         EXPECT_FALSE(output->as_object().contains("marker"));
-        EXPECT_EQ(output->at("transactions").as_array().size(), 1);
-    });
-}
-
-TEST_F(RPCAccountTxHandlerTest, SpecificTransactionType)
-{
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
-    // adjust the order for forward->false
-    auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
-    auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
-    EXPECT_CALL(
-        *rawBackendPtr,
-        fetchAccountTransactions(
-            testing::_,
-            testing::_,
-            false,
-            testing::Optional(testing::Eq(TransactionsCursor{MAXSEQ, INT32_MAX})),
-            testing::_))
-        .Times(2);
-
-    auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(2);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
-
-    runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
-        auto const static input = boost::json::parse(fmt::format(
-            R"({{
-                "account":"{}",
-                "ledger_index":"validated",
-                "TransactionType": "EscrowCancel"
-            }})",
-            ACCOUNT));
-        auto const output = handler.process(input, Context{yield});
-        ASSERT_TRUE(output);
-        // The result should be transaction of type payment,
-        // however, EscrowCancel was specified, so it is filtered out.
-        EXPECT_EQ(output->at("transactions").as_array().size(), 0);
-    });
-
-    runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
-        auto const static input = boost::json::parse(fmt::format(
-            R"({{
-                "account":"{}",
-                "ledger_index":"validated",
-                "TransactionType": "Payment"
-            }})",
-            ACCOUNT));
-        auto const output = handler.process(input, Context{yield});
-        ASSERT_TRUE(output);
-        // Not filtered out in this case
         EXPECT_EQ(output->at("transactions").as_array().size(), 1);
     });
 }
@@ -802,7 +747,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": false
@@ -843,7 +788,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
         auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
         auto const static input = json::parse(fmt::format(
             R"({{
-                "account":"{}",
+                "account": "{}",
                 "ledger_index_min": {},
                 "ledger_index_max": {},
                 "forward": false
@@ -1084,5 +1029,313 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs)
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
+    });
+}
+
+struct AccountTxTransactionBundle
+{
+    std::string testName;
+    std::string testJson;
+    std::string result;
+};
+
+// parameterized test cases for parameters check
+struct AccountTxTransactionTypeTest : public RPCAccountTxHandlerTest,
+                                      public WithParamInterface<AccountTxTransactionBundle>
+{
+    struct NameGenerator
+    {
+        template <class ParamType>
+        std::string
+        operator()(const testing::TestParamInfo<ParamType>& info) const
+        {
+            auto bundle = static_cast<AccountTxTransactionBundle>(info.param);
+            return bundle.testName;
+        }
+    };
+};
+
+static auto
+generateTransactionTypeTestValues()
+{
+    return std::vector<AccountTxTransactionBundle>{
+        AccountTxTransactionBundle{
+            "AccountSet",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "AccountSet"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "AccountDelete",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "AccountDelete"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "CheckCancel",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "CheckCancel"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "CheckCash",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "CheckCash"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "CheckCreate",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "CheckCreate"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "DepositPreauth",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "DepositPreauth"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "EscrowCancel",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "EscrowCancel"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "EscrowCreate",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "EscrowCreate"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "EscrowFinish",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "EscrowFinish"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "NFTokenAcceptOffer",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "NFTokenAcceptOffer"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "NFTokenBurn",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "NFTokenBurn"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "NFTokenCancelOffer",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "NFTokenCancelOffer"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "NFTokenCreateOffer",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "NFTokenCreateOffer"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "NFTokenMint",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "NFTokenMint"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "OfferCancel",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "OfferCancel"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "OfferCreate",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "OfferCreate"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "Payment",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "Payment"
+            })",
+            R"([
+                {
+                "meta": {
+                "AffectedNodes": [
+                    {
+                        "ModifiedNode": {
+                            "FinalFields": {
+                                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                "Balance": "22"
+                            },
+                            "LedgerEntryType": "AccountRoot"
+                        }
+                    },
+                    {
+                        "ModifiedNode": {
+                            "FinalFields": {
+                                "Account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+                                "Balance": "23"
+                            },
+                            "LedgerEntryType": "AccountRoot"
+                        }
+                    }
+                    ],
+                "TransactionIndex": 0,
+                "TransactionResult": "tesSUCCESS",
+                "delivered_amount": "unavailable"
+            },
+            "tx": {
+                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "Amount": "1",
+                "Destination": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+                "Fee": "1",
+                "Sequence": 32,
+                "SigningPubKey": "74657374",
+                "TransactionType": "Payment",
+                "hash": "51D2AAA6B8E4E16EF22F6424854283D8391B56875858A711B8CE4D5B9A422CC2",
+                "ledger_index": 30,
+                "date": 1
+            },
+            "validated": true
+            }
+        ])"},
+        AccountTxTransactionBundle{
+            "PaymentChannelClaim",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "PaymentChannelClaim"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "PaymentChannelCreate",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "PaymentChannelCreate"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "PaymentChannelFund",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "PaymentChannelFund"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "SetRegularKey",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "SetRegularKey"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "SignerListSet",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "SignerListSet"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "TicketCreate",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "TicketCreate"
+            })",
+            "[]"},
+        AccountTxTransactionBundle{
+            "TrustSet",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "TransactionType": "TrustSet"
+            })",
+            "[]"},
+    };
+}
+
+INSTANTIATE_TEST_CASE_P(
+    RPCAccountTxTransactionTypeTest,
+    AccountTxTransactionTypeTest,
+    ValuesIn(generateTransactionTypeTestValues()),
+    AccountTxTransactionTypeTest::NameGenerator{});
+
+TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
+{
+    mockBackendPtr->updateRange(MINSEQ);  // min
+    mockBackendPtr->updateRange(MAXSEQ);  // max
+    MockBackend* rawBackendPtr = static_cast<MockBackend*>(mockBackendPtr.get());
+
+    auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
+    auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
+    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    EXPECT_CALL(
+        *rawBackendPtr,
+        fetchAccountTransactions(
+            testing::_,
+            testing::_,
+            false,
+            testing::Optional(testing::Eq(TransactionsCursor{MAXSEQ, INT32_MAX})),
+            testing::_))
+        .Times(1);
+
+    auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
+    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+
+    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
+
+    auto const testBundle = GetParam();
+    runSpawn([&, this](auto yield) {
+        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const req = json::parse(testBundle.testJson);
+        auto const output = handler.process(req, Context{yield});
+        ASSERT_TRUE(output);
+
+        auto transactions = output->at("transactions").as_array();
+        // parse to json object
+        boost::json::value jsonObject = boost::json::parse(testBundle.result);
+
+        EXPECT_EQ(jsonObject, transactions);
     });
 }


### PR DESCRIPTION
Implements #685 

Original PR by @PeterChen13579: https://github.com/XRPLF/clio/pull/826

This PR adds on top of that
- Change request field name used to `tx_type`
- Introduces ToLower util and RPC field modifier
- Matches `tx_type` without case-sensitivity