### PR TITLE
Move AdminVerificationStrategy to Server

### DIFF
--- a/src/web/HttpSession.h
+++ b/src/web/HttpSession.h
@@ -55,7 +55,7 @@ public:
     explicit HttpSession(
         tcp::socket&& socket,
         std::string const& ip,
-        std::optional<std::string> adminPassword,
+        std::shared_ptr<detail::AdminVerificationStrategy> const& adminVerification,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<web::DOSGuard> dosGuard,
         std::shared_ptr<HandlerType> const& handler,
@@ -64,7 +64,7 @@ public:
         : detail::HttpBase<HttpSession, HandlerType>(
               ip,
               tagFactory,
-              std::move(adminPassword),
+              adminVerification,
               dosGuard,
               handler,
               std::move(buffer)

--- a/src/web/Server.h
+++ b/src/web/Server.h
@@ -75,15 +75,15 @@ public:
         std::optional<std::reference_wrapper<boost::asio::ssl::context>> ctx,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<web::DOSGuard> dosGuard,
-        std::shared_ptr<HandlerType> const& handler,
-        std::shared_ptr<detail::AdminVerificationStrategy> const& adminVerification
+        std::shared_ptr<HandlerType> handler,
+        std::shared_ptr<detail::AdminVerificationStrategy> adminVerification
     )
         : stream_(std::move(socket))
         , ctx_(ctx)
         , tagFactory_(std::cref(tagFactory))
         , dosGuard_(dosGuard)
-        , handler_(handler)
-        , adminVerification_(adminVerification)
+        , handler_(std::move(handler))
+        , adminVerification_(std::move(adminVerification))
     {
     }
 
@@ -194,14 +194,14 @@ public:
         tcp::endpoint endpoint,
         util::TagDecoratorFactory tagFactory,
         web::DOSGuard& dosGuard,
-        std::shared_ptr<HandlerType> const& handler,
+        std::shared_ptr<HandlerType> handler,
         std::optional<std::string> adminPassword
     )
         : ioc_(std::ref(ioc))
         , ctx_(ctx)
         , tagFactory_(tagFactory)
         , dosGuard_(std::ref(dosGuard))
-        , handler_(handler)
+        , handler_(std::move(handler))
         , acceptor_(boost::asio::make_strand(ioc))
         , adminVerification_(detail::make_AdminVerificationStrategy(std::move(adminPassword)))
     {

--- a/src/web/Server.h
+++ b/src/web/Server.h
@@ -83,7 +83,7 @@ public:
         , tagFactory_(std::cref(tagFactory))
         , dosGuard_(dosGuard)
         , handler_(handler)
-        , adminVerification_(std::move(adminVerification))
+        , adminVerification_(adminVerification)
     {
     }
 

--- a/src/web/SslHttpSession.h
+++ b/src/web/SslHttpSession.h
@@ -56,7 +56,7 @@ public:
     explicit SslHttpSession(
         tcp::socket&& socket,
         std::string const& ip,
-        std::optional<std::string> adminPassword,
+        std::shared_ptr<detail::AdminVerificationStrategy> const& adminVerification,
         boost::asio::ssl::context& ctx,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<web::DOSGuard> dosGuard,
@@ -66,7 +66,7 @@ public:
         : detail::HttpBase<SslHttpSession, HandlerType>(
               ip,
               tagFactory,
-              std::move(adminPassword),
+              adminVerification,
               dosGuard,
               handler,
               std::move(buffer)

--- a/src/web/SslWsSession.h
+++ b/src/web/SslWsSession.h
@@ -109,19 +109,19 @@ public:
         std::string ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<web::DOSGuard> dosGuard,
-        std::shared_ptr<HandlerType> const& handler,
+        std::shared_ptr<HandlerType> handler,
         boost::beast::flat_buffer&& buffer,
         http::request<http::string_body> request,
-        bool isAdmiin
+        bool isAdmin
     )
         : https_(std::move(stream))
         , buffer_(std::move(buffer))
         , ip_(std::move(ip))
         , tagFactory_(tagFactory)
         , dosGuard_(dosGuard)
-        , handler_(handler)
+        , handler_(std::move(handler))
         , req_(std::move(request))
-        , isAdmin_(isAdmiin)
+        , isAdmin_(isAdmin)
     {
     }
 

--- a/src/web/impl/AdminVerificationStrategy.cpp
+++ b/src/web/impl/AdminVerificationStrategy.cpp
@@ -54,13 +54,13 @@ PasswordAdminVerificationStrategy::isAdmin(RequestType const& request, std::stri
     return passwordSha256_ == userAuth;
 }
 
-std::unique_ptr<AdminVerificationStrategy>
+std::shared_ptr<AdminVerificationStrategy>
 make_AdminVerificationStrategy(std::optional<std::string> password)
 {
     if (password.has_value()) {
-        return std::make_unique<PasswordAdminVerificationStrategy>(std::move(*password));
+        return std::make_shared<PasswordAdminVerificationStrategy>(std::move(*password));
     }
-    return std::make_unique<IPAdminVerificationStrategy>();
+    return std::make_shared<IPAdminVerificationStrategy>();
 }
 
 }  // namespace web::detail

--- a/src/web/impl/AdminVerificationStrategy.h
+++ b/src/web/impl/AdminVerificationStrategy.h
@@ -73,7 +73,7 @@ public:
     isAdmin(RequestType const& request, std::string_view) const override;
 };
 
