### PR TITLE
Add config to run without valid etl 

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -26,6 +26,7 @@
             // ---
         }
     },
+    "allow_no_etl": false, // Allow Clio to run without valid ETL source, otherwise Clio will stop if ETL check fails
     "etl_sources": [
         {
             "ip": "127.0.0.1",

--- a/src/etl/ETLService.h
+++ b/src/etl/ETLService.h
@@ -208,6 +208,7 @@ public:
 
     /**
      * @brief Get the etl nodes' state
+     * @return the etl nodes' state, nullopt if etl nodes are not connected
      */
     std::optional<etl::ETLState>
     getETLState() const noexcept

--- a/src/etl/ETLService.h
+++ b/src/etl/ETLService.h
@@ -209,7 +209,7 @@ public:
     /**
      * @brief Get the etl nodes' state
      */
-    etl::ETLState
+    std::optional<etl::ETLState>
     getETLState() const noexcept
     {
         return loadBalancer_->getETLState();

--- a/src/etl/ETLState.cpp
+++ b/src/etl/ETLState.cpp
@@ -17,25 +17,10 @@
 */
 //==============================================================================
 
-#include <data/BackendInterface.h>
 #include <etl/ETLState.h>
-#include <etl/Source.h>
 #include <rpc/JS.h>
 
 namespace etl {
-
-ETLState
-ETLState::fetchETLStateFromSource(Source const& source) noexcept
-{
-    auto const serverInfoRippled = data::synchronous([&source](auto yield) {
-        return source.forwardToRippled({{"command", "server_info"}}, std::nullopt, yield);
-    });
-
-    if (serverInfoRippled)
-        return boost::json::value_to<ETLState>(boost::json::value(*serverInfoRippled));
-
-    return ETLState{};
-}
 
 ETLState
 tag_invoke(boost::json::value_to_tag<ETLState>, boost::json::value const& jv)

--- a/src/etl/ETLState.h
+++ b/src/etl/ETLState.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
+#include <data/BackendInterface.h>
+
 #include <boost/json.hpp>
 
 #include <cstdint>
 #include <optional>
 
 namespace etl {
-
-class Source;
 
 /**
  * @brief This class is responsible for fetching and storing the state of the ETL information, such as the network id
@@ -36,9 +36,22 @@ struct ETLState {
 
     /**
      * @brief Fetch the ETL state from the rippled server
+     * @param source The source to fetch the state from
+     * @return The ETL state, nullopt if source not available
      */
-    static ETLState
-    fetchETLStateFromSource(Source const& source) noexcept;
+    template <typename Forward>
+    static std::optional<ETLState>
+    fetchETLStateFromSource(Forward const& source) noexcept
+    {
+        auto const serverInfoRippled = data::synchronous([&source](auto yield) {
+            return source.forwardToRippled({{"command", "server_info"}}, std::nullopt, yield);
+        });
+
+        if (serverInfoRippled)
+            return boost::json::value_to<ETLState>(boost::json::value(*serverInfoRippled));
+
+        return std::nullopt;
+    }
 };
 
 ETLState

--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -126,9 +126,8 @@ LoadBalancer::LoadBalancer(
     }
 
     if (sources_.empty())
-    {
         checkOnETLFailure("No ETL sources configured. Please check the configuration");
-    }
+    
 }
 
 LoadBalancer::~LoadBalancer()

--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -88,36 +88,30 @@ LoadBalancer::LoadBalancer(
     auto const checkOnETLFailure = [this, allowNoEtl](std::string const& log) {
         LOG(log_.error()) << log;
 
-        if (!allowNoEtl)
-        {
+        if (!allowNoEtl) {
             LOG(log_.error()) << "Set allow_no_etl as true in config to allow clio run without valid ETL sources.";
             throw std::logic_error("ETL configuration error.");
         }
     };
 
-    for (auto const& entry : config.array("etl_sources"))
-    {
+    for (auto const& entry : config.array("etl_sources")) {
         std::unique_ptr<Source> source = make_Source(entry, ioc, backend, subscriptions, validatedLedgers, *this);
 
         // checking etl node validity
         auto const stateOpt = ETLState::fetchETLStateFromSource(*source);
 
-        if (!stateOpt)
-        {
+        if (!stateOpt) {
             checkOnETLFailure(fmt::format(
                 "Failed to fetch ETL state from source = {} Please check the configuration and network",
-                source->toString()));
-        }
-        else if (
-            etlState_ && etlState_->networkID && stateOpt->networkID && etlState_->networkID != stateOpt->networkID)
-        {
+                source->toString()
+            ));
+        } else if (etlState_ && etlState_->networkID && stateOpt->networkID && etlState_->networkID != stateOpt->networkID) {
             checkOnETLFailure(fmt::format(
                 "ETL sources must be on the same network. Source network id = {} does not match others network id = {}",
                 *(stateOpt->networkID),
-                *(etlState_->networkID)));
-        }
-        else
-        {
+                *(etlState_->networkID)
+            ));
+        } else {
             etlState_ = stateOpt;
         }
 
@@ -127,7 +121,6 @@ LoadBalancer::LoadBalancer(
 
     if (sources_.empty())
         checkOnETLFailure("No ETL sources configured. Please check the configuration");
-    
 }
 
 LoadBalancer::~LoadBalancer()
@@ -277,8 +270,7 @@ LoadBalancer::execute(Func f, uint32_t ledgerSequence)
 std::optional<ETLState>
 LoadBalancer::getETLState() noexcept
 {
-    if (!etlState_)
-    {
+    if (!etlState_) {
         // retry ETLState fetch
         etlState_ = ETLState::fetchETLStateFromSource(*this);
     }

--- a/src/etl/LoadBalancer.h
+++ b/src/etl/LoadBalancer.h
@@ -181,6 +181,7 @@ public:
 
     /**
      * @brief Return state of ETL nodes.
+     * @return ETL state, nullopt if etl nodes not available
      */
     std::optional<ETLState>
     getETLState() noexcept;

--- a/src/etl/LoadBalancer.h
+++ b/src/etl/LoadBalancer.h
@@ -182,8 +182,8 @@ public:
     /**
      * @brief Return state of ETL nodes.
      */
-    ETLState
-    getETLState() const noexcept;
+    std::optional<ETLState>
+    getETLState() noexcept;
 
 private:
     /**

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -99,7 +99,7 @@ public:
         }
 
         std::optional<uint32_t> currentNetId = std::nullopt;
-        if (auto const& etlState = etl_->getETLState())
+        if (auto const& etlState = etl_->getETLState(); etlState.has_value())
             currentNetId = etlState->networkID;
 
         std::optional<data::TransactionAndMetadata> dbResponse;

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -98,7 +98,9 @@ public:
                 return Error{Status{RippledError::rpcEXCESSIVE_LGR_RANGE}};
         }
 
-        auto const currentNetId = etl_->getETLState().networkID;
+        std::optional<uint32_t> currentNetId = std::nullopt;
+        if (auto const& etlState = etl_->getETLState())
+            currentNetId = etlState->networkID;
 
         std::optional<data::TransactionAndMetadata> dbResponse;
 

--- a/unittests/etl/ETLStateTests.cpp
+++ b/unittests/etl/ETLStateTests.cpp
@@ -36,7 +36,7 @@ TEST_F(ETLStateTest, Error)
 {
     EXPECT_CALL(source, forwardToRippled).WillOnce(Return(std::nullopt));
     auto const state = etl::ETLState::fetchETLStateFromSource(source);
-    EXPECT_FALSE(state.networkID.has_value());
+    EXPECT_FALSE(state);
 }
 
 TEST_F(ETLStateTest, NetworkIdValid)
@@ -52,8 +52,9 @@ TEST_F(ETLStateTest, NetworkIdValid)
     );
     EXPECT_CALL(source, forwardToRippled).WillOnce(Return(json.as_object()));
     auto const state = etl::ETLState::fetchETLStateFromSource(source);
-    ASSERT_TRUE(state.networkID.has_value());
-    EXPECT_EQ(state.networkID.value(), 12);
+    ASSERT_TRUE(state.has_value());
+    ASSERT_TRUE(state->networkID.has_value());
+    EXPECT_EQ(state->networkID.value(), 12);
 }
 
 TEST_F(ETLStateTest, NetworkIdInvalid)
@@ -69,5 +70,6 @@ TEST_F(ETLStateTest, NetworkIdInvalid)
     );
     EXPECT_CALL(source, forwardToRippled).WillOnce(Return(json.as_object()));
     auto const state = etl::ETLState::fetchETLStateFromSource(source);
-    EXPECT_FALSE(state.networkID.has_value());
+    ASSERT_TRUE(state.has_value());
+    EXPECT_FALSE(state->networkID.has_value());
 }

--- a/unittests/rpc/handlers/TxTests.cpp
+++ b/unittests/rpc/handlers/TxTests.cpp
@@ -410,7 +410,7 @@ TEST_F(RPCTxTest, ReturnBinaryWithCTID)
 TEST_F(RPCTxTest, MintNFT)
 {
     // Note: `inLedger` is API v1 only. See DefaultOutput_*
-    auto const static OUT = fmt::format(
+    auto static const OUT = fmt::format(
         R"({{
             "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Fee": "50",
@@ -821,7 +821,8 @@ TEST_F(RPCTxTest, NotReturnCTIDIfETLNotAvaiable)
                 "command": "tx",
                 "transaction": "{}"
             }})",
-            TXNID));
+            TXNID
+        ));
         auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(*output, json::parse(OUT));
@@ -830,7 +831,7 @@ TEST_F(RPCTxTest, NotReturnCTIDIfETLNotAvaiable)
 
 TEST_F(RPCTxTest, ViaCTID)
 {
-    auto const static OUT = fmt::format(
+    auto static const OUT = fmt::format(
         R"({{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Fee":"2",

--- a/unittests/rpc/handlers/TxTests.cpp
+++ b/unittests/rpc/handlers/TxTests.cpp
@@ -756,6 +756,78 @@ TEST_F(RPCTxTest, ReturnCTIDForTxInput)
     });
 }
 
+TEST_F(RPCTxTest, NotReturnCTIDIfETLNotAvaiable)
+{
+    auto constexpr static OUT = R"({
+            "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+            "Fee":"2",
+            "Sequence":100,
+            "SigningPubKey":"74657374",
+            "TakerGets":
+            {
+                "currency":"0158415500000000C1F76FF6ECB0BAC600000000",
+                "issuer":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
+                "value":"200"
+            },
+            "TakerPays":"300",
+            "TransactionType":"OfferCreate",
+            "hash":"2E2FBAAFF767227FE4381C4BE9855986A6B9F96C62F6E443731AB36F7BBB8A08",
+            "meta":
+            {
+                "AffectedNodes":
+                [
+                    {
+                        "CreatedNode":
+                        {
+                            "LedgerEntryType":"Offer",
+                            "NewFields":
+                            {
+                                "TakerGets":"200",
+                                "TakerPays":
+                                {
+                                    "currency":"0158415500000000C1F76FF6ECB0BAC600000000",
+                                    "issuer":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                                    "value":"300"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "TransactionIndex":100,
+                "TransactionResult":"tesSUCCESS"
+            },
+            "date":123456,
+            "ledger_index":100,
+            "inLedger":100,
+            "validated": true
+    })";
+    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
+    TransactionAndMetadata tx;
+    tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
+    tx.transaction =
+        CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
+    tx.date = 123456;
+    tx.ledgerSequence = 100;
+    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+
+    auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
+    ASSERT_NE(rawETLPtr, nullptr);
+    EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(std::nullopt));
+
+    runSpawn([this](auto yield) {
+        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const req = json::parse(fmt::format(
+            R"({{ 
+                "command": "tx",
+                "transaction": "{}"
+            }})",
+            TXNID));
+        auto const output = handler.process(req, Context{yield});
+        ASSERT_TRUE(output);
+        EXPECT_EQ(*output, json::parse(OUT));
+    });
+}
+
 TEST_F(RPCTxTest, ViaCTID)
 {
     auto const static OUT = fmt::format(

--- a/unittests/util/MockETLService.h
+++ b/unittests/util/MockETLService.h
@@ -32,5 +32,5 @@ struct MockETLService {
     MOCK_METHOD(std::uint32_t, lastPublishAgeSeconds, (), (const));
     MOCK_METHOD(std::uint32_t, lastCloseAgeSeconds, (), (const));
     MOCK_METHOD(bool, isAmendmentBlocked, (), (const));
-    MOCK_METHOD(etl::ETLState, getETLState, (), (const));
+    MOCK_METHOD(std::optional<etl::ETLState>, getETLState, (), (const));
 };


### PR DESCRIPTION
We previously added the logic to check the ETL nodes validity at startup. It caused some inconvenience of dev. 
This PR adds a config "allow_no_etl", if it is true, Clio is allowed to run without ETL. 
If the "allow_no_etl" is false, which by default, the error will be like:
![Screenshot 2023-10-20 at 09 10 28](https://github.com/XRPLF/clio/assets/120398799/bc2ff237-bf24-46b4-be26-24b7f23441c3)
