### PR TITLE
Remove deprecated cassandra options

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -19,7 +19,7 @@
             "core_connections_per_host": 1 // Defaults to 1
             //
             // Below options will use defaults from cassandra driver if left unspecified.
-            // See https://docs.datastax.com/en/developer/cpp-driver/2.0/api/struct.CassCluster/ for details.
+            // See https://docs.datastax.com/en/developer/cpp-driver/2.17/api/struct.CassCluster/ for details.
             // 
             // "queue_size_io": 2
             //

--- a/example-config.json
+++ b/example-config.json
@@ -16,21 +16,12 @@
             //
             // Advanced options. USE AT OWN RISK:
             // ---
-            "max_connections_per_host": 1, // Defaults to 2
-            "core_connections_per_host": 1, // Defaults to 2
-            "max_concurrent_requests_threshold": 55000 // Defaults to ((max_read + max_write) / core_connections_per_host)
+            "core_connections_per_host": 1 // Defaults to 1
             //
             // Below options will use defaults from cassandra driver if left unspecified.
             // See https://docs.datastax.com/en/developer/cpp-driver/2.0/api/struct.CassCluster/ for details.
             // 
-            // "queue_size_event": 1,
-            // "queue_size_io": 2,
-            // "write_bytes_high_water_mark": 3,
-            // "write_bytes_low_water_mark": 4,
-            // "pending_requests_high_water_mark": 5,
-            // "pending_requests_low_water_mark": 6,
-            // "max_requests_per_flush": 7,
-            // "max_concurrent_creation": 8
+            // "queue_size_io": 2
             //
             // ---
         }

--- a/src/data/cassandra/SettingsProvider.cpp
+++ b/src/data/cassandra/SettingsProvider.cpp
@@ -116,22 +116,10 @@ SettingsProvider::parseSettings() const
         config_.valueOr<uint32_t>("max_write_requests_outstanding", settings.maxWriteRequestsOutstanding);
     settings.maxReadRequestsOutstanding =
         config_.valueOr<uint32_t>("max_read_requests_outstanding", settings.maxReadRequestsOutstanding);
-    settings.maxConnectionsPerHost =
-        config_.valueOr<uint32_t>("max_connections_per_host", settings.maxConnectionsPerHost);
     settings.coreConnectionsPerHost =
         config_.valueOr<uint32_t>("core_connections_per_host", settings.coreConnectionsPerHost);
-    settings.maxConcurrentRequestsThreshold = config_.valueOr<uint32_t>(
-        "max_concurrent_requests_threshold",
-        (settings.maxReadRequestsOutstanding + settings.maxWriteRequestsOutstanding) / settings.coreConnectionsPerHost);
 
     settings.queueSizeIO = config_.maybeValue<uint32_t>("queue_size_io");
-    settings.queueSizeEvent = config_.maybeValue<uint32_t>("queue_size_event");
-    settings.writeBytesHighWatermark = config_.maybeValue<uint32_t>("write_bytes_high_water_mark");
-    settings.writeBytesLowWatermark = config_.maybeValue<uint32_t>("write_bytes_low_water_mark");
-    settings.pendingRequestsHighWatermark = config_.maybeValue<uint32_t>("pending_requests_high_water_mark");
-    settings.pendingRequestsLowWatermark = config_.maybeValue<uint32_t>("pending_requests_low_water_mark");
-    settings.maxRequestsPerFlush = config_.maybeValue<uint32_t>("max_requests_per_flush");
-    settings.maxConcurrentCreation = config_.maybeValue<uint32_t>("max_concurrent_creation");
 
     auto const connectTimeoutSecond = config_.maybeValue<uint32_t>("connect_timeout");
     if (connectTimeoutSecond)

--- a/src/data/cassandra/impl/Cluster.h
+++ b/src/data/cassandra/impl/Cluster.h
@@ -73,44 +73,16 @@ struct Settings
     uint32_t threads = std::thread::hardware_concurrency();
 
     /** @brief The maximum number of outstanding write requests at any given moment */
