### PR TITLE
Add close_time_iso to transaction stream

### DIFF
--- a/src/feed/SubscriptionManager.cpp
+++ b/src/feed/SubscriptionManager.cpp
@@ -201,25 +201,26 @@ SubscriptionManager::pubTransaction(data::TransactionAndMetadata const& blobs, r
 {
     auto [tx, meta] = rpc::deserializeTxPlusMeta(blobs, lgrInfo.seq);
     boost::json::object pubObj;
-    pubObj["transaction"] = rpc::toJson(*tx);
-    pubObj["meta"] = rpc::toJson(*meta);
-    rpc::insertDeliveredAmount(pubObj["meta"].as_object(), tx, meta, blobs.date);
+    pubObj[JS(transaction)] = rpc::toJson(*tx);
+    pubObj[JS(meta)] = rpc::toJson(*meta);
+    rpc::insertDeliveredAmount(pubObj[JS(meta)].as_object(), tx, meta, blobs.date);
     // hardcode api_version to 1 for now, until https://github.com/XRPLF/clio/issues/978 fixed
-    rpc::insertDeliverMaxAlias(pubObj["transaction"].as_object(), 1);
-    pubObj["type"] = "transaction";
-    pubObj["validated"] = true;
-    pubObj["status"] = "closed";
+    rpc::insertDeliverMaxAlias(pubObj[JS(transaction)].as_object(), 1);
+    pubObj[JS(type)] = "transaction";
+    pubObj[JS(validated)] = true;
+    pubObj[JS(status)] = "closed";
+    pubObj[JS(close_time_iso)] = ripple::to_string_iso(lgrInfo.closeTime);
 
-    pubObj["ledger_index"] = lgrInfo.seq;
-    pubObj["ledger_hash"] = ripple::strHex(lgrInfo.hash);
-    pubObj["transaction"].as_object()["date"] = lgrInfo.closeTime.time_since_epoch().count();
+    pubObj[JS(ledger_index)] = lgrInfo.seq;
+    pubObj[JS(ledger_hash)] = ripple::strHex(lgrInfo.hash);
+    pubObj[JS(transaction)].as_object()[JS(date)] = lgrInfo.closeTime.time_since_epoch().count();
 
-    pubObj["engine_result_code"] = meta->getResult();
+    pubObj[JS(engine_result_code)] = meta->getResult();
     std::string token;
     std::string human;
     ripple::transResultInfo(meta->getResultTER(), token, human);
-    pubObj["engine_result"] = token;
-    pubObj["engine_result_message"] = human;
+    pubObj[JS(engine_result)] = token;
+    pubObj[JS(engine_result_message)] = human;
     if (tx->getTxnType() == ripple::ttOFFER_CREATE) {
         auto account = tx->getAccountID(ripple::sfAccount);
         auto amount = tx->getFieldAmount(ripple::sfTakerGets);
@@ -233,7 +234,7 @@ SubscriptionManager::pubTransaction(data::TransactionAndMetadata const& blobs, r
 
             data::retryOnTimeout(fetchFundsSynchronous);
 
-            pubObj["transaction"].as_object()["owner_funds"] = ownerFunds.getText();
+            pubObj[JS(transaction)].as_object()[JS(owner_funds)] = ownerFunds.getText();
         }
     }
 

--- a/unittests/SubscriptionManagerTests.cpp
+++ b/unittests/SubscriptionManagerTests.cpp
@@ -440,6 +440,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerTransaction)
         "validated":true,
         "status":"closed",
         "ledger_index":33,
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
         "engine_result":"tesSUCCESS",
@@ -511,6 +512,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerTransactionOffer
         "ledger_index":33,
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "engine_result":"tesSUCCESS",
         "engine_result_message":"The transaction was applied. Only final in a validated ledger."
     })";
@@ -543,6 +545,7 @@ constexpr static auto TransactionForOwnerFundFrozen = R"({
     "validated":true,
     "status":"closed",
     "ledger_index":33,
+    "close_time_iso": "2000-01-01T00:00:00Z",
     "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
     "engine_result_code":0,
     "engine_result":"tesSUCCESS",
@@ -691,6 +694,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerAccount)
         "ledger_index":33,
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "engine_result":"tesSUCCESS",
         "engine_result_message":"The transaction was applied. Only final in a validated ledger."
     })";
@@ -765,6 +769,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
         "engine_result":"tesSUCCESS",
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "engine_result_message":"The transaction was applied. Only final in a validated ledger."
     })";
     CheckSubscriberMessage(OrderbookPublish, session);
@@ -815,6 +820,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
         "engine_result":"tesSUCCESS",
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "engine_result_message":"The transaction was applied. Only final in a validated ledger."
     })";
     CheckSubscriberMessage(OrderbookCancelPublish, session1);
@@ -859,6 +865,7 @@ TEST_F(SubscriptionManagerSimpleBackendTest, SubscriptionManagerOrderBook)
         "ledger_hash":"1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC",
         "engine_result_code":0,
         "engine_result":"tesSUCCESS",
+        "close_time_iso": "2000-01-01T00:00:00Z",
         "engine_result_message":"The transaction was applied. Only final in a validated ledger."
     })";
     std::shared_ptr<web::ConnectionBase> const session2 = std::make_shared<MockSession>(tagDecoratorFactory);


### PR DESCRIPTION
Fix #1011 
close_time_iso usually only appears when api_version is larger than 1. Transaction stream is an exception. close_time_iso will be always present no matter api_version.
