### PR TITLE
Implement DID  

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -66,7 +66,7 @@
         // Max number of requests to queue up before rejecting further requests.
         // Defaults to 0, which disables the limit.
         "max_queue_size": 500,
-        // If request contains header with authorization, Clio will check if it matches this value's hash
+        // If request contains header with authorization, Clio will check if it matches this value's sha256 hash
         // If matches, the request will be considered as admin request
         "admin_password": "xrp",
         // If local_admin is true, Clio will consider requests come from 127.0.0.1 as admin requests

--- a/src/rpc/handlers/AccountObjects.cpp
+++ b/src/rpc/handlers/AccountObjects.cpp
@@ -22,18 +22,27 @@
 namespace rpc {
 
 // found here : https://xrpl.org/ledger_entry.html#:~:text=valid%20fields%20are%3A-,index,-account_root
-std::unordered_map<std::string, ripple::LedgerEntryType> const AccountObjectsHandler::TYPESMAP{
-    {"state", ripple::ltRIPPLE_STATE},
-    {"ticket", ripple::ltTICKET},
-    {"signer_list", ripple::ltSIGNER_LIST},
-    {"payment_channel", ripple::ltPAYCHAN},
-    {"offer", ripple::ltOFFER},
-    {"escrow", ripple::ltESCROW},
-    {"deposit_preauth", ripple::ltDEPOSIT_PREAUTH},
-    {"check", ripple::ltCHECK},
-    {"nft_page", ripple::ltNFTOKEN_PAGE},
-    {"nft_offer", ripple::ltNFTOKEN_OFFER},
+std::unordered_map<std::string, ripple::LedgerEntryType> const AccountObjectsHandler::TYPES_MAP{
+    {JS(state), ripple::ltRIPPLE_STATE},
+    {JS(ticket), ripple::ltTICKET},
+    {JS(signer_list), ripple::ltSIGNER_LIST},
+    {JS(payment_channel), ripple::ltPAYCHAN},
+    {JS(offer), ripple::ltOFFER},
+    {JS(escrow), ripple::ltESCROW},
+    {JS(deposit_preauth), ripple::ltDEPOSIT_PREAUTH},
+    {JS(check), ripple::ltCHECK},
+    {JS(nft_page), ripple::ltNFTOKEN_PAGE},
+    {JS(nft_offer), ripple::ltNFTOKEN_OFFER},
+    {JS(did), ripple::ltDID},
 };
+
+std::unordered_set<std::string> const AccountObjectsHandler::TYPES_KEYS = [] {
+    std::unordered_set<std::string> keys;
+    std::transform(TYPES_MAP.begin(), TYPES_MAP.end(), std::inserter(keys, keys.begin()), [](auto const& pair) {
+        return pair.first;
+    });
+    return keys;
+}();
 
 AccountObjectsHandler::Result
 AccountObjectsHandler::process(AccountObjectsHandler::Input input, Context const& ctx) const
@@ -153,7 +162,7 @@ tag_invoke(boost::json::value_to_tag<AccountObjectsHandler::Input>, boost::json:
     }
 
     if (jsonObject.contains(JS(type)))
-        input.type = AccountObjectsHandler::TYPESMAP.at(jv.at(JS(type)).as_string().c_str());
+        input.type = AccountObjectsHandler::TYPES_MAP.at(jv.at(JS(type)).as_string().c_str());
 
     if (jsonObject.contains(JS(limit)))
         input.limit = jv.at(JS(limit)).as_int64();

--- a/src/rpc/handlers/AccountObjects.h
+++ b/src/rpc/handlers/AccountObjects.h
@@ -33,7 +33,7 @@ namespace rpc {
  * @brief The account_objects command returns the raw ledger format for all objects owned by an account.
  * The results can be filtered by the type.
  * The valid types are: check, deposit_preauth, escrow, nft_offer, offer, payment_channel, signer_list, state (trust
- * line), and ticket.
+ * line), did and ticket.
  *
  * For more details see: https://xrpl.org/account_objects.html
  */
@@ -42,7 +42,8 @@ class AccountObjectsHandler {
     std::shared_ptr<BackendInterface> sharedPtrBackend_;
 
     // constants
-    static std::unordered_map<std::string, ripple::LedgerEntryType> const TYPESMAP;
+    static std::unordered_map<std::string, ripple::LedgerEntryType> const TYPES_MAP;
+    static std::unordered_set<std::string> const TYPES_KEYS;
 
 public:
     static auto constexpr LIMIT_MIN = 10;
@@ -89,18 +90,7 @@ public:
              modifiers::Clamp<int32_t>(LIMIT_MIN, LIMIT_MAX)},
             {JS(type),
              validation::Type<std::string>{},
-             validation::OneOf<std::string>{
-                 "state",
-                 "ticket",
-                 "signer_list",
-                 "payment_channel",
-                 "offer",
-                 "escrow",
-                 "deposit_preauth",
-                 "check",
-                 "nft_page",
-                 "nft_offer",
-             }},
+             validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend())},
             {JS(marker), validation::AccountMarkerValidator},
             {JS(deletion_blockers_only), validation::Type<bool>{}},
         };

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -56,6 +56,8 @@ std::unordered_map<std::string, ripple::TxType> const AccountTxHandler::TYPESMAP
     {JSL(SignerListSet), ripple::ttSIGNER_LIST_SET},
     {JSL(TicketCreate), ripple::ttTICKET_CREATE},
     {JSL(TrustSet), ripple::ttTRUST_SET},
