### PR TITLE
DeliverMax alias of Payment tx

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -187,7 +187,7 @@ toJson(ripple::STBase const& obj)
 std::pair<boost::json::object, boost::json::object>
 toExpandedJson(
     data::TransactionAndMetadata const& blobs,
-    std::uint32_t apiVersion,
+    std::uint32_t const apiVersion,
     NFTokenjson nftEnabled,
     std::optional<uint16_t> networkId
 )
@@ -253,7 +253,7 @@ insertDeliveredAmount(
 }
 
 void
-insertDeliverMaxAlias(boost::json::object& txJson, std::uint32_t apiVersion)
+insertDeliverMaxAlias(boost::json::object& txJson, std::uint32_t const apiVersion)
 {
     if (txJson.contains(JS(TransactionType)) and txJson.at(JS(TransactionType)).is_string() and
         txJson.at(JS(TransactionType)).as_string() == JS(Payment) and txJson.contains(JS(Amount))) {

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -187,7 +187,7 @@ toJson(ripple::STBase const& obj)
 std::pair<boost::json::object, boost::json::object>
 toExpandedJson(
     data::TransactionAndMetadata const& blobs,
-    uint32_t apiVersion,
+    std::uint32_t apiVersion,
     NFTokenjson nftEnabled,
     std::optional<uint16_t> networkId
 )
@@ -253,7 +253,7 @@ insertDeliveredAmount(
 }
 
 void
-insertDeliverMaxAlias(boost::json::object& txJson, uint32_t apiVersion)
+insertDeliverMaxAlias(boost::json::object& txJson, std::uint32_t apiVersion)
 {
     if (txJson.contains(JS(TransactionType)) and txJson.at(JS(TransactionType)).is_string() and
         txJson.at(JS(TransactionType)).as_string() == JS(Payment) and txJson.contains(JS(Amount))) {

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -185,12 +185,18 @@ toJson(ripple::STBase const& obj)
 }
 
 std::pair<boost::json::object, boost::json::object>
-toExpandedJson(data::TransactionAndMetadata const& blobs, NFTokenjson nftEnabled, std::optional<uint16_t> networkId)
+toExpandedJson(
+    data::TransactionAndMetadata const& blobs,
+    uint32_t apiVersion,
+    NFTokenjson nftEnabled,
+    std::optional<uint16_t> networkId
+)
 {
     auto [txn, meta] = deserializeTxPlusMeta(blobs, blobs.ledgerSequence);
     auto txnJson = toJson(*txn);
     auto metaJson = toJson(*meta);
     insertDeliveredAmount(metaJson, txn, meta, blobs.date);
+    insertDeliverMaxAlias(txnJson, apiVersion);
 
     if (nftEnabled == NFTokenjson::ENABLE) {
         Json::Value nftJson;
@@ -244,6 +250,17 @@ insertDeliveredAmount(
         return true;
     }
     return false;
+}
+
+void
+insertDeliverMaxAlias(boost::json::object& txJson, uint32_t apiVersion)
+{
+    if (txJson.contains(JS(TransactionType)) and txJson.at(JS(TransactionType)).is_string() and
+        txJson.at(JS(TransactionType)).as_string() == JS(Payment) and txJson.contains(JS(Amount))) {
+        txJson[JS(DeliverMax)] = txJson[JS(Amount)];
+        if (apiVersion > 1)
+            txJson.erase(JS(Amount));
+    }
 }
 
 boost::json::object
@@ -456,7 +473,7 @@ traverseNFTObjects(
     if (!page) {
         if (nextPage == beast::zero) {  // no nft objects in lastNFTPage
             return AccountCursor{beast::zero, 0};
-        }  // marker is in the right range, but still invalid
+        }                               // marker is in the right range, but still invalid
         return Status{RippledError::rpcINVALID_PARAMS, "Invalid marker."};
     }
 

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -473,7 +473,8 @@ traverseNFTObjects(
     if (!page) {
         if (nextPage == beast::zero) {  // no nft objects in lastNFTPage
             return AccountCursor{beast::zero, 0};
-        }                               // marker is in the right range, but still invalid
+        }
+        // marker is in the right range, but still invalid
         return Status{RippledError::rpcINVALID_PARAMS, "Invalid marker."};
     }
 

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -73,9 +73,19 @@ deserializeTxPlusMeta(data::TransactionAndMetadata const& blobs, std::uint32_t s
 std::pair<boost::json::object, boost::json::object>
 toExpandedJson(
     data::TransactionAndMetadata const& blobs,
+    uint32_t apiVersion,
     NFTokenjson nftEnabled = NFTokenjson::DISABLE,
     std::optional<uint16_t> networkId = std::nullopt
 );
+
+/**
+ * @brief Add "DeliverMax" which is the alias of "Amount" for "Payment" transaction. Remove the "Amount" field when
+ * version is greater than 1
+ * @param txJson The transaction json object
+ * @param apiVersion The api version
+ */
+void
+insertDeliverMaxAlias(boost::json::object& txJson, uint32_t apiVersion);
 
 bool
 insertDeliveredAmount(

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -79,8 +79,8 @@ toExpandedJson(
 );
 
 /**
- * @brief Add "DeliverMax" which is the alias of "Amount" for "Payment" transaction. Remove the "Amount" field when
- * version is greater than 1
+ * @brief Add "DeliverMax" which is the alias of "Amount" for "Payment" transaction to transaction json. Remove the
+ * "Amount" field when version is greater than 1
  * @param txJson The transaction json object
  * @param apiVersion The api version
  */

--- a/src/rpc/RPCHelpers.h
+++ b/src/rpc/RPCHelpers.h
@@ -73,7 +73,7 @@ deserializeTxPlusMeta(data::TransactionAndMetadata const& blobs, std::uint32_t s
 std::pair<boost::json::object, boost::json::object>
 toExpandedJson(
     data::TransactionAndMetadata const& blobs,
-    uint32_t apiVersion,
+    std::uint32_t apiVersion,
     NFTokenjson nftEnabled = NFTokenjson::DISABLE,
     std::optional<uint16_t> networkId = std::nullopt
 );
@@ -85,7 +85,7 @@ toExpandedJson(
  * @param apiVersion The api version
  */
 void
-insertDeliverMaxAlias(boost::json::object& txJson, uint32_t apiVersion);
+insertDeliverMaxAlias(boost::json::object& txJson, std::uint32_t apiVersion);
 
 bool
 insertDeliveredAmount(

--- a/src/rpc/handlers/AccountTx.cpp
+++ b/src/rpc/handlers/AccountTx.cpp
@@ -165,7 +165,7 @@ AccountTxHandler::process(AccountTxHandler::Input input, Context const& ctx) con
 
         boost::json::object obj;
         if (!input.binary) {
-            auto [txn, meta] = toExpandedJson(txnPlusMeta, NFTokenjson::ENABLE);
+            auto [txn, meta] = toExpandedJson(txnPlusMeta, ctx.apiVersion, NFTokenjson::ENABLE);
             obj[JS(meta)] = std::move(meta);
             obj[JS(tx)] = std::move(txn);
 

--- a/src/rpc/handlers/Ledger.cpp
+++ b/src/rpc/handlers/Ledger.cpp
@@ -67,7 +67,7 @@ LedgerHandler::process(LedgerHandler::Input input, Context const& ctx) const
                 [&](auto obj) {
                     boost::json::object entry;
                     if (!input.binary) {
-                        auto [txn, meta] = toExpandedJson(obj);
+                        auto [txn, meta] = toExpandedJson(obj, ctx.apiVersion);
                         entry = std::move(txn);
                         entry[JS(metaData)] = std::move(meta);
                     } else {

--- a/src/rpc/handlers/NFTHistory.cpp
+++ b/src/rpc/handlers/NFTHistory.cpp
@@ -106,7 +106,7 @@ NFTHistoryHandler::process(NFTHistoryHandler::Input input, Context const& ctx) c
         boost::json::object obj;
 
         if (!input.binary) {
-            auto [txn, meta] = toExpandedJson(txnPlusMeta);
+            auto [txn, meta] = toExpandedJson(txnPlusMeta, ctx.apiVersion);
             obj[JS(meta)] = std::move(meta);
             obj[JS(tx)] = std::move(txn);
             obj[JS(tx)].as_object()[JS(ledger_index)] = txnPlusMeta.ledgerSequence;

--- a/src/rpc/handlers/TransactionEntry.cpp
+++ b/src/rpc/handlers/TransactionEntry.cpp
@@ -47,7 +47,7 @@ TransactionEntryHandler::process(TransactionEntryHandler::Input input, Context c
         return Error{Status{RippledError::rpcTXN_NOT_FOUND, "transactionNotFound", "Transaction not found."}};
 
     auto output = TransactionEntryHandler::Output{};
-    auto [txn, meta] = toExpandedJson(*dbRet);
+    auto [txn, meta] = toExpandedJson(*dbRet, ctx.apiVersion);
 
     output.tx = std::move(txn);
     output.metadata = std::move(meta);

--- a/src/rpc/handlers/Tx.h
+++ b/src/rpc/handlers/Tx.h
@@ -141,7 +141,7 @@ public:
             return Error{Status{RippledError::rpcTXN_NOT_FOUND}};
         }
 
-        auto const [txn, meta] = toExpandedJson(*dbResponse, NFTokenjson::ENABLE, currentNetId);
+        auto const [txn, meta] = toExpandedJson(*dbResponse, ctx.apiVersion, NFTokenjson::ENABLE, currentNetId);
 
         if (!input.binary) {
             output.tx = txn;

--- a/unittests/rpc/RPCHelpersTests.cpp
+++ b/unittests/rpc/RPCHelpersTests.cpp
@@ -24,6 +24,8 @@
 #include <boost/json.hpp>
 #include <fmt/core.h>
 
+#include <array>
+#include <string>
 #include <variant>
 
 using namespace rpc;
@@ -341,43 +343,54 @@ TEST_F(RPCHelpersTest, DecodeInvalidCTID)
 
 TEST_F(RPCHelpersTest, DeliverMaxAliasV1)
 {
-    // add alias for payment
-    auto req = boost::json::parse(
-                   R"({
-                        "TransactionType": "Payment",
-                        "Amount": {
-                            "test": "test"
-                        }
-                    })"
-    )
-                   .as_object();
+    std::array<std::string, 3> const inputArray = {
+        R"({
+            "TransactionType": "Payment",
+            "Amount": {
+                "test": "test"
+            }
+        })",
+        R"({
+            "TransactionType": "OfferCreate",
+            "Amount": {
+                "test": "test"
+            }
+        })",
+        R"({
+            "TransactionType": "Payment",
+            "Amount1": {
+                "test": "test"
+            }
+        })"};
 
-    insertDeliverMaxAlias(req, 1);
-    EXPECT_EQ(
-        req,
-        boost::json::parse(
-            R"({
-                "TransactionType": "Payment",
-                "Amount": {
-                    "test": "test"
-                },
-                "DeliverMax": {
-                    "test": "test"
-                }
-            })"
-        )
-    );
+    std::array<std::string, 3> outputArray = {
+        R"({
+            "TransactionType": "Payment",
+            "Amount": {
+                "test": "test"
+            },
+            "DeliverMax": {
+                "test": "test"
+            }
+        })",
+        R"({
+            "TransactionType": "OfferCreate",
+            "Amount": {
+                "test": "test"
+            }
+        })",
+        R"({
+            "TransactionType": "Payment",
+            "Amount1": {
+                "test": "test"
+            }
+        })"};
 
-    // not add alias for other tx
-    auto constexpr static str = R"({
-                    "TransactionType": "OfferCreate",
-                    "Amount": {
-                        "test": "test"
-                    }
-                })";
-    req = boost::json::parse(str).as_object();
-    insertDeliverMaxAlias(req, 1);
-    EXPECT_EQ(req, boost::json::parse(str));
+    for (size_t i = 0; i < inputArray.size(); i++) {
+        auto req = boost::json::parse(inputArray[i]).as_object();
+        insertDeliverMaxAlias(req, 1);
+        EXPECT_EQ(req, boost::json::parse(outputArray[i]).as_object());
+    }
 }
 
 TEST_F(RPCHelpersTest, DeliverMaxAliasV2)

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -1714,6 +1714,7 @@ generateTransactionTypeTestValues()
                     "tx": {
                         "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                         "Amount": "1",
+                        "DeliverMax": "1",
                         "Destination": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
                         "Fee": "1",
                         "Sequence": 32,
@@ -1763,7 +1764,7 @@ generateTransactionTypeTestValues()
                 },
                 "tx": {
                     "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
-                    "Amount": "1",
+                    "DeliverMax": "1",
                     "Destination": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
                     "Fee": "1",
                     "Sequence": 32,

--- a/unittests/rpc/handlers/LedgerTests.cpp
+++ b/unittests/rpc/handlers/LedgerTests.cpp
@@ -468,6 +468,7 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinary)
                     {
                         "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                         "Amount":"100",
+                        "DeliverMax":"100",
                         "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
                         "Fee":"3",
                         "Sequence":30,
@@ -695,6 +696,7 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsEmtpy)
                     {
                         "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
                         "Amount":"100",
+                        "DeliverMax":"100",
                         "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
                         "Fee":"3",
                         "Sequence":30,


### PR DESCRIPTION
Fix #973
'Amount' maybe misleading for partial payment transaction.
-This PR add an alias for 'Amount' -> 'DeliverMax'. 
-For version 2, remove 'Amount' field
This change is only for 'Payment' transaction.

The affected API:
- tx 
- transaction_entry
- account_tx
- ledger

The remaining work:
- subscribe
 Currently subscription does not support api_version. We will solve it in separate [PR](https://github.com/XRPLF/clio/issues/978) . 