### PR TITLE
Amm ledgerentry

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,6 +23,7 @@ class Clio(ConanFile):
         'boost/1.82.0',
         'cassandra-cpp-driver/2.17.0',
         'fmt/10.1.1',
+        'protobuf/3.21.12',
         'grpc/1.50.1',
         'openssl/1.1.1u',
         'xrpl/2.0.0-b2',

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -66,7 +66,7 @@ LedgerEntryHandler::process(LedgerEntryHandler::Input input, Context const& ctx)
 
         key = ripple::getTicketIndex(*id, input.ticket->at(JS(ticket_seq)).as_int64());
     } else if (input.amm) {
-        auto const getIssuerFromJson = [](auto const assetJson) {
+        auto const getIssuerFromJson = [](auto const& assetJson) {
             // the field check has been done in validator
             auto const currency = ripple::to_currency(assetJson.at(JS(currency)).as_string().c_str());
             if (ripple::isXRP(currency)) {

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -196,8 +196,7 @@ tag_invoke(boost::json::value_to_tag<LedgerEntryHandler::Input>, boost::json::va
         {JS(deposit_preauth), ripple::ltDEPOSIT_PREAUTH},
         {JS(ticket), ripple::ltTICKET},
         {JS(nft_page), ripple::ltNFTOKEN_PAGE},
-        {JS(amm), ripple::ltAMM}
-    };
+        {JS(amm), ripple::ltAMM}};
 
     auto const indexFieldType =
         std::find_if(indexFieldTypeMap.begin(), indexFieldTypeMap.end(), [&jsonObject](auto const& pair) {

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -71,11 +71,9 @@ LedgerEntryHandler::process(LedgerEntryHandler::Input input, Context const& ctx)
             auto const currency = ripple::to_currency(assetJson.at(JS(currency)).as_string().c_str());
             if (ripple::isXRP(currency)) {
                 return ripple::xrpIssue();
-            } else {
-                auto const issuer =
-                    ripple::parseBase58<ripple::AccountID>(assetJson.at(JS(issuer)).as_string().c_str());
-                return ripple::Issue{currency, *issuer};
             }
+            auto const issuer = ripple::parseBase58<ripple::AccountID>(assetJson.at(JS(issuer)).as_string().c_str());
+            return ripple::Issue{currency, *issuer};
         };
 
         key = ripple::keylet::amm(

--- a/src/rpc/handlers/LedgerEntry.h
+++ b/src/rpc/handlers/LedgerEntry.h
@@ -146,8 +146,7 @@ public:
              meta::IfType<boost::json::object>{meta::Section{
                  {JS(owner), validation::AccountBase58Validator},
                  {JS(dir_root), validation::Uint256HexStringValidator},
-                 {JS(sub_index), malformedRequestIntValidator}
-             }}},
+                 {JS(sub_index), malformedRequestIntValidator}}}},
             {JS(escrow),
              validation::Type<std::string, boost::json::object>{},
              meta::IfType<std::string>{malformedRequestHexStringValidator},
@@ -193,18 +192,15 @@ public:
                      {JS(asset),
                       meta::WithCustomError{validation::Required{}, Status(ClioError::rpcMALFORMED_REQUEST)},
                       meta::WithCustomError{
-                          validation::Type<boost::json::object>{}, Status(ClioError::rpcMALFORMED_REQUEST)
-                      },
+                          validation::Type<boost::json::object>{}, Status(ClioError::rpcMALFORMED_REQUEST)},
                       ammAssetValidator},
                      {JS(asset2),
                       meta::WithCustomError{validation::Required{}, Status(ClioError::rpcMALFORMED_REQUEST)},
                       meta::WithCustomError{
-                          validation::Type<boost::json::object>{}, Status(ClioError::rpcMALFORMED_REQUEST)
-                      },
+                          validation::Type<boost::json::object>{}, Status(ClioError::rpcMALFORMED_REQUEST)},
                       ammAssetValidator},
                  },
-             }}
-        };
+             }}};
 
         return rpcSpec;
     }

--- a/src/rpc/handlers/LedgerEntry.h
+++ b/src/rpc/handlers/LedgerEntry.h
@@ -112,7 +112,7 @@ public:
                     jvAsset["issuer"] = value.at(JS(issuer)).as_string().c_str();
                 if (value.as_object().contains(JS(currency)))
                     jvAsset["currency"] = value.at(JS(currency)).as_string().c_str();
-
+                // same as rippled
                 try {
                     ripple::issueFromJson(jvAsset);
                 } catch (std::runtime_error const&) {

--- a/unittests/rpc/handlers/LedgerEntryTests.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTests.cpp
@@ -72,7 +72,8 @@ generateTestValuesForParametersTest()
                 "binary": "invalid"
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidAccountRootFormat",
@@ -80,7 +81,8 @@ generateTestValuesForParametersTest()
                 "account_root": "invalid"
             })",
             "malformedAddress",