-std::unique_ptr<AdminVerificationStrategy>
+std::shared_ptr<AdminVerificationStrategy>
 make_AdminVerificationStrategy(std::optional<std::string> password);
 
 }  // namespace web::detail

--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -85,7 +85,7 @@ class HttpBase : public ConnectionBase {
 
     std::shared_ptr<void> res_;
     SendLambda sender_;
-    std::unique_ptr<AdminVerificationStrategy> adminVerification_;
+    std::shared_ptr<AdminVerificationStrategy> adminVerification_;
 
 protected:
     boost::beast::flat_buffer buffer_;
@@ -129,14 +129,14 @@ public:
     HttpBase(
         std::string const& ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
-        std::optional<std::string> adminPassword,
+        std::shared_ptr<AdminVerificationStrategy> const& adminVerification,
         std::reference_wrapper<web::DOSGuard> dosGuard,
         std::shared_ptr<HandlerType> const& handler,
         boost::beast::flat_buffer buffer
     )
         : ConnectionBase(tagFactory, ip)
         , sender_(*this)
-        , adminVerification_(make_AdminVerificationStrategy(std::move(adminPassword)))
+        , adminVerification_(adminVerification)
         , buffer_(std::move(buffer))
         , dosGuard_(dosGuard)
         , handler_(handler)

--- a/src/web/impl/HttpBase.h
+++ b/src/web/impl/HttpBase.h
@@ -129,17 +129,17 @@ public:
     HttpBase(
         std::string const& ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
-        std::shared_ptr<AdminVerificationStrategy> const& adminVerification,
+        std::shared_ptr<AdminVerificationStrategy> adminVerification,
         std::reference_wrapper<web::DOSGuard> dosGuard,
-        std::shared_ptr<HandlerType> const& handler,
+        std::shared_ptr<HandlerType> handler,
         boost::beast::flat_buffer buffer
     )
         : ConnectionBase(tagFactory, ip)
         , sender_(*this)
-        , adminVerification_(adminVerification)
+        , adminVerification_(std::move(adminVerification))
         , buffer_(std::move(buffer))
         , dosGuard_(dosGuard)
-        , handler_(handler)
+        , handler_(std::move(handler))
     {
         LOG(perfLog_.debug()) << tag() << "http session created";
         dosGuard_.get().increment(ip);


### PR DESCRIPTION
Following this PR #958 
This PR removes the password member from Server class. Also AdminVerificationStrategy can be shared between sessions. This PR move the construction from session to web server.