+    {JSL(DIDSet), ripple::ttDID_SET},
+    {JSL(DIDDelete), ripple::ttDID_DELETE},
 };
 
 // TODO: should be std::views::keys when clang supports it

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -41,8 +41,7 @@ std::unordered_map<std::string, ripple::LedgerEntryType> const LedgerDataHandler
     {JS(state), ripple::ltRIPPLE_STATE},
     {JS(ticket), ripple::ltTICKET},
     {JS(nft_offer), ripple::ltNFTOKEN_OFFER},
-    {JS(nft_page), ripple::ltNFTOKEN_PAGE}
-};
+    {JS(nft_page), ripple::ltNFTOKEN_PAGE}};
 
 // TODO: should be std::views::keys when clang supports it
 std::unordered_set<std::string> const LedgerDataHandler::TYPES_KEYS = [] {

--- a/src/rpc/handlers/LedgerData.cpp
+++ b/src/rpc/handlers/LedgerData.cpp
@@ -27,6 +27,7 @@ namespace rpc {
 
 std::unordered_map<std::string, ripple::LedgerEntryType> const LedgerDataHandler::TYPES_MAP{
     {JS(account), ripple::ltACCOUNT_ROOT},
+    {JS(did), ripple::ltDID},
     {JS(amendments), ripple::ltAMENDMENTS},
     {JS(check), ripple::ltCHECK},
     {JS(deposit_preauth), ripple::ltDEPOSIT_PREAUTH},
@@ -40,7 +41,8 @@ std::unordered_map<std::string, ripple::LedgerEntryType> const LedgerDataHandler
     {JS(state), ripple::ltRIPPLE_STATE},
     {JS(ticket), ripple::ltTICKET},
     {JS(nft_offer), ripple::ltNFTOKEN_OFFER},
-    {JS(nft_page), ripple::ltNFTOKEN_PAGE}};
+    {JS(nft_page), ripple::ltNFTOKEN_PAGE}
+};
 
 // TODO: should be std::views::keys when clang supports it
 std::unordered_set<std::string> const LedgerDataHandler::TYPES_KEYS = [] {

--- a/src/rpc/handlers/LedgerData.h
+++ b/src/rpc/handlers/LedgerData.h
@@ -95,8 +95,8 @@ public:
              meta::IfType<std::string>{validation::Uint256HexStringValidator}},
             {JS(type),
              meta::WithCustomError{
-                 validation::Type<std::string>{}, Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}
-             },
+                 validation::Type<std::string>{},
+                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}},
              validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend())},
 
         };

