### PR TITLE
Fix dosguard max_connection

### DIFF
--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -195,10 +195,8 @@ public:
                 upgraded = true;
                 return derived().upgrade();
             }
-            else
-            {
-                httpFail(boost::asio::error::connection_refused, "too many requests");
-            }
+
+            return httpFail(boost::asio::error::connection_refused, "too many requests");
         }
 
         if (req_.method() != http::verb::post)

--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -187,11 +187,18 @@ public:
 
         if (boost::beast::websocket::is_upgrade(req_))
         {
-            // Disable the timeout. The websocket::stream uses its own timeout settings.
-            boost::beast::get_lowest_layer(derived().stream()).expires_never();
+            if (dosGuard_.get().isOk(this->clientIp))
+            {
+                // Disable the timeout. The websocket::stream uses its own timeout settings.
+                boost::beast::get_lowest_layer(derived().stream()).expires_never();
 
-            upgraded = true;
-            return derived().upgrade();
+                upgraded = true;
+                return derived().upgrade();
+            }
+            else
+            {
+                httpFail(boost::asio::error::connection_refused, "too many requests");
+            }
         }
 
         if (req_.method() != http::verb::post)

--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -196,7 +196,7 @@ public:
                 return derived().upgrade();
             }
 
-            return httpFail(boost::asio::error::connection_refused, "too many requests");
+            return sender_(httpResponse(http::status::too_many_requests, "text/html", "Too many requests"));
         }
 
         if (req_.method() != http::verb::post)

--- a/src/web/impl/WsBase.h
+++ b/src/web/impl/WsBase.h
@@ -60,10 +60,10 @@ protected:
     void
     wsFail(boost::beast::error_code ec, char const* what)
     {
+        LOG(perfLog_.error()) << tag() << ": " << what << ": " << ec.message();
         if (!ec_ && ec != boost::asio::error::operation_aborted)
         {
             ec_ = ec;
-            LOG(perfLog_.error()) << tag() << ": " << what << ": " << ec.message();
             boost::beast::get_lowest_layer(derived().ws()).socket().close(ec);
             (*handler_)(ec, derived().shared_from_this());
         }

--- a/unittests/web/ServerTests.cpp
+++ b/unittests/web/ServerTests.cpp
@@ -361,6 +361,31 @@ TEST_F(WebServerTest, WsPayloadOverload)
         R"({"payload":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","warning":"load","warnings":[{"id":2003,"message":"You are about to be rate limited"}]})");
 }
 
+TEST_F(WebServerTest, WsTooManyConnection)
+{
+    auto e = std::make_shared<EchoExecutor>();
+    auto server = makeServerSync(cfg, ctx, std::nullopt, dosGuardOverload, e);
+    // max connection is 2, exception should happen when the third connection is made
+    WebSocketSyncClient wsClient1;
+    wsClient1.connect("localhost", "8888");
+    WebSocketSyncClient wsClient2;
+    wsClient2.connect("localhost", "8888");
+    bool exceptionThrown = false;
+    try
+    {
+        WebSocketSyncClient wsClient3;
+        wsClient3.connect("localhost", "8888");
+    }
+    catch (boost::system::system_error const& ex)
+    {
+        exceptionThrown = true;
+        EXPECT_EQ(ex.code(), boost::beast::http::error::end_of_stream);
+    }
+    wsClient1.disconnect();
+    wsClient2.disconnect();
+    EXPECT_TRUE(exceptionThrown);
+}
+
 static auto constexpr JSONServerConfigWithAdminPassword = R"JSON(
     {
         "server":{

--- a/unittests/web/ServerTests.cpp
+++ b/unittests/web/ServerTests.cpp
@@ -379,7 +379,7 @@ TEST_F(WebServerTest, WsTooManyConnection)
     catch (boost::system::system_error const& ex)
     {
         exceptionThrown = true;
-        EXPECT_EQ(ex.code(), boost::beast::http::error::end_of_stream);
+        EXPECT_EQ(ex.code(), boost::beast::websocket::error::upgrade_declined);
     }
     wsClient1.disconnect();
     wsClient2.disconnect();


### PR DESCRIPTION
We found some ip issued too many concurrent connections from log. To fix the potential port exhaustion
```
2023-10-10 00:06:34.311641 (src/web/DOSGuard.h:144) [0x00007f864b98b100] RPC:WRN Dosguard: Client surpassed the rate limit. ip = 18.100.136.76 Concurrent connection: 761
2023-10-10 00:06:34.326178 (src/web/DOSGuard.h:144) [0x00007f864b98b100] RPC:WRN Dosguard: Client surpassed the rate limit. ip = 18.100.136.76 Concurrent connection: 760
2023-10-10 00:06:34.348356 (src/web/DOSGuard.h:144) [0x00007f85f7ff7700] RPC:WRN Dosguard: Client surpassed the rate limit. ip = 18.100.136.76 Concurrent connection: 761
```
This PR will prevent the connection building if the current connections of one IP is over DosGuard setting.

Before the PR:
The ws connection can be built, but request will be rejected.

After the PR:
The ws connection can not be built.
The python client will receive error if over limit:
![Screenshot 2023-10-13 at 09 19 16](https://github.com/XRPLF/clio/assets/120398799/09784d4c-eaff-4c00-af4c-edb555bd3649)
The web client will receive error if over limit:
![Screenshot 2023-10-13 at 09 15 57](https://github.com/XRPLF/clio/assets/120398799/6e42176b-bc63-4c65-a783-d5dab2851dc3)
