### PR TITLE
Fix coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if (tests)
   # Generate `clio_tests-ccov` if coverage is enabled
   # Note: use `make clio_tests-ccov` to generate report
   if (coverage)
+    target_compile_definitions(${TEST_TARGET} PRIVATE COVERAGE_ENABLED)
     include (CMake/Coverage.cmake)
     add_coverage (${TEST_TARGET})
   endif ()

--- a/src/util/log/Logger.h
+++ b/src/util/log/Logger.h
@@ -93,12 +93,16 @@ using SourceLocationType = SourceLocation;
  *
  * Note: Currently this introduces potential shadowing (unlikely).
  */
+#ifndef COVERAGE_ENABLED
 #define LOG(x)                                 \
     if (auto clio_pump__ = x; not clio_pump__) \
     {                                          \
     }                                          \
     else                                       \
         clio_pump__
+#else
+#define LOG(x) x
+#endif
 
 /**
  * @brief Custom severity levels for @ref util::Logger.

--- a/unittests/LoggerTests.cpp
+++ b/unittests/LoggerTests.cpp
@@ -57,6 +57,7 @@ TEST_F(LoggerTest, Filtering)
     checkEqual("Trace:TRC Trace line logged for 'Trace' component");
 }
 
+#ifndef COVERAGE_ENABLED
 TEST_F(LoggerTest, LOGMacro)
 {
     Logger log{"General"};
@@ -73,6 +74,7 @@ TEST_F(LoggerTest, LOGMacro)
     log.trace() << compute();
     EXPECT_TRUE(computeCalled);
 }
+#endif
 
 TEST_F(NoLoggerTest, Basic)
 {


### PR DESCRIPTION
This PR is for fixing https://github.com/XRPLF/clio/issues/845 
 LOG macro causes the coverage result being inaccurate. Even the code is tested fully, but it will still skip the log in the unittest.
I think for unittest, we'd better also cover the evaluation part. 
In this PR, I define different implementation for LOG according to COVERAGE_ENABLED. That will require to disable one unittest.
Let us discuss here, welcome new idea 🤙 