-            "Malformed address."},
+            "Malformed address."
+        },
 
         ParamTestCaseBundle{
             "InvalidAccountRootNotString",
@@ -88,7 +90,8 @@ generateTestValuesForParametersTest()
                 "account_root": 123
             })",
             "invalidParams",
-            "account_rootNotString"},
+            "account_rootNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidLedgerIndex",
@@ -96,7 +99,8 @@ generateTestValuesForParametersTest()
                 "ledger_index": "wrong"
             })",
             "invalidParams",
-            "ledgerIndexMalformed"},
+            "ledgerIndexMalformed"
+        },
 
         ParamTestCaseBundle{"UnknownOption", R"({})", "invalidParams", "Invalid parameters."},
 
@@ -106,7 +110,8 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": 123
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthString",
@@ -114,7 +119,8 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthEmtpyJson",
@@ -122,7 +128,8 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": {}
             })",
             "invalidParams",
-            "Required field 'owner' missing"},
+            "Required field 'owner' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonWrongAccount",
@@ -133,7 +140,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."},
+            "Malformed owner."
+        },
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonOwnerNotString",
@@ -144,7 +152,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."},
+            "Malformed owner."
+        },
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonAuthorizedNotString",
@@ -158,7 +167,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "authorizedNotString"},
+            "authorizedNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketType",
@@ -166,7 +176,8 @@ generateTestValuesForParametersTest()
                 "ticket": 123
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketIndex",
@@ -174,7 +185,8 @@ generateTestValuesForParametersTest()
                 "ticket": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketEmptyJson",
@@ -182,7 +194,8 @@ generateTestValuesForParametersTest()
                 "ticket": {}
             })",
             "invalidParams",
-            "Required field 'account' missing"},
+            "Required field 'account' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketJsonAccountNotString",
@@ -193,7 +206,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "accountNotString"},
+            "accountNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketJsonAccountInvalid",
@@ -204,7 +218,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."},
+            "Malformed address."
+        },
 
         ParamTestCaseBundle{
             "InvalidTicketJsonSeqNotInt",
@@ -218,7 +233,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferType",
@@ -226,7 +242,8 @@ generateTestValuesForParametersTest()
                 "offer": 123
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferIndex",
@@ -234,7 +251,8 @@ generateTestValuesForParametersTest()
                 "offer": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferEmptyJson",
@@ -242,7 +260,8 @@ generateTestValuesForParametersTest()
                 "offer": {}
             })",
             "invalidParams",
-            "Required field 'account' missing"},
+            "Required field 'account' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferJsonAccountNotString",
@@ -253,7 +272,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "accountNotString"},
+            "accountNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferJsonAccountInvalid",
@@ -264,7 +284,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."},
+            "Malformed address."
+        },
 
         ParamTestCaseBundle{
             "InvalidOfferJsonSeqNotInt",
@@ -278,7 +299,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowType",
@@ -286,7 +308,8 @@ generateTestValuesForParametersTest()
                 "escrow": 123
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowIndex",
@@ -294,7 +317,8 @@ generateTestValuesForParametersTest()
                 "escrow": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowEmptyJson",
@@ -302,7 +326,8 @@ generateTestValuesForParametersTest()
                 "escrow": {}
             })",
             "invalidParams",
-            "Required field 'owner' missing"},
+            "Required field 'owner' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonAccountNotString",
@@ -313,7 +338,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."},
+            "Malformed owner."
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonAccountInvalid",
@@ -324,7 +350,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."},
+            "Malformed owner."
+        },
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonSeqNotInt",
@@ -338,7 +365,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateType",
@@ -346,7 +374,8 @@ generateTestValuesForParametersTest()
                 "ripple_state": "123"
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateMissField",
@@ -356,7 +385,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "Required field 'accounts' missing"},
+            "Required field 'accounts' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateEmtpyJson",
@@ -364,7 +394,8 @@ generateTestValuesForParametersTest()
                 "ripple_state": {}
             })",
             "invalidParams",
-            "Required field 'accounts' missing"},
+            "Required field 'accounts' missing"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateOneAccount",
@@ -377,7 +408,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"},
+            "malformedAccounts"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateSameAccounts",
@@ -392,7 +424,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"},
+            "malformedAccounts"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongAccountsNotString",
@@ -406,7 +439,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"},
+            "malformedAccounts"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongAccountsFormat",
@@ -420,7 +454,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedAddress",
-            "malformedAddresses"},
+            "malformedAddresses"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongCurrency",
@@ -435,7 +470,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT2
             ),
             "malformedCurrency",
