### PR TITLE
Duplicate signer_lists in account_info

### DIFF
--- a/.github/actions/linux_build/build.sh
+++ b/.github/actions/linux_build/build.sh
@@ -15,6 +15,6 @@ cmake --build build_rippled --target xrpl_core --parallel $(($(nproc) - 2))
 cd ..
 
 conan export external/cassandra
-conan install . -if build_clio -of build_clio --build missing --build protobuf --build grpc --settings build_type=Release -o tests=True
+conan install . -if build_clio -of build_clio --build missing --settings build_type=Release -o tests=True
 cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -B build_clio
 cmake --build build_clio --parallel $(($(nproc) - 2))

--- a/.github/actions/linux_build/build.sh
+++ b/.github/actions/linux_build/build.sh
@@ -15,6 +15,6 @@ cmake --build build_rippled --target xrpl_core --parallel $(($(nproc) - 2))
 cd ..
 
 conan export external/cassandra
-conan install . -if build_clio -of build_clio --build missing --settings build_type=Release -o tests=True
+conan install . -if build_clio -of build_clio --build missing --build protobuf --settings build_type=Release -o tests=True
 cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -B build_clio
 cmake --build build_clio --parallel $(($(nproc) - 2))

--- a/.github/actions/linux_build/build.sh
+++ b/.github/actions/linux_build/build.sh
@@ -15,6 +15,6 @@ cmake --build build_rippled --target xrpl_core --parallel $(($(nproc) - 2))
 cd ..
 
 conan export external/cassandra
-conan install . -if build_clio -of build_clio --build missing --build protobuf --settings build_type=Release -o tests=True
+conan install . -if build_clio -of build_clio --build missing --build protobuf --build grpc --settings build_type=Release -o tests=True
 cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -B build_clio
 cmake --build build_clio --parallel $(($(nproc) - 2))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     continue-on-error: true
     runs-on: [self-hosted, Linux]
     container:
-      image: conanio/gcc11:1.60.2
+      image: thejohnfreeman/rippled-build-ubuntu:12e19cd9034b
       options: --user root
     steps:
       - name: Get Clio
@@ -94,22 +94,22 @@ jobs:
     needs: build_mac
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: clio_tests_mac
-    - name: Run clio_tests
-      run: |
-        chmod +x ./clio_tests
-        ./clio_tests --gtest_filter="-BackendCassandraBaseTest*:BackendCassandraTest*:BackendCassandraFactoryTestWithDB*"
+      - uses: actions/download-artifact@v3
+        with:
+          name: clio_tests_mac
+      - name: Run clio_tests
+        run: |
+          chmod +x ./clio_tests
+          ./clio_tests --gtest_filter="-BackendCassandraBaseTest*:BackendCassandraTest*:BackendCassandraFactoryTestWithDB*"
 
   test_linux:
     needs: build_linux
     runs-on: [self-hosted, x-heavy]
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: clio_tests_linux
-    - name: Run clio_tests
-      run: |
-        chmod +x ./clio_tests
-        ./clio_tests --gtest_filter="-BackendCassandraBaseTest*:BackendCassandraTest*:BackendCassandraFactoryTestWithDB*"
+      - uses: actions/download-artifact@v3
+        with:
+          name: clio_tests_linux
+      - name: Run clio_tests
+        run: |
+          chmod +x ./clio_tests
+          ./clio_tests --gtest_filter="-BackendCassandraBaseTest*:BackendCassandraTest*:BackendCassandraFactoryTestWithDB*"

--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -128,8 +128,7 @@ tag_invoke(boost::json::value_from_tag, boost::json::value& jv, AccountInfoHandl
     for (auto const& lsf : lsFlags)
         acctFlags[lsf.first.data()] = output.accountData.isFlag(lsf.second);
 
-    // wait for conan integration-> jss::account_flags
-    jv.as_object()["account_flags"] = std::move(acctFlags);
+    jv.as_object()[JS(account_flags)] = std::move(acctFlags);
 
     if (output.signerLists)
     {
@@ -140,7 +139,11 @@ tag_invoke(boost::json::value_from_tag, boost::json::value& jv, AccountInfoHandl
             std::back_inserter(signers),
             [](auto const& signerList) { return toJson(signerList); });
         // version 2 puts the signer_lists out of the account_data
-        jv.as_object()[JS(signer_lists)] = std::move(signers);
+        jv.as_object()[JS(signer_lists)] = signers;
+        // this is a temporary fix to support the clients that still expect v1 api(the signer_lists under
+        // account_data)
+        // TODO: we need to deprecate the duplicate later
+        jv.as_object()[JS(account_data)].as_object()[JS(signer_lists)] = std::move(signers);
     }
 }
 