--- a/src/rpc/handlers/LedgerData.h
+++ b/src/rpc/handlers/LedgerData.h
@@ -41,9 +41,9 @@ class LedgerDataHandler {
     std::shared_ptr<BackendInterface> sharedPtrBackend_;
     util::Logger log_{"RPC"};
 
-    static const std::unordered_map<std::string, ripple::LedgerEntryType> TYPES_MAP;
+    static std::unordered_map<std::string, ripple::LedgerEntryType> const TYPES_MAP;
 
-    static const std::unordered_set<std::string> TYPES_KEYS;
+    static std::unordered_set<std::string> const TYPES_KEYS;
 
 public:
     // constants
@@ -95,8 +95,8 @@ public:
              meta::IfType<std::string>{validation::Uint256HexStringValidator}},
             {JS(type),
              meta::WithCustomError{
-                 validation::Type<std::string>{},
-                 Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}},
+                 validation::Type<std::string>{}, Status{ripple::rpcINVALID_PARAMS, "Invalid field 'type', not string."}
+             },
              validation::OneOf<std::string>(TYPES_KEYS.cbegin(), TYPES_KEYS.cend())},
 
         };

--- a/src/rpc/handlers/LedgerEntry.cpp
+++ b/src/rpc/handlers/LedgerEntry.cpp
@@ -32,6 +32,8 @@ LedgerEntryHandler::process(LedgerEntryHandler::Input input, Context const& ctx)
         key = ripple::uint256{std::string_view(*(input.index))};
     } else if (input.accountRoot) {
         key = ripple::keylet::account(*ripple::parseBase58<ripple::AccountID>(*(input.accountRoot))).key;
+    } else if (input.did) {
+        key = ripple::keylet::did(*ripple::parseBase58<ripple::AccountID>(*(input.did))).key;
     } else if (input.directory) {
         auto const keyOrStatus = composeKeyFromDirectory(*input.directory);
         if (auto const status = std::get_if<Status>(&keyOrStatus))
@@ -209,6 +211,8 @@ tag_invoke(boost::json::value_to_tag<LedgerEntryHandler::Input>, boost::json::va
     // check if request for account root
     else if (jsonObject.contains(JS(account_root))) {
         input.accountRoot = jv.at(JS(account_root)).as_string().c_str();
+    } else if (jsonObject.contains(JS(did))) {
+        input.did = jv.at(JS(did)).as_string().c_str();
     }
     // no need to check if_object again, validator only allows string or object
     else if (jsonObject.contains(JS(directory))) {

--- a/src/rpc/handlers/LedgerEntry.h
+++ b/src/rpc/handlers/LedgerEntry.h
@@ -56,6 +56,8 @@ public:
         ripple::LedgerEntryType expectedType = ripple::ltANY;
         // account id to address account root object
         std::optional<std::string> accountRoot;
+        // account id to address did object
+        std::optional<std::string> did;
         // TODO: extract into custom objects, remove json from Input
         std::optional<boost::json::object> directory;
         std::optional<boost::json::object> offer;
@@ -128,6 +130,7 @@ public:
             {JS(ledger_index), validation::LedgerIndexValidator},
             {JS(index), malformedRequestHexStringValidator},
             {JS(account_root), validation::AccountBase58Validator},
+            {JS(did), validation::AccountBase58Validator},
             {JS(check), malformedRequestHexStringValidator},
             {JS(deposit_preauth),
              validation::Type<std::string, boost::json::object>{},
@@ -146,7 +149,8 @@ public:
              meta::IfType<boost::json::object>{meta::Section{
                  {JS(owner), validation::AccountBase58Validator},
                  {JS(dir_root), validation::Uint256HexStringValidator},
-                 {JS(sub_index), malformedRequestIntValidator}}}},
+                 {JS(sub_index), malformedRequestIntValidator}
+             }}},
             {JS(escrow),
              validation::Type<std::string, boost::json::object>{},
              meta::IfType<std::string>{malformedRequestHexStringValidator},

--- a/src/rpc/handlers/LedgerEntry.h
+++ b/src/rpc/handlers/LedgerEntry.h
@@ -149,8 +149,7 @@ public:
              meta::IfType<boost::json::object>{meta::Section{
                  {JS(owner), validation::AccountBase58Validator},
                  {JS(dir_root), validation::Uint256HexStringValidator},
-                 {JS(sub_index), malformedRequestIntValidator}
-             }}},
+                 {JS(sub_index), malformedRequestIntValidator}}}},
             {JS(escrow),
              validation::Type<std::string, boost::json::object>{},
              meta::IfType<std::string>{malformedRequestHexStringValidator},

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -64,88 +64,74 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
     {
         return std::vector<AccountTxParamTestCaseBundle>{
             AccountTxParamTestCaseBundle{
-                "MissingAccount", R"({})", "invalidParams", "Required field 'account' missing"
-            },
+                "MissingAccount", R"({})", "invalidParams", "Required field 'account' missing"},
             AccountTxParamTestCaseBundle{
                 "BinaryNotBool",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "binary": 1})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "BinaryNotBool_API_v1",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "binary": 1})",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "ForwardNotBool",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "forward": 1})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "ForwardNotBool_API_v1",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "forward": 1})",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "ledger_index_minNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index_min": "x"})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "ledger_index_maxNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index_max": "x"})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "ledger_indexInvalid",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index": "x"})",
                 "invalidParams",