-            "malformedCurrency"},
+            "malformedCurrency"
+        },
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongCurrencyNotString",
@@ -450,7 +486,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT2
             ),
             "invalidParams",
-            "currencyNotString"},
+            "currencyNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryType",
@@ -458,7 +495,8 @@ generateTestValuesForParametersTest()
                 "directory": 123
             })",
             "invalidParams",
-            "Invalid parameters."},
+            "Invalid parameters."
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryIndex",
@@ -466,7 +504,8 @@ generateTestValuesForParametersTest()
                 "directory": "123"
             })",
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryEmtpyJson",
@@ -474,7 +513,8 @@ generateTestValuesForParametersTest()
                 "directory": {}
             })",
             "invalidParams",
-            "missingOwnerOrDirRoot"},
+            "missingOwnerOrDirRoot"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongOwnerNotString",
@@ -484,7 +524,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "ownerNotString"},
+            "ownerNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongOwnerFormat",
@@ -494,7 +535,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."},
+            "Malformed address."
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongDirFormat",
@@ -504,7 +546,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "dir_rootMalformed"},
+            "dir_rootMalformed"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongDirNotString",
@@ -514,7 +557,8 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "dir_rootNotString"},
+            "dir_rootNotString"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryDirOwnerConflict",
@@ -529,7 +573,8 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "mayNotSpecifyBothDirRootAndOwner"},
+            "mayNotSpecifyBothDirRootAndOwner"
+        },
 
         ParamTestCaseBundle{
             "InvalidDirectoryDirSubIndexNotInt",
@@ -543,7 +588,260 @@ generateTestValuesForParametersTest()
                 INDEX1
             ),
             "malformedRequest",