-    uint32_t maxWriteRequestsOutstanding = 10'000;
+    uint32_t maxWriteRequestsOutstanding = 10'000u;
 
     /** @brief The maximum number of outstanding read requests at any given moment */
-    uint32_t maxReadRequestsOutstanding = 100'000;
-
-    /** @brief The maximum number of connections per host */
-    uint32_t maxConnectionsPerHost = 2u;
+    uint32_t maxReadRequestsOutstanding = 100'000u;
 
     /** @brief The number of connection per host to always have active */
-    uint32_t coreConnectionsPerHost = 2u;
-
-    /** @brief The maximum concurrent requests per connection; new connections will be created when reached */
-    uint32_t maxConcurrentRequestsThreshold =
-        (maxWriteRequestsOutstanding + maxReadRequestsOutstanding) / coreConnectionsPerHost;
-
-    /** @brief Size of the event queue */
-    std::optional<uint32_t> queueSizeEvent;
+    uint32_t coreConnectionsPerHost = 1u;
 
     /** @brief Size of the IO queue */
     std::optional<uint32_t> queueSizeIO;
-
-    /** @brief High watermark for bytes written */
-    std::optional<uint32_t> writeBytesHighWatermark;
-
-    /** @brief Low watermark for bytes written */
-    std::optional<uint32_t> writeBytesLowWatermark;
-
-    /** @brief High watermark for pending requests */
-    std::optional<uint32_t> pendingRequestsHighWatermark;
-
-    /** @brief Low watermark for pending requests */
-    std::optional<uint32_t> pendingRequestsLowWatermark;
-
-    /** @brief Maximum number of requests per flush */
-    std::optional<uint32_t> maxRequestsPerFlush;
-
-    /** @brief Maximum number of connections that will be created concurrently */
-    std::optional<uint32_t> maxConcurrentCreation;
 
     /** @brief SSL certificate */
     std::optional<std::string> certificate;  // ssl context