-                "ledgerIndexMalformed"
-            },
+                "ledgerIndexMalformed"},
             AccountTxParamTestCaseBundle{
                 "ledger_hashInvalid",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_hash": "x"})",
                 "invalidParams",
-                "ledger_hashMalformed"
-            },
+                "ledger_hashMalformed"},
             AccountTxParamTestCaseBundle{
                 "ledger_hashNotString",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_hash": 123})",
                 "invalidParams",
-                "ledger_hashNotString"
-            },
+                "ledger_hashNotString"},
             AccountTxParamTestCaseBundle{
                 "limitNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": "123"})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "limitNegative",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": -1})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "limitZero",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "MarkerNotObject",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 101})",
                 "invalidParams",
-                "invalidMarker"
-            },
+                "invalidMarker"},
             AccountTxParamTestCaseBundle{
                 "MarkerMissingSeq",
                 R"({
@@ -153,8 +139,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "marker": {"ledger": 123}
             })",
                 "invalidParams",
-                "Required field 'seq' missing"
-            },
+                "Required field 'seq' missing"},
             AccountTxParamTestCaseBundle{
                 "MarkerMissingLedger",
                 R"({
@@ -162,8 +147,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "marker":{"seq": 123}
             })",
                 "invalidParams",
-                "Required field 'ledger' missing"
-            },
+                "Required field 'ledger' missing"},
             AccountTxParamTestCaseBundle{
                 "MarkerLedgerNotInt",
                 R"({
@@ -175,8 +159,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 }
             })",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "MarkerSeqNotInt",
                 R"({
@@ -188,8 +171,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 }
             })",
                 "invalidParams",
-                "Invalid parameters."
-            },
+                "Invalid parameters."},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLessThanMinSeq",
                 R"({
@@ -197,8 +179,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"
-            },
+                "ledgerSeqMinOutOfRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLargeThanMaxSeq",
                 R"({
@@ -206,8 +187,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_max": 31
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMaxOutOfRange"
-            },
+                "ledgerSeqMaxOutOfRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLargeThanMaxSeq_API_v1",
                 R"({
@@ -216,8 +196,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxSmallerThanMinSeq",
                 R"({
@@ -225,8 +204,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_max": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMaxOutOfRange"
-            },
+                "ledgerSeqMaxOutOfRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxSmallerThanMinSeq_API_v1",
                 R"({
@@ -235,8 +213,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinSmallerThanMinSeq",
                 R"({
@@ -244,8 +221,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"
-            },
+                "ledgerSeqMinOutOfRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinSmallerThanMinSeq_API_v1",
                 R"({
@@ -254,8 +230,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLargerThanMaxSeq",
                 R"({
@@ -263,8 +238,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 31
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"
-            },
+                "ledgerSeqMinOutOfRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLargerThanMaxSeq_API_v1",
                 R"({
@@ -273,8 +247,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLessThanLedgerIndexMin",
                 R"({
@@ -283,8 +256,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 20
             })",
                 "invalidLgrRange",
-                "Ledger range is invalid."
-            },
+                "Ledger range is invalid."},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLessThanLedgerIndexMin_API_v1",
                 R"({