-            "Malformed request."},
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "InvalidAMMStringIndex",
+            R"({
+                "amm": "invalid"
+            })",
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "EmptyAMMJson",
+            R"({
+                "amm": {}
+            })",
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "EmptyAMMAssetJson",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset":{{}},
+                        "asset2":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "EmptyAMMAsset2Json",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":{{}},
+                        "asset":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "MissingAMMAsset2Json",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "MissingAMMAssetJson",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "AMMAssetNotJson",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset": "invalid",
+                        "asset2":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "AMMAsset2NotJson",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2": "invalid",
+                        "asset":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "WrongAMMAssetCurrency",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency":"XRP"
+                        }},
+                        "asset":
+                        {{
+                            "currency" : "USD2",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "WrongAMMAssetIssuer",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency":"XRP"
+                        }},
+                        "asset":
+                        {{
+                            "currency" : "USD2",
+                            "issuer" : "aa{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "MissingAMMAssetIssuerForNonXRP",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency":"JPY"
+                        }},
+                        "asset":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "AMMAssetHasIssuerForXRP",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency":"XRP",
+                            "issuer":"{}"
+                        }},
+                        "asset":
+                        {{
+                            "currency" : "USD",
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT,
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
+
+        ParamTestCaseBundle{
+            "MissingAMMAssetCurrency",
+            fmt::format(
+                R"({{
+                    "amm": 
+                    {{
+                        "asset2":
+                        {{
+                            "currency":"XRP"
+                        }},
+                        "asset":
+                        {{
+                            "issuer" : "{}"
+                        }}
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            "malformedRequest",
+            "Malformed request."
+        },
     };
 }
 
@@ -698,7 +996,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateAccountRootObject(ACCOUNT2, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3)},
+            CreateAccountRootObject(ACCOUNT2, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3)
+        },
         NormalPathTestBundle{
             "Payment_channel",
             fmt::format(
@@ -709,7 +1008,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 200, 300, INDEX1, 400)},
+            CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 200, 300, INDEX1, 400)
+        },
         NormalPathTestBundle{
             "Nft_page",
             fmt::format(
@@ -722,7 +1022,8 @@ generateTestValuesForNormalPathTest()
             ripple::uint256{INDEX1},
             CreateNFTTokenPage(
                 std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt
-            )},
+            )
+        },
         NormalPathTestBundle{
             "Check",
             fmt::format(
@@ -733,7 +1034,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateCheckLedgerObject(ACCOUNT, ACCOUNT2)},
+            CreateCheckLedgerObject(ACCOUNT, ACCOUNT2)
+        },
         NormalPathTestBundle{
             "DirectoryIndex",
             fmt::format(
@@ -744,7 +1046,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
+        },
         NormalPathTestBundle{
             "OfferIndex",
             fmt::format(
@@ -757,7 +1060,8 @@ generateTestValuesForNormalPathTest()
             ripple::uint256{INDEX1},
             CreateOfferLedgerObject(
                 ACCOUNT, 100, 200, "USD", "XRP", ACCOUNT2, ripple::toBase58(ripple::xrpAccount()), INDEX1
-            )},
+            )
+        },
         NormalPathTestBundle{
             "EscrowIndex",
             fmt::format(
@@ -768,7 +1072,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)},
+            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)
+        },
         NormalPathTestBundle{
             "TicketIndex",
             fmt::format(
@@ -779,7 +1084,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateTicketLedgerObject(ACCOUNT, 0)},
+            CreateTicketLedgerObject(ACCOUNT, 0)
+        },
         NormalPathTestBundle{
             "DepositPreauthIndex",
             fmt::format(
@@ -790,7 +1096,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)},
+            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)
+        },
         NormalPathTestBundle{
             "AccountRoot",
             fmt::format(
@@ -801,7 +1108,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key,
-            CreateAccountRootObject(ACCOUNT, 0, 1, 1, 1, INDEX1, 1)},
+            CreateAccountRootObject(ACCOUNT, 0, 1, 1, 1, INDEX1, 1)
+        },
         NormalPathTestBundle{
             "DirectoryViaDirRoot",
             fmt::format(
@@ -815,7 +1123,8 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::keylet::page(ripple::uint256{INDEX1}, 2).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
+        },
         NormalPathTestBundle{
             "DirectoryViaOwner",
             fmt::format(
@@ -829,7 +1138,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::page(ripple::keylet::ownerDir(account1), 2).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
+        },
         NormalPathTestBundle{
             "DirectoryViaDefaultSubIndex",
             fmt::format(
@@ -843,7 +1153,8 @@ generateTestValuesForNormalPathTest()
             ),
             // default sub_index is 0
             ripple::keylet::page(ripple::keylet::ownerDir(account1), 0).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
+        },
         NormalPathTestBundle{
             "Escrow",
             fmt::format(
@@ -857,7 +1168,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::escrow(account1, 1).key,
-            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)},
+            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)
+        },
         NormalPathTestBundle{
             "DepositPreauth",
             fmt::format(
@@ -872,7 +1184,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2
             ),
             ripple::keylet::depositPreauth(account1, account2).key,
-            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)},
+            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)
+        },
         NormalPathTestBundle{
             "RippleState",
             fmt::format(
@@ -887,7 +1200,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2
             ),
             ripple::keylet::line(account1, account2, currency).key,
-            CreateRippleStateLedgerObject("USD", ACCOUNT2, 100, ACCOUNT, 10, ACCOUNT2, 20, INDEX1, 123, 0)},
+            CreateRippleStateLedgerObject("USD", ACCOUNT2, 100, ACCOUNT, 10, ACCOUNT2, 20, INDEX1, 123, 0)
+        },
         NormalPathTestBundle{
             "Ticket",
             fmt::format(
@@ -901,7 +1215,8 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::getTicketIndex(account1, 2),
-            CreateTicketLedgerObject(ACCOUNT, 0)},
+            CreateTicketLedgerObject(ACCOUNT, 0)
+        },
         NormalPathTestBundle{
             "Offer",
             fmt::format(
@@ -917,7 +1232,9 @@ generateTestValuesForNormalPathTest()
             ripple::keylet::offer(account1, 2).key,
             CreateOfferLedgerObject(
                 ACCOUNT, 100, 200, "USD", "XRP", ACCOUNT2, ripple::toBase58(ripple::xrpAccount()), INDEX1
-            )}};
+            )
+        }
+    };
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/rpc/handlers/LedgerEntryTests.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTests.cpp
@@ -762,7 +762,7 @@ generateTestValuesForParametersTest()
                         }},
                         "asset":
                         {{
-                            "currency" : "USD2",
+                            "currency" : "USD",
                             "issuer" : "aa{}"
                         }}
                     }}

--- a/unittests/rpc/handlers/LedgerEntryTests.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTests.cpp
@@ -1233,6 +1233,39 @@ generateTestValuesForNormalPathTest()
             CreateOfferLedgerObject(
                 ACCOUNT, 100, 200, "USD", "XRP", ACCOUNT2, ripple::toBase58(ripple::xrpAccount()), INDEX1
             )
