### PR TITLE
[Trivial] .empty() instead of .size() for vectors

### DIFF
--- a/src/data/BackendInterface.cpp
+++ b/src/data/BackendInterface.cpp
@@ -200,7 +200,7 @@ BackendInterface::fetchBookOffers(
     for (size_t i = 0; i < keys.size() && i < limit; ++i) {
         LOG(gLog.trace()) << "Key = " << ripple::strHex(keys[i]) << " blob = " << ripple::strHex(objs[i])
                           << " ledgerSequence = " << ledgerSequence;
-        assert(objs[i].size());
+        assert(!objs[i].empty());
         page.offers.push_back({keys[i], objs[i]});
     }
     auto end = std::chrono::system_clock::now();

--- a/src/data/CassandraBackend.h
+++ b/src/data/CassandraBackend.h
@@ -736,7 +736,7 @@ public:
         LOG(log_.trace()) << "Writing successor. key = " << key.size() << " bytes. "
                           << " seq = " << std::to_string(seq) << " successor = " << successor.size() << " bytes.";
         assert(!key.empty());
-        assert(!successor.size());
+        assert(!successor.empty());
 
         executor_.write(schema_->insertSuccessor, std::move(key), seq, std::move(successor));
     }

--- a/src/data/CassandraBackend.h
+++ b/src/data/CassandraBackend.h
@@ -735,8 +735,8 @@ public:
     {
         LOG(log_.trace()) << "Writing successor. key = " << key.size() << " bytes. "
                           << " seq = " << std::to_string(seq) << " successor = " << successor.size() << " bytes.";
-        assert(key.size() != 0);
-        assert(successor.size() != 0);
+        assert(!key.empty());
+        assert(!successor.size());
 
         executor_.write(schema_->insertSuccessor, std::move(key), seq, std::move(successor));
     }


### PR DESCRIPTION
I've been getting this warning while compiling:
```
/Users/ak/Dev/ak-forks/new/clio/src/data/BackendInterface.cpp:203:16: error: the 'empty' method should be used to check for emptiness instead of 'size' [readability-container-size-empty,-warnings-as-errors]
        assert(objs[i].size());
               ^
/opt/homebrew/Cellar/llvm@16/16.0.6/bin/../include/c++/v1/vector:551:10: note: method 'vector'::empty() defined here
    bool empty() const _NOEXCEPT
```
This PR fixes this issue.