@@ -294,8 +266,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndex",
                 R"({
@@ -305,8 +276,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index": 10
             })",
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"
-            },
+                "containsLedgerSpecifierAndRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndexValidated",
                 R"({
@@ -316,8 +286,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index": "validated"
             })",
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"
-            },
+                "containsLedgerSpecifierAndRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndex_API_v1",
                 R"({
@@ -328,8 +297,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerHash",
                 fmt::format(
@@ -342,8 +310,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                     LEDGERHASH
                 ),
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"
-            },
+                "containsLedgerSpecifierAndRange"},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerHash_API_v1",
                 fmt::format(
@@ -357,8 +324,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 ),
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndexValidated_API_v1",
                 R"({
@@ -369,8 +335,7 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u
-            },
+                1u},
         };
     };
 };
@@ -1528,8 +1493,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "DIDSet"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "DIDDelete",
             R"({
@@ -1537,8 +1501,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "DIDDelete"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "AccountSet",
             R"({
@@ -1546,8 +1509,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "AccountSet"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "AccountDelete",
             R"({
@@ -1555,8 +1517,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "AccountDelete"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "AMMBid",
             R"({
@@ -1604,8 +1565,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCancel"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "CheckCash",
             R"({
@@ -1613,8 +1573,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCash"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "CheckCreate",
             R"({
@@ -1622,8 +1581,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCreate"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "Clawback",
             R"({
@@ -1631,8 +1589,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "Clawback"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "DepositPreauth",
             R"({
@@ -1640,8 +1597,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "DepositPreauth"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "EscrowCancel",
             R"({
@@ -1649,8 +1605,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowCancel"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "EscrowCreate",
             R"({
@@ -1658,8 +1613,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowCreate"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "EscrowFinish",
             R"({
@@ -1667,8 +1621,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowFinish"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "NFTokenAcceptOffer",
             R"({
@@ -1676,8 +1629,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenAcceptOffer"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "NFTokenBurn",
             R"({
@@ -1685,8 +1637,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenBurn"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "NFTokenCancelOffer",
             R"({
@@ -1694,8 +1645,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenCancelOffer"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "NFTokenCreateOffer",
             R"({
@@ -1703,8 +1653,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenCreateOffer"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "NFTokenMint",
             R"({
@@ -1712,8 +1661,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenMint"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "OfferCancel",
             R"({
@@ -1721,8 +1669,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "OfferCancel"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "OfferCreate",
             R"({
@@ -1730,8 +1677,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "OfferCreate"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "Payment_API_v1",
             R"({
@@ -1781,8 +1727,7 @@ generateTransactionTypeTestValues()
                     "validated": true
                 }
             ])",
-            1u
-        },
+            1u},
         AccountTxTransactionBundle{
             "Payment_API_v2",
             R"({
@@ -1831,8 +1776,7 @@ generateTransactionTypeTestValues()
                 "validated": true
                 }
             ])",
-            2u
-        },
+            2u},
         AccountTxTransactionBundle{
             "PaymentChannelClaim",
             R"({
@@ -1840,8 +1784,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelClaim"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "PaymentChannelCreate",
             R"({
@@ -1849,8 +1792,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelCreate"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "PaymentChannelFund",
             R"({
@@ -1858,8 +1800,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelFund"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "SetRegularKey",
             R"({
@@ -1867,8 +1808,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "SetRegularKey"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "SignerListSet",
             R"({
@@ -1876,8 +1816,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "SignerListSet"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "TicketCreate",
             R"({
@@ -1885,8 +1824,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "TicketCreate"
             })",
-            "[]"
-        },
+            "[]"},
         AccountTxTransactionBundle{
             "TrustSet",
             R"({
@@ -1894,8 +1832,7 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "TrustSet"
             })",