+        },
+        NormalPathTestBundle{
+            "AMMViaIndex",
+            fmt::format(
+                R"({{
+                    "binary": true,
+                    "amm": "{}"
+                }})",
+                INDEX1
+            ),
+            ripple::uint256{INDEX1},
+            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)
+        },
+        NormalPathTestBundle{
+            "AMMViaJson",
+            fmt::format(
+                R"({{
+                    "binary": true,
+                    "amm": {{
+                        "asset": {{
+                            "currency": "XRP"
+                        }},
+                        "asset2": {{
+                            "currency": "{}",
+                            "issuer": "{}"
+                        }}
+                    }}
+                }})",
+                "JPY",
+                ACCOUNT2
+            ),
+            ripple::keylet::amm(GetIssue("XRP", ripple::toBase58(ripple::xrpAccount())), GetIssue("JPY", ACCOUNT2)).key,
+            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)
         }
     };
 }

--- a/unittests/rpc/handlers/LedgerEntryTests.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTests.cpp
@@ -72,8 +72,7 @@ generateTestValuesForParametersTest()
                 "binary": "invalid"
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidAccountRootFormat",
@@ -81,8 +80,7 @@ generateTestValuesForParametersTest()
                 "account_root": "invalid"
             })",
             "malformedAddress",
-            "Malformed address."
-        },
+            "Malformed address."},
 
         ParamTestCaseBundle{
             "InvalidAccountRootNotString",
@@ -90,8 +88,7 @@ generateTestValuesForParametersTest()
                 "account_root": 123
             })",
             "invalidParams",
-            "account_rootNotString"
-        },
+            "account_rootNotString"},
 
         ParamTestCaseBundle{
             "InvalidLedgerIndex",
@@ -99,8 +96,7 @@ generateTestValuesForParametersTest()
                 "ledger_index": "wrong"
             })",
             "invalidParams",
-            "ledgerIndexMalformed"
-        },
+            "ledgerIndexMalformed"},
 
         ParamTestCaseBundle{"UnknownOption", R"({})", "invalidParams", "Invalid parameters."},
 
@@ -110,8 +106,7 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": 123
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthString",
@@ -119,8 +114,7 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthEmtpyJson",
@@ -128,8 +122,7 @@ generateTestValuesForParametersTest()
                 "deposit_preauth": {}
             })",
             "invalidParams",
-            "Required field 'owner' missing"
-        },
+            "Required field 'owner' missing"},
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonWrongAccount",
@@ -140,8 +133,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."
-        },
+            "Malformed owner."},
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonOwnerNotString",
@@ -152,8 +144,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."
-        },
+            "Malformed owner."},
 
         ParamTestCaseBundle{
             "InvalidDepositPreauthJsonAuthorizedNotString",
@@ -167,8 +158,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "authorizedNotString"
-        },
+            "authorizedNotString"},
 
         ParamTestCaseBundle{
             "InvalidTicketType",
@@ -176,8 +166,7 @@ generateTestValuesForParametersTest()
                 "ticket": 123
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidTicketIndex",
@@ -185,8 +174,7 @@ generateTestValuesForParametersTest()
                 "ticket": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidTicketEmptyJson",
@@ -194,8 +182,7 @@ generateTestValuesForParametersTest()
                 "ticket": {}
             })",
             "invalidParams",
-            "Required field 'account' missing"
-        },
+            "Required field 'account' missing"},
 
         ParamTestCaseBundle{
             "InvalidTicketJsonAccountNotString",
@@ -206,8 +193,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "accountNotString"
-        },
+            "accountNotString"},
 
         ParamTestCaseBundle{
             "InvalidTicketJsonAccountInvalid",
@@ -218,8 +204,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."
-        },
+            "Malformed address."},
 
         ParamTestCaseBundle{
             "InvalidTicketJsonSeqNotInt",
@@ -233,8 +218,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidOfferType",
@@ -242,8 +226,7 @@ generateTestValuesForParametersTest()
                 "offer": 123
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidOfferIndex",
@@ -251,8 +234,7 @@ generateTestValuesForParametersTest()
                 "offer": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidOfferEmptyJson",
@@ -260,8 +242,7 @@ generateTestValuesForParametersTest()
                 "offer": {}
             })",
             "invalidParams",
-            "Required field 'account' missing"
-        },
+            "Required field 'account' missing"},
 
         ParamTestCaseBundle{
             "InvalidOfferJsonAccountNotString",
@@ -272,8 +253,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "accountNotString"
-        },
+            "accountNotString"},
 
         ParamTestCaseBundle{
             "InvalidOfferJsonAccountInvalid",
@@ -284,8 +264,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."
-        },
+            "Malformed address."},
 
         ParamTestCaseBundle{
             "InvalidOfferJsonSeqNotInt",
@@ -299,8 +278,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidEscrowType",
@@ -308,8 +286,7 @@ generateTestValuesForParametersTest()
                 "escrow": 123
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidEscrowIndex",
@@ -317,8 +294,7 @@ generateTestValuesForParametersTest()
                 "escrow": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidEscrowEmptyJson",
@@ -326,8 +302,7 @@ generateTestValuesForParametersTest()
                 "escrow": {}
             })",
             "invalidParams",