--- a/unittests/rpc/handlers/AccountInfoTests.cpp
+++ b/unittests/rpc/handlers/AccountInfoTests.cpp
@@ -289,7 +289,8 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrue)
 {
     auto const expectedOutput = fmt::format(
         R"({{
-            "account_data": {{
+            "account_data": 
+            {{
                 "Account": "{}",
                 "Balance": "200",
                 "Flags": 0,
@@ -299,9 +300,8 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrue)
                 "PreviousTxnLgrSeq": 2,
                 "Sequence": 2,
                 "TransferRate": 0,
-                "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
-            }},
-            "signer_lists":
+                "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+                "signer_lists":
                 [
                     {{
                         "Flags": 0,
@@ -330,8 +330,40 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrue)
                         "SignerQuorum": 2,
                         "index": "A9C28A28B85CD533217F5C0A0C7767666B093FA58A0F2D80026FCC4CD932DDC7"
                     }}
-                ],
-            "account_flags": {{
+                ]
+            }},
+            "signer_lists":
+            [
+                {{
+                    "Flags": 0,
+                    "LedgerEntryType": "SignerList",
+                    "OwnerNode": "0",
+                    "PreviousTxnID": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "PreviousTxnLgrSeq": 0,
+                    "SignerEntries":
+                    [
+                        {{
+                            "SignerEntry":
+                            {{
+                                "Account": "{}",
+                                "SignerWeight": 1
+                            }}
+                        }},
+                        {{
+                            "SignerEntry":
+                            {{
+                                "Account": "{}",
+                                "SignerWeight": 1
+                            }}
+                        }}
+                    ],
+                    "SignerListID": 0,
+                    "SignerQuorum": 2,
+                    "index": "A9C28A28B85CD533217F5C0A0C7767666B093FA58A0F2D80026FCC4CD932DDC7"
+                }}
+            ],
+            "account_flags": 
+            {{
                 "defaultRipple": false,
                 "depositAuth": false,
                 "disableMasterKey": false,
@@ -348,6 +380,8 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrue)
         }})",
         ACCOUNT,
         INDEX1,
+        ACCOUNT1,
+        ACCOUNT2,
         ACCOUNT1,
         ACCOUNT2,
         LEDGERHASH);


### PR DESCRIPTION
For API version 1, account_info has "signer_lists" under "account_data" field.
For API version 2, account_info has "signer_list" under root.
 
Clio supports API version v2 by default. [PR](https://github.com/XRPLF/clio/pull/747/files), in addition, [document](https://xrpl.org/account_info.html) also mentions "signer_lists" should be the same level as "account_data". 
 However, some clients still expect the v1 format response. To avoid breaking these clients, Clio now applies a temporary fix to duplicate the signer_lists field.

Next, we shall update the document to highlight this change and deprecate the duplicate.
After the fix , the response will be like:

```
{
    "result": {
        "account_data": {
            "Account": "rQw55Up4ioBLY1i4s8xPAqgvNmTJa7QUV4",
            "Balance": "39999980",
            "Flags": 0,
            "index": "81D2F48A068B62B934CF674A7036BCFD267D26A6768C8AD8B3DDE3E7840FE70B",
            "LedgerEntryType": "AccountRoot",
            "OwnerCount": 1,
            "PreviousTxnID": "E6147B64CB6496BB8AE6C5BB98A762EB56A319D3F8D8E03DBF3F2B60D1F2D64C",
            "PreviousTxnLgrSeq": 163952,
            "Sequence": 163950,
            "signer_lists": [
                {
                    "Flags": 65536,
                    "index": "83D457BA12936FD9135FD25458536541F3E3C7C802CD9028FD9BE4E817D619E1",
                    "LedgerEntryType": "SignerList",
                    "OwnerNode": "0",
                    "PreviousTxnID": "E6147B64CB6496BB8AE6C5BB98A762EB56A319D3F8D8E03DBF3F2B60D1F2D64C",
                    "PreviousTxnLgrSeq": 163952,
                    "SignerEntries": [
                        {
                            "SignerEntry": {
                                "Account": "rNdAMnpLovAxS14gw6za5GbbEFNmexXonm",
                                "SignerWeight": 2
                            }
                        }
                    ],
                    "SignerListID": 0,
                    "SignerQuorum": 2
                }
            ]
        },
        "account_flags": {
            "allowTrustLineClawback": false,
            "defaultRipple": false,
            "depositAuth": false,
            "disableMasterKey": false,
            "disallowIncomingCheck": false,
            "disallowIncomingNFTokenOffer": false,
            "disallowIncomingPayChan": false,
            "disallowIncomingTrustline": false,
            "disallowIncomingXRP": false,
            "globalFreeze": false,
            "noFreeze": false,
            "passwordSpent": false,
            "requireAuthorization": false,
            "requireDestinationTag": false
        },
        "ledger_hash": "900A061E3A59B37B652FDE52FE828FB98DE16F840AF08EC61A6FD003624AA037",
        "ledger_index": 163995,
        "signer_lists": [
            {
                "Flags": 65536,
                "index": "83D457BA12936FD9135FD25458536541F3E3C7C802CD9028FD9BE4E817D619E1",
                "LedgerEntryType": "SignerList",
                "OwnerNode": "0",
                "PreviousTxnID": "E6147B64CB6496BB8AE6C5BB98A762EB56A319D3F8D8E03DBF3F2B60D1F2D64C",
                "PreviousTxnLgrSeq": 163952,
                "SignerEntries": [
                    {
                        "SignerEntry": {
                            "Account": "rNdAMnpLovAxS14gw6za5GbbEFNmexXonm",
                            "SignerWeight": 2
                        }
                    }
                ],
                "SignerListID": 0,
                "SignerQuorum": 2
            }
        ],
        "status": "success",
        "validated": true
    },
    "warnings": [
        {
            "id": 2001,
            "message": "This is a clio server. clio only serves validated data. If you want to talk to rippled, include 'ledger_index':'current' in your request"
        }
```