-            "[]"
-        },
+            "[]"},
     };
 }
 

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -64,74 +64,88 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
     {
         return std::vector<AccountTxParamTestCaseBundle>{
             AccountTxParamTestCaseBundle{
-                "MissingAccount", R"({})", "invalidParams", "Required field 'account' missing"},
+                "MissingAccount", R"({})", "invalidParams", "Required field 'account' missing"
+            },
             AccountTxParamTestCaseBundle{
                 "BinaryNotBool",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "binary": 1})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "BinaryNotBool_API_v1",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "binary": 1})",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "ForwardNotBool",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "forward": 1})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "ForwardNotBool_API_v1",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "forward": 1})",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "ledger_index_minNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index_min": "x"})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "ledger_index_maxNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index_max": "x"})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "ledger_indexInvalid",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_index": "x"})",
                 "invalidParams",
-                "ledgerIndexMalformed"},
+                "ledgerIndexMalformed"
+            },
             AccountTxParamTestCaseBundle{
                 "ledger_hashInvalid",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_hash": "x"})",
                 "invalidParams",
-                "ledger_hashMalformed"},
+                "ledger_hashMalformed"
+            },
             AccountTxParamTestCaseBundle{
                 "ledger_hashNotString",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "ledger_hash": 123})",
                 "invalidParams",
-                "ledger_hashNotString"},
+                "ledger_hashNotString"
+            },
             AccountTxParamTestCaseBundle{
                 "limitNotInt",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": "123"})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "limitNegative",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": -1})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "limitZero",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "limit": 0})",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "MarkerNotObject",
                 R"({"account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn", "marker": 101})",
                 "invalidParams",
-                "invalidMarker"},
+                "invalidMarker"
+            },
             AccountTxParamTestCaseBundle{
                 "MarkerMissingSeq",
                 R"({
@@ -139,7 +153,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "marker": {"ledger": 123}
             })",
                 "invalidParams",
-                "Required field 'seq' missing"},
+                "Required field 'seq' missing"
+            },
             AccountTxParamTestCaseBundle{
                 "MarkerMissingLedger",
                 R"({
@@ -147,7 +162,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "marker":{"seq": 123}
             })",
                 "invalidParams",
-                "Required field 'ledger' missing"},
+                "Required field 'ledger' missing"
+            },
             AccountTxParamTestCaseBundle{
                 "MarkerLedgerNotInt",
                 R"({
@@ -159,7 +175,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 }
             })",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "MarkerSeqNotInt",
                 R"({
@@ -171,7 +188,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 }
             })",
                 "invalidParams",
-                "Invalid parameters."},
+                "Invalid parameters."
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLessThanMinSeq",
                 R"({
@@ -179,7 +197,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"},
+                "ledgerSeqMinOutOfRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLargeThanMaxSeq",
                 R"({
@@ -187,7 +206,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_max": 31
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMaxOutOfRange"},
+                "ledgerSeqMaxOutOfRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLargeThanMaxSeq_API_v1",
                 R"({
@@ -196,7 +216,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxSmallerThanMinSeq",
                 R"({
@@ -204,7 +225,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_max": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMaxOutOfRange"},
+                "ledgerSeqMaxOutOfRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxSmallerThanMinSeq_API_v1",
                 R"({
@@ -213,7 +235,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinSmallerThanMinSeq",
                 R"({
@@ -221,7 +244,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 9
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"},
+                "ledgerSeqMinOutOfRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinSmallerThanMinSeq_API_v1",
                 R"({
@@ -230,7 +254,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLargerThanMaxSeq",
                 R"({
@@ -238,7 +263,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 31
             })",
                 "lgrIdxMalformed",
-                "ledgerSeqMinOutOfRange"},
+                "ledgerSeqMinOutOfRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMinLargerThanMaxSeq_API_v1",
                 R"({
@@ -247,7 +273,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLessThanLedgerIndexMin",
                 R"({
@@ -256,7 +283,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index_min": 20
             })",
                 "invalidLgrRange",
-                "Ledger range is invalid."},
+                "Ledger range is invalid."
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxLessThanLedgerIndexMin_API_v1",
                 R"({
@@ -266,7 +294,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 "lgrIdxsInvalid",
                 "Ledger indexes invalid.",
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndex",
                 R"({
@@ -276,7 +305,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index": 10
             })",
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"},
+                "containsLedgerSpecifierAndRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndexValidated",
                 R"({
@@ -286,7 +316,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 "ledger_index": "validated"
             })",
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"},
+                "containsLedgerSpecifierAndRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndex_API_v1",
                 R"({