--- a/unittests/data/cassandra/SettingsProviderTests.cpp
+++ b/unittests/data/cassandra/SettingsProviderTests.cpp
@@ -53,7 +53,7 @@ TEST_F(SettingsProviderTest, Defaults)
     EXPECT_EQ(settings.requestTimeout, std::chrono::milliseconds{0});
     EXPECT_EQ(settings.maxWriteRequestsOutstanding, 10'000);
     EXPECT_EQ(settings.maxReadRequestsOutstanding, 100'000);
-    EXPECT_EQ(settings.coreConnectionsPerHost, 2);
+    EXPECT_EQ(settings.coreConnectionsPerHost, 1);
     EXPECT_EQ(settings.certificate, std::nullopt);
     EXPECT_EQ(settings.username, std::nullopt);
     EXPECT_EQ(settings.password, std::nullopt);

--- a/unittests/data/cassandra/SettingsProviderTests.cpp
+++ b/unittests/data/cassandra/SettingsProviderTests.cpp
@@ -53,20 +53,11 @@ TEST_F(SettingsProviderTest, Defaults)
     EXPECT_EQ(settings.requestTimeout, std::chrono::milliseconds{0});
     EXPECT_EQ(settings.maxWriteRequestsOutstanding, 10'000);
     EXPECT_EQ(settings.maxReadRequestsOutstanding, 100'000);
-    EXPECT_EQ(settings.maxConnectionsPerHost, 2);
     EXPECT_EQ(settings.coreConnectionsPerHost, 2);
-    EXPECT_EQ(settings.maxConcurrentRequestsThreshold, (100'000 + 10'000) / 2);
     EXPECT_EQ(settings.certificate, std::nullopt);
     EXPECT_EQ(settings.username, std::nullopt);
     EXPECT_EQ(settings.password, std::nullopt);
     EXPECT_EQ(settings.queueSizeIO, std::nullopt);
-    EXPECT_EQ(settings.queueSizeEvent, std::nullopt);
-    EXPECT_EQ(settings.writeBytesHighWatermark, std::nullopt);
-    EXPECT_EQ(settings.writeBytesLowWatermark, std::nullopt);
-    EXPECT_EQ(settings.pendingRequestsHighWatermark, std::nullopt);
-    EXPECT_EQ(settings.pendingRequestsLowWatermark, std::nullopt);
-    EXPECT_EQ(settings.maxRequestsPerFlush, std::nullopt);
-    EXPECT_EQ(settings.maxConcurrentCreation, std::nullopt);
 
     auto const* cp = std::get_if<Settings::ContactPoints>(&settings.connectionInfo);
     ASSERT_TRUE(cp != nullptr);
@@ -103,69 +94,16 @@ TEST_F(SettingsProviderTest, SimpleConfig)
     EXPECT_EQ(provider.getTablePrefix(), "prefix");
 }
 
-TEST_F(SettingsProviderTest, DriverOptionCalculation)
-{
-    Config cfg{json::parse(R"({
-        "contact_points": "123.123.123.123",
-        "max_write_requests_outstanding": 100,
-        "max_read_requests_outstanding": 200
-    })")};
-    SettingsProvider provider{cfg};
-
-    auto const settings = provider.getSettings();
-    EXPECT_EQ(settings.maxReadRequestsOutstanding, 200);
-    EXPECT_EQ(settings.maxWriteRequestsOutstanding, 100);
-
-    EXPECT_EQ(settings.maxConnectionsPerHost, 2);
-    EXPECT_EQ(settings.coreConnectionsPerHost, 2);
-    EXPECT_EQ(settings.maxConcurrentRequestsThreshold, 150);  // calculated from above
-}
-
-TEST_F(SettingsProviderTest, DriverOptionSecifiedMaxConcurrentRequestsThreshold)
-{
-    Config cfg{json::parse(R"({
-        "contact_points": "123.123.123.123",
-        "max_write_requests_outstanding": 100,
-        "max_read_requests_outstanding": 200,
-        "max_connections_per_host": 5,
-        "core_connections_per_host": 4,
-        "max_concurrent_requests_threshold": 1234
-    })")};
-    SettingsProvider provider{cfg};
-
-    auto const settings = provider.getSettings();
-    EXPECT_EQ(settings.maxReadRequestsOutstanding, 200);
-    EXPECT_EQ(settings.maxWriteRequestsOutstanding, 100);
-
-    EXPECT_EQ(settings.maxConnectionsPerHost, 5);
-    EXPECT_EQ(settings.coreConnectionsPerHost, 4);
-    EXPECT_EQ(settings.maxConcurrentRequestsThreshold, 1234);
-}
-
 TEST_F(SettingsProviderTest, DriverOptionalOptionsSpecified)
 {
     Config cfg{json::parse(R"({
         "contact_points": "123.123.123.123",
-        "queue_size_event": 1,
-        "queue_size_io": 2,
-        "write_bytes_high_water_mark": 3,
-        "write_bytes_low_water_mark": 4,
-        "pending_requests_high_water_mark": 5,
-        "pending_requests_low_water_mark": 6,
-        "max_requests_per_flush": 7,
-        "max_concurrent_creation": 8
+        "queue_size_io": 2
     })")};
     SettingsProvider provider{cfg};
 
     auto const settings = provider.getSettings();
-    EXPECT_EQ(settings.queueSizeEvent, 1);
     EXPECT_EQ(settings.queueSizeIO, 2);
-    EXPECT_EQ(settings.writeBytesHighWatermark, 3);
-    EXPECT_EQ(settings.writeBytesLowWatermark, 4);
-    EXPECT_EQ(settings.pendingRequestsHighWatermark, 5);
-    EXPECT_EQ(settings.pendingRequestsLowWatermark, 6);
-    EXPECT_EQ(settings.maxRequestsPerFlush, 7);
-    EXPECT_EQ(settings.maxConcurrentCreation, 8);
 }
 
 TEST_F(SettingsProviderTest, SecureBundleConfig)


### PR DESCRIPTION
Unfortunately all the options we added for testing turned out to be deprecated. Removing them so that this does not make it to 2.0 release.