### PR TITLE
Fix lowercase ctid 

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -66,7 +66,7 @@
         // Max number of requests to queue up before rejecting further requests.
         // Defaults to 0, which disables the limit.
         "max_queue_size": 500,
-        // If request contains header with authorization, Clio will check if it matches this value's sha256 hash
+        // If request contains header with authorization, Clio will check if it matches the prefix 'Password ' + this value's sha256 hash
         // If matches, the request will be considered as admin request
         "admin_password": "xrp",
         // If local_admin is true, Clio will consider requests come from 127.0.0.1 as admin requests

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -227,7 +227,7 @@ private:
 
         if (jsonObject.contains(JS(ctid))) {
             input.ctid = jv.at(JS(ctid)).as_string().c_str();
-            util::toUpper(*input.ctid);
+            input.ctid = util::toUpper(*input.ctid);
         }
 
         if (jsonObject.contains(JS(binary)))

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -24,6 +24,7 @@
 #include <rpc/RPCHelpers.h>
 #include <rpc/common/Types.h>
 #include <rpc/common/Validators.h>
+#include <util/JsonUtils.h>
 
 namespace rpc {
 
@@ -226,7 +227,7 @@ private:
 
         if (jsonObject.contains(JS(ctid))) {
             input.ctid = jv.at(JS(ctid)).as_string().c_str();
-            std::transform(input.ctid->begin(), input.ctid->end(), input.ctid->begin(), ::toupper);
+            util::toUpper(*input.ctid);
         }
 
         if (jsonObject.contains(JS(binary)))

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -224,8 +224,10 @@ private:
         if (jsonObject.contains(JS(transaction)))
             input.transaction = jv.at(JS(transaction)).as_string().c_str();
 
-        if (jsonObject.contains(JS(ctid)))
+        if (jsonObject.contains(JS(ctid))) {
             input.ctid = jv.at(JS(ctid)).as_string().c_str();
+            std::transform(input.ctid->begin(), input.ctid->end(), input.ctid->begin(), ::toupper);
+        }
 
         if (jsonObject.contains(JS(binary)))
             input.binary = jv.at(JS(binary)).as_bool();

--- a/src/util/JsonUtils.h
+++ b/src/util/JsonUtils.h
@@ -37,6 +37,13 @@ toLower(std::string str)
     return str;
 }
 
+inline std::string
+toUpper(std::string str)
+{
+    std::transform(std::begin(str), std::end(str), std::begin(str), [](unsigned char c) { return std::toupper(c); });
+    return str;
+}
+
 /**
  * @brief Removes any detected secret information from a response JSON object.
  *

--- a/src/web/impl/AdminVerificationStrategy.cpp
+++ b/src/web/impl/AdminVerificationStrategy.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <fmt/format.h>
+#include <util/JsonUtils.h>
 #include <web/impl/AdminVerificationStrategy.h>
 
 #include <ripple/protocol/digest.h>
@@ -39,7 +40,7 @@ PasswordAdminVerificationStrategy::PasswordAdminVerificationStrategy(std::string
     std::memcpy(sha256.data(), d.data(), d.size());
     passwordSha256_ = ripple::to_string(sha256);
     // make sure it's uppercase
-    std::transform(passwordSha256_.begin(), passwordSha256_.end(), passwordSha256_.begin(), ::toupper);
+    util::toUpper(passwordSha256_);
 }
 
 bool
@@ -55,11 +56,9 @@ PasswordAdminVerificationStrategy::isAdmin(RequestType const& request, std::stri
         // Invalid Authorization header
         return false;
     }
+
     userAuth.remove_prefix(passwordPrefix.size());
-    std::string userPasswordHash;
-    userPasswordHash.reserve(userAuth.size());
-    std::transform(userAuth.begin(), userAuth.end(), std::back_inserter(userPasswordHash), ::toupper);
-    return passwordSha256_ == userPasswordHash;
+    return passwordSha256_ == util::toUpper(userAuth);
 }
 
 std::shared_ptr<AdminVerificationStrategy>

--- a/src/web/impl/AdminVerificationStrategy.cpp
+++ b/src/web/impl/AdminVerificationStrategy.cpp
@@ -40,7 +40,7 @@ PasswordAdminVerificationStrategy::PasswordAdminVerificationStrategy(std::string
     std::memcpy(sha256.data(), d.data(), d.size());
     passwordSha256_ = ripple::to_string(sha256);
     // make sure it's uppercase
-    util::toUpper(passwordSha256_);
+    passwordSha256_ = util::toUpper(passwordSha256_);
 }
 
 bool

--- a/src/web/impl/AdminVerificationStrategy.cpp
+++ b/src/web/impl/AdminVerificationStrategy.cpp
@@ -40,7 +40,7 @@ PasswordAdminVerificationStrategy::PasswordAdminVerificationStrategy(std::string
     std::memcpy(sha256.data(), d.data(), d.size());
     passwordSha256_ = ripple::to_string(sha256);
     // make sure it's uppercase
-    passwordSha256_ = util::toUpper(passwordSha256_);
+    passwordSha256_ = util::toUpper(std::move(passwordSha256_));
 }
 
 bool


### PR DESCRIPTION
I am thinking to make lowercase convert to string util function. Now the stringutils are for unittests only. Do you think we need to move  it out from unittests?