@@ -297,7 +328,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerHash",
                 fmt::format(
@@ -310,7 +342,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                     LEDGERHASH
                 ),
                 "invalidParams",
-                "containsLedgerSpecifierAndRange"},
+                "containsLedgerSpecifierAndRange"
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerHash_API_v1",
                 fmt::format(
@@ -324,7 +357,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
                 ),
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
             AccountTxParamTestCaseBundle{
                 "LedgerIndexMaxMinAndLedgerIndexValidated_API_v1",
                 R"({
@@ -335,7 +369,8 @@ struct AccountTxParameterTest : public RPCAccountTxHandlerTest,
             })",
                 std::nullopt,
                 std::nullopt,
-                1u},
+                1u
+            },
         };
     };
 };
@@ -1487,13 +1522,32 @@ generateTransactionTypeTestValues()
 {
     return std::vector<AccountTxTransactionBundle>{
         AccountTxTransactionBundle{
+            "DIDSet",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "tx_type": "DIDSet"
+            })",
+            "[]"
+        },
+        AccountTxTransactionBundle{
+            "DIDDelete",
+            R"({
+                "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+                "ledger_index": "validated",
+                "tx_type": "DIDDelete"
+            })",
+            "[]"
+        },
+        AccountTxTransactionBundle{
             "AccountSet",
             R"({
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                 "ledger_index": "validated",
                 "tx_type": "AccountSet"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "AccountDelete",
             R"({
@@ -1501,7 +1555,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "AccountDelete"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "AMMBid",
             R"({
@@ -1549,7 +1604,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCancel"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "CheckCash",
             R"({
@@ -1557,7 +1613,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCash"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "CheckCreate",
             R"({
@@ -1565,7 +1622,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "CheckCreate"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "Clawback",
             R"({
@@ -1573,7 +1631,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "Clawback"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "DepositPreauth",
             R"({
@@ -1581,7 +1640,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "DepositPreauth"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "EscrowCancel",
             R"({
@@ -1589,7 +1649,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowCancel"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "EscrowCreate",
             R"({
@@ -1597,7 +1658,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowCreate"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "EscrowFinish",
             R"({
@@ -1605,7 +1667,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "EscrowFinish"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "NFTokenAcceptOffer",
             R"({
@@ -1613,7 +1676,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenAcceptOffer"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "NFTokenBurn",
             R"({
@@ -1621,7 +1685,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenBurn"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "NFTokenCancelOffer",
             R"({
@@ -1629,7 +1694,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenCancelOffer"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "NFTokenCreateOffer",
             R"({
@@ -1637,7 +1703,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenCreateOffer"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "NFTokenMint",
             R"({
@@ -1645,7 +1712,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "NFTokenMint"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "OfferCancel",
             R"({
@@ -1653,7 +1721,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "OfferCancel"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "OfferCreate",
             R"({
@@ -1661,7 +1730,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "OfferCreate"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "Payment_API_v1",
             R"({
@@ -1711,7 +1781,8 @@ generateTransactionTypeTestValues()
                     "validated": true
                 }
             ])",
-            1u},
+            1u
+        },
         AccountTxTransactionBundle{
             "Payment_API_v2",
             R"({
@@ -1760,7 +1831,8 @@ generateTransactionTypeTestValues()
                 "validated": true
                 }
             ])",
-            2u},
+            2u
+        },
         AccountTxTransactionBundle{
             "PaymentChannelClaim",
             R"({
@@ -1768,7 +1840,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelClaim"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "PaymentChannelCreate",
             R"({
@@ -1776,7 +1849,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelCreate"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "PaymentChannelFund",
             R"({
@@ -1784,7 +1858,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "PaymentChannelFund"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "SetRegularKey",
             R"({
@@ -1792,7 +1867,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "SetRegularKey"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "SignerListSet",
             R"({
@@ -1800,7 +1876,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "SignerListSet"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "TicketCreate",
             R"({
@@ -1808,7 +1885,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "TicketCreate"
             })",
-            "[]"},
+            "[]"
+        },
         AccountTxTransactionBundle{
             "TrustSet",
             R"({
@@ -1816,7 +1894,8 @@ generateTransactionTypeTestValues()
                 "ledger_index": "validated",
                 "tx_type": "TrustSet"
             })",
