### PR TITLE
Fix account_tx response both both ledger range and ledger index/hash are specified

### DIFF
--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -109,8 +109,9 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
             return Error{Status{RippledError::rpcINVALID_PARAMS, "containsLedgerSpecifierAndRange"}};
         }
         else if (!input.ledgerIndexMax && !input.ledgerIndexMin)
-        {  // mimic rippled, when both range and index specified, respect the range.
-           // take ledger from ledgerHash or ledgerIndex only when range is not specified
+        {
+            // mimic rippled, when both range and index specified, respect the range.
+            // take ledger from ledgerHash or ledgerIndex only when range is not specified
             auto const lgrInfoOrStatus = getLedgerInfoFromHashOrSeq(
                 *sharedPtrBackend_, ctx.yield, input.ledgerHash, input.ledgerIndex, range->maxSequence);
 

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -200,9 +200,6 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
             obj[JS(meta)] = ripple::strHex(txnPlusMeta.metadata);
             obj[JS(tx_blob)] = ripple::strHex(txnPlusMeta.transaction);
             obj[JS(ledger_index)] = txnPlusMeta.ledgerSequence;
-
-            if (ctx.apiVersion < 2u)
-                obj[JS(inLedger)] = txnPlusMeta.ledgerSequence;
         }
 
         obj[JS(validated)] = true;

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -105,15 +105,20 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
     if (input.ledgerHash || input.ledgerIndex || input.usingValidatedLedger)
     {
         if (ctx.apiVersion > 1u && (input.ledgerIndexMax || input.ledgerIndexMin))
+        {
             return Error{Status{RippledError::rpcINVALID_PARAMS, "containsLedgerSpecifierAndRange"}};
+        }
+        else if (!input.ledgerIndexMax && !input.ledgerIndexMin)
+        {  // mimic rippled, when both range and index specified, respect the range.
+           // take ledger from ledgerHash or ledgerIndex only when range is not specified
+            auto const lgrInfoOrStatus = getLedgerInfoFromHashOrSeq(
+                *sharedPtrBackend_, ctx.yield, input.ledgerHash, input.ledgerIndex, range->maxSequence);
 
-        auto const lgrInfoOrStatus = getLedgerInfoFromHashOrSeq(
-            *sharedPtrBackend_, ctx.yield, input.ledgerHash, input.ledgerIndex, range->maxSequence);
+            if (auto status = std::get_if<Status>(&lgrInfoOrStatus))
+                return Error{*status};
 
-        if (auto status = std::get_if<Status>(&lgrInfoOrStatus))
-            return Error{*status};
-
-        maxIndex = minIndex = std::get<ripple::LedgerHeader>(lgrInfoOrStatus).seq;
+            maxIndex = minIndex = std::get<ripple::LedgerHeader>(lgrInfoOrStatus).seq;
+        }
     }
 
     std::optional<data::TransactionsCursor> cursor;

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -371,14 +371,6 @@ TEST_P(AccountTxParameterTest, CheckParams)
     }
     else
     {
-        if (req.as_object().contains("ledger_hash"))
-        {
-            EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).WillOnce(testing::Return(ripple::LedgerHeader{}));
-        }
-        else if (req.as_object().contains("ledger_index"))
-        {
-            EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(testing::Return(ripple::LedgerHeader{}));
-        }
         EXPECT_CALL(*rawBackendPtr, fetchAccountTransactions);
 
         runSpawn([&, this](auto yield) {

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -652,7 +652,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
             "144B4E9C06F24296074F7BC48F92A97916C6DC5EA98314D31252CF902EF8DD8451"
             "243869B38667CBD89DF3");
         EXPECT_FALSE(output->at("transactions").as_array()[0].as_object().contains("date"));
-
+        EXPECT_FALSE(output->at("transactions").as_array()[0].as_object().contains("inLedger"));
         EXPECT_FALSE(output->as_object().contains("limit"));
     });
 }


### PR DESCRIPTION
1 For the request which specifies both ledger range and ledger index/hash, itself is an invalid request.
V2 will return error for it.
We mimic rippled's behavior to take the range instead of the ledger index/hash.

2 Remove account_tx inLedger field when binary is true