-            "Required field 'owner' missing"
-        },
+            "Required field 'owner' missing"},
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonAccountNotString",
@@ -338,8 +313,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."
-        },
+            "Malformed owner."},
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonAccountInvalid",
@@ -350,8 +324,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedOwner",
-            "Malformed owner."
-        },
+            "Malformed owner."},
 
         ParamTestCaseBundle{
             "InvalidEscrowJsonSeqNotInt",
@@ -365,8 +338,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidRippleStateType",
@@ -374,8 +346,7 @@ generateTestValuesForParametersTest()
                 "ripple_state": "123"
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidRippleStateMissField",
@@ -385,8 +356,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "Required field 'accounts' missing"
-        },
+            "Required field 'accounts' missing"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateEmtpyJson",
@@ -394,8 +364,7 @@ generateTestValuesForParametersTest()
                 "ripple_state": {}
             })",
             "invalidParams",
-            "Required field 'accounts' missing"
-        },
+            "Required field 'accounts' missing"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateOneAccount",
@@ -408,8 +377,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"
-        },
+            "malformedAccounts"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateSameAccounts",
@@ -424,8 +392,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"
-        },
+            "malformedAccounts"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongAccountsNotString",
@@ -439,8 +406,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "malformedAccounts"
-        },
+            "malformedAccounts"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongAccountsFormat",
@@ -454,8 +420,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedAddress",
-            "malformedAddresses"
-        },
+            "malformedAddresses"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongCurrency",
@@ -470,8 +435,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT2
             ),
             "malformedCurrency",
-            "malformedCurrency"
-        },
+            "malformedCurrency"},
 
         ParamTestCaseBundle{
             "InvalidRippleStateWrongCurrencyNotString",
@@ -486,8 +450,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT2
             ),
             "invalidParams",
-            "currencyNotString"
-        },
+            "currencyNotString"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryType",
@@ -495,8 +458,7 @@ generateTestValuesForParametersTest()
                 "directory": 123
             })",
             "invalidParams",
-            "Invalid parameters."
-        },
+            "Invalid parameters."},
 
         ParamTestCaseBundle{
             "InvalidDirectoryIndex",
@@ -504,8 +466,7 @@ generateTestValuesForParametersTest()
                 "directory": "123"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidDirectoryEmtpyJson",
@@ -513,8 +474,7 @@ generateTestValuesForParametersTest()
                 "directory": {}
             })",
             "invalidParams",
-            "missingOwnerOrDirRoot"
-        },
+            "missingOwnerOrDirRoot"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongOwnerNotString",
@@ -524,8 +484,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "ownerNotString"
-        },
+            "ownerNotString"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongOwnerFormat",
@@ -535,8 +494,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "malformedAddress",
-            "Malformed address."
-        },
+            "Malformed address."},
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongDirFormat",
@@ -546,8 +504,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "dir_rootMalformed"
-        },
+            "dir_rootMalformed"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryWrongDirNotString",
@@ -557,8 +514,7 @@ generateTestValuesForParametersTest()
                 }
             })",
             "invalidParams",
-            "dir_rootNotString"
-        },
+            "dir_rootNotString"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryDirOwnerConflict",
@@ -573,8 +529,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "invalidParams",
-            "mayNotSpecifyBothDirRootAndOwner"
-        },
+            "mayNotSpecifyBothDirRootAndOwner"},
 
         ParamTestCaseBundle{
             "InvalidDirectoryDirSubIndexNotInt",
@@ -588,8 +543,7 @@ generateTestValuesForParametersTest()
                 INDEX1
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "InvalidAMMStringIndex",
@@ -597,8 +551,7 @@ generateTestValuesForParametersTest()
                 "amm": "invalid"
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "EmptyAMMJson",
@@ -606,8 +559,7 @@ generateTestValuesForParametersTest()
                 "amm": {}
             })",
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "EmptyAMMAssetJson",
@@ -626,8 +578,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "EmptyAMMAsset2Json",
@@ -646,8 +597,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "MissingAMMAsset2Json",
@@ -665,8 +615,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "MissingAMMAssetJson",
@@ -684,8 +633,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "AMMAssetNotJson",
@@ -704,8 +652,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "AMMAsset2NotJson",
@@ -724,8 +671,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "WrongAMMAssetCurrency",
@@ -747,8 +693,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "WrongAMMAssetIssuer",
@@ -770,8 +715,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "MissingAMMAssetIssuerForNonXRP",
@@ -793,8 +737,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "AMMAssetHasIssuerForXRP",
@@ -818,8 +761,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
 
         ParamTestCaseBundle{
             "MissingAMMAssetCurrency",
@@ -840,8 +782,7 @@ generateTestValuesForParametersTest()
                 ACCOUNT
             ),
             "malformedRequest",