-            "[]"},
+            "[]"
+        },
     };
 }
 

--- a/unittests/rpc/handlers/LedgerEntryTests.cpp
+++ b/unittests/rpc/handlers/LedgerEntryTests.cpp
@@ -83,6 +83,14 @@ generateTestValuesForParametersTest()
             "Malformed address."},
 
         ParamTestCaseBundle{
+            "InvalidDidFormat",
+            R"({
+                "did": "invalid"
+            })",
+            "malformedAddress",
+            "Malformed address."},
+
+        ParamTestCaseBundle{
             "InvalidAccountRootNotString",
             R"({
                 "account_root": 123
@@ -1041,6 +1049,17 @@ generateTestValuesForNormalPathTest()
             ),
             ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key,
             CreateAccountRootObject(ACCOUNT, 0, 1, 1, 1, INDEX1, 1)},
+        NormalPathTestBundle{
+            "DID",
+            fmt::format(
+                R"({{
+                    "binary": true,
+                    "did": "{}"
+                }})",
+                ACCOUNT
+            ),
+            ripple::keylet::did(GetAccountIDWithString(ACCOUNT)).key,
+            CreateDidObject(ACCOUNT, "mydocument", "myURI", "mydata")},
         NormalPathTestBundle{
             "DirectoryViaDirRoot",
             fmt::format(

--- a/unittests/util/TestObject.cpp
+++ b/unittests/util/TestObject.cpp
@@ -137,6 +137,25 @@ CreatePaymentTransactionMetaObject(
 }
 
 ripple::STObject
+CreateDidObject(std::string_view accountId, std::string_view didDoc, std::string_view uri, std::string_view data)
+{
+    ripple::STObject did(ripple::sfLedgerEntry);
+    did.setAccountID(ripple::sfAccount, GetAccountIDWithString(accountId));
+    did.setFieldU16(ripple::sfLedgerEntryType, ripple::ltDID);
+    did.setFieldU32(ripple::sfFlags, 0);
+    did.setFieldU64(ripple::sfOwnerNode, 0);
+    did.setFieldH256(ripple::sfPreviousTxnID, ripple::uint256{});
+    did.setFieldU32(ripple::sfPreviousTxnLgrSeq, 0);
+    ripple::Slice const sliceDoc(didDoc.data(), didDoc.size());
+    did.setFieldVL(ripple::sfDIDDocument, sliceDoc);
+    ripple::Slice const sliceUri(uri.data(), uri.size());
+    did.setFieldVL(ripple::sfURI, sliceUri);
+    ripple::Slice const sliceData(data.data(), data.size());
+    did.setFieldVL(ripple::sfData, sliceData);
+    return did;
+}
+
+ripple::STObject
 CreateAccountRootObject(
     std::string_view accountId,
     uint32_t flag,

--- a/unittests/util/TestObject.h
+++ b/unittests/util/TestObject.h
@@ -286,3 +286,6 @@ CreateAMMObject(
     std::string_view asset2Currency,
     std::string_view asset2Issuer
 );
+
+[[nodiscard]] ripple::STObject
+CreateDidObject(std::string_view accountId, std::string_view didDoc, std::string_view uri, std::string_view data);


### PR DESCRIPTION
DID is a new ledger object. More info please check [here](https://github.com/XRPLF/rippled/pull/4636)

This PR adds
1 DID to ledger_entry
2 DID to account_objects
3 DID to ledger_data
4 DID tx to account_tx 

This feature is not available on devnet.
I have tested with standalone rippled:

![Screenshot 2023-10-23 at 10 54 07](https://github.com/XRPLF/clio/assets/120398799/6a6bcbca-7dcf-4e23-a78c-49eefe424f53)
![Screenshot 2023-10-23 at 10 56 31](https://github.com/XRPLF/clio/assets/120398799/04d3659b-7097-4163-88ce-2e25592b2945)

![Screenshot 2023-10-23 at 10 58 36](https://github.com/XRPLF/clio/assets/120398799/3d8d76df-6889-428b-80b7-0f45c52c046b)
