### PR TITLE
"DeliverMax" alias for Payment tx in subscription streams

### DIFF
--- a/src/feed/SubscriptionManager.cpp
+++ b/src/feed/SubscriptionManager.cpp
@@ -174,6 +174,8 @@ SubscriptionManager::pubTransaction(data::TransactionAndMetadata const& blobs, r
     pubObj["transaction"] = rpc::toJson(*tx);
     pubObj["meta"] = rpc::toJson(*meta);
     rpc::insertDeliveredAmount(pubObj["meta"].as_object(), tx, meta, blobs.date);
+    // hardcode api_version to 1 for now, until https://github.com/XRPLF/clio/issues/978 fixed
+    rpc::insertDeliverMaxAlias(pubObj["transaction"].as_object(), 1);
     pubObj["type"] = "transaction";
     pubObj["validated"] = true;
     pubObj["status"] = "closed";

--- a/unittests/SubscriptionManagerTests.cpp
+++ b/unittests/SubscriptionManagerTests.cpp
@@ -397,6 +397,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerTransaction)
         "transaction":{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount":"1",
+            "DeliverMax":"1",
             "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "Fee":"1",
             "Sequence":32,
@@ -636,6 +637,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerAccount)
         "transaction":{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount":"1",
+            "DeliverMax":"1",
             "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "Fee":"1",
             "Sequence":32,
@@ -695,6 +697,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "transaction":{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount":"1",
+            "DeliverMax":"1",
             "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "Fee":"1",
             "Sequence":32,
@@ -752,6 +755,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "transaction":{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount":"1",
+            "DeliverMax":"1",
             "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "Fee":"1",
             "Sequence":32,
@@ -795,6 +799,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "transaction":{
             "Account":"rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "Amount":"1",
+            "DeliverMax":"1",
             "Destination":"rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun",
             "Fee":"1",
             "Sequence":32,


### PR DESCRIPTION
Following #979 
There are 3 places having payment tx json:
transaction stream
accounts stream
orderbook stream

This PR is adding "DeliverMax" there. "api_version" has not been supported for subscription, thus hardcode the version for now.
I was thinking to support api_version for subscription in this PR, but it seems like a big change. We will implement it in the upcoming redesign task.