-            "Malformed request."
-        },
+            "Malformed request."},
     };
 }
 
@@ -996,8 +937,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateAccountRootObject(ACCOUNT2, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3)
-        },
+            CreateAccountRootObject(ACCOUNT2, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3)},
         NormalPathTestBundle{
             "Payment_channel",
             fmt::format(
@@ -1008,8 +948,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 200, 300, INDEX1, 400)
-        },
+            CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 200, 300, INDEX1, 400)},
         NormalPathTestBundle{
             "Nft_page",
             fmt::format(
@@ -1022,8 +961,7 @@ generateTestValuesForNormalPathTest()
             ripple::uint256{INDEX1},
             CreateNFTTokenPage(
                 std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt
-            )
-        },
+            )},
         NormalPathTestBundle{
             "Check",
             fmt::format(
@@ -1034,8 +972,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateCheckLedgerObject(ACCOUNT, ACCOUNT2)
-        },
+            CreateCheckLedgerObject(ACCOUNT, ACCOUNT2)},
         NormalPathTestBundle{
             "DirectoryIndex",
             fmt::format(
@@ -1046,8 +983,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
-        },
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
         NormalPathTestBundle{
             "OfferIndex",
             fmt::format(
@@ -1060,8 +996,7 @@ generateTestValuesForNormalPathTest()
             ripple::uint256{INDEX1},
             CreateOfferLedgerObject(
                 ACCOUNT, 100, 200, "USD", "XRP", ACCOUNT2, ripple::toBase58(ripple::xrpAccount()), INDEX1
-            )
-        },
+            )},
         NormalPathTestBundle{
             "EscrowIndex",
             fmt::format(
@@ -1072,8 +1007,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)
-        },
+            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)},
         NormalPathTestBundle{
             "TicketIndex",
             fmt::format(
@@ -1084,8 +1018,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateTicketLedgerObject(ACCOUNT, 0)
-        },
+            CreateTicketLedgerObject(ACCOUNT, 0)},
         NormalPathTestBundle{
             "DepositPreauthIndex",
             fmt::format(
@@ -1096,8 +1029,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)
-        },
+            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)},
         NormalPathTestBundle{
             "AccountRoot",
             fmt::format(
@@ -1108,8 +1040,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key,
-            CreateAccountRootObject(ACCOUNT, 0, 1, 1, 1, INDEX1, 1)
-        },
+            CreateAccountRootObject(ACCOUNT, 0, 1, 1, 1, INDEX1, 1)},
         NormalPathTestBundle{
             "DirectoryViaDirRoot",
             fmt::format(
@@ -1123,8 +1054,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::keylet::page(ripple::uint256{INDEX1}, 2).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
-        },
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
         NormalPathTestBundle{
             "DirectoryViaOwner",
             fmt::format(
@@ -1138,8 +1068,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::page(ripple::keylet::ownerDir(account1), 2).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
-        },
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
         NormalPathTestBundle{
             "DirectoryViaDefaultSubIndex",
             fmt::format(
@@ -1153,8 +1082,7 @@ generateTestValuesForNormalPathTest()
             ),
             // default sub_index is 0
             ripple::keylet::page(ripple::keylet::ownerDir(account1), 0).key,
-            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)
-        },
+            CreateOwnerDirLedgerObject(std::vector<ripple::uint256>{ripple::uint256{INDEX1}}, INDEX1)},
         NormalPathTestBundle{
             "Escrow",
             fmt::format(
@@ -1168,8 +1096,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::keylet::escrow(account1, 1).key,
-            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)
-        },
+            CreateEscrowLedgerObject(ACCOUNT, ACCOUNT2)},
         NormalPathTestBundle{
             "DepositPreauth",
             fmt::format(
@@ -1184,8 +1111,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2
             ),
             ripple::keylet::depositPreauth(account1, account2).key,
-            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)
-        },
+            CreateDepositPreauthLedgerObject(ACCOUNT, ACCOUNT2)},
         NormalPathTestBundle{
             "RippleState",
             fmt::format(
@@ -1200,8 +1126,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2
             ),
             ripple::keylet::line(account1, account2, currency).key,
-            CreateRippleStateLedgerObject("USD", ACCOUNT2, 100, ACCOUNT, 10, ACCOUNT2, 20, INDEX1, 123, 0)
-        },
+            CreateRippleStateLedgerObject("USD", ACCOUNT2, 100, ACCOUNT, 10, ACCOUNT2, 20, INDEX1, 123, 0)},
         NormalPathTestBundle{
             "Ticket",
             fmt::format(
@@ -1215,8 +1140,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT
             ),
             ripple::getTicketIndex(account1, 2),
-            CreateTicketLedgerObject(ACCOUNT, 0)
-        },
+            CreateTicketLedgerObject(ACCOUNT, 0)},
         NormalPathTestBundle{
             "Offer",
             fmt::format(
@@ -1232,8 +1156,7 @@ generateTestValuesForNormalPathTest()
             ripple::keylet::offer(account1, 2).key,
             CreateOfferLedgerObject(
                 ACCOUNT, 100, 200, "USD", "XRP", ACCOUNT2, ripple::toBase58(ripple::xrpAccount()), INDEX1
-            )
-        },
+            )},
         NormalPathTestBundle{
             "AMMViaIndex",
             fmt::format(
@@ -1244,8 +1167,7 @@ generateTestValuesForNormalPathTest()
                 INDEX1
             ),
             ripple::uint256{INDEX1},
-            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)
-        },
+            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)},
         NormalPathTestBundle{
             "AMMViaJson",
             fmt::format(
@@ -1265,9 +1187,7 @@ generateTestValuesForNormalPathTest()
                 ACCOUNT2
             ),
             ripple::keylet::amm(GetIssue("XRP", ripple::toBase58(ripple::xrpAccount())), GetIssue("JPY", ACCOUNT2)).key,
-            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)
-        }
-    };
+            CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2)}};
 }
 
 INSTANTIATE_TEST_CASE_P(

--- a/unittests/util/TestObject.cpp
+++ b/unittests/util/TestObject.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 
 constexpr static auto INDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC";
+constexpr static auto CURRENCY = "03930D02208264E2E40EC1B0C09E4DB96EE197B1";
 
 ripple::AccountID
 GetAccountIDWithString(std::string_view id)
@@ -748,4 +749,28 @@ CreateAmendmentsObject(std::vector<ripple::uint256> const& enabledAmendments)
     ripple::STVector256 const list(enabledAmendments);
     amendments.setFieldV256(ripple::sfAmendments, list);
     return amendments;
+}
+
+ripple::STObject
+CreateAMMObject(
+    std::string_view accountId,
+    std::string_view assetCurrency,
+    std::string_view assetIssuer,
+    std::string_view asset2Currency,
+    std::string_view asset2Issuer
+)
+{
+    auto amm = ripple::STObject(ripple::sfLedgerEntry);
+    amm.setFieldU16(ripple::sfLedgerEntryType, ripple::ltAMM);
+    amm.setAccountID(ripple::sfAccount, GetAccountIDWithString(accountId));
+    amm.setFieldU16(ripple::sfTradingFee, 5);
+    amm.setFieldU64(ripple::sfOwnerNode, 0);
+    amm.setFieldIssue(ripple::sfAsset, ripple::STIssue{ripple::sfAsset, GetIssue(assetCurrency, assetIssuer)});
+    amm.setFieldIssue(ripple::sfAsset2, ripple::STIssue{ripple::sfAsset2, GetIssue(asset2Currency, asset2Issuer)});
+    ripple::Issue const issue1(
+        ripple::Currency{CURRENCY}, ripple::parseBase58<ripple::AccountID>(std::string(accountId)).value()
+    );
+    amm.setFieldAmount(ripple::sfLPTokenBalance, ripple::STAmount(issue1, 100));
+    amm.setFieldU32(ripple::sfFlags, 0);
+    return amm;
 }

--- a/unittests/util/TestObject.h
+++ b/unittests/util/TestObject.h
@@ -277,3 +277,12 @@ CreateCreateNFTOfferTxWithMetadata(
 
 [[nodiscard]] ripple::STObject
 CreateAmendmentsObject(std::vector<ripple::uint256> const& enabledAmendments);
+
+[[nodiscard]] ripple::STObject
+CreateAMMObject(
+    std::string_view accountId,
+    std::string_view assetCurrency,
+    std::string_view assetIssuer,
+    std::string_view asset2Currency,
+    std::string_view asset2Issuer
+);


### PR DESCRIPTION
Add amm option for ledger_entry:

Had tested e2e. Two way to get the amm object from ledger_entry:
1
Via index 
![Screenshot 2023-10-26 at 13 25 55](https://github.com/XRPLF/clio/assets/120398799/8336981f-03cd-4197-9135-ba00e8e05c12)

2
Via asset
![Screenshot 2023-10-26 at 13 25 32](https://github.com/XRPLF/clio/assets/120398799/14b8ac4e-5e93-4f5d-9828-4f7f072dd15d)
