### PR TITLE
Fix exit of ETL on exception

### DIFF
--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -131,7 +131,7 @@ ETLService::monitor()
     LOG(log_.debug()) << "Database is populated. "
                       << "Starting monitor loop. sequence = " << nextSequence;
 
-    while (true) {
+    while (not isStopping()) {
         nextSequence = publishNextSequence(nextSequence);
     }
 }
@@ -199,7 +199,7 @@ ETLService::monitorReadOnly()
     cacheLoader_.load(latestSequence);
     latestSequence++;
 
-    while (true) {
+    while (not isStopping()) {
         if (auto rng = backend_->hardFetchLedgerRangeNoThrow(); rng && rng->maxSequence >= latestSequence) {
             ledgerPublisher_.publish(latestSequence, {});
             latestSequence = latestSequence + 1;


### PR DESCRIPTION
Fixes #708 

@cindyyan317 while this is fixing the original issue you found (i assume, when having both "admin_password" and "local_admin" set), this is not actually a full fix for any unexpected exception path. For proper clean exit we would have to refactor more code, especially ETL.