### PR TITLE
Omit the uri when nft is burned

### DIFF
--- a/src/rpc/handlers/NFTInfo.cpp
+++ b/src/rpc/handlers/NFTInfo.cpp
@@ -91,15 +91,18 @@ tag_invoke(boost::json::value_from_tag, boost::json::value& jv, NFTInfoHandler::
         {JS(nft_id), output.nftID},
         {JS(ledger_index), output.ledgerIndex},
         {JS(owner), output.owner},
-        {"is_burned", output.isBurned},
+        {JS(is_burned), output.isBurned},
         {JS(flags), output.flags},
         {"transfer_fee", output.transferFee},
         {JS(issuer), output.issuer},
-        {"nft_taxon", output.taxon},
+        {JS(nft_taxon), output.taxon},
         {JS(nft_serial), output.serial},
         {JS(validated), output.validated},
-        {JS(uri), output.uri},
     };
+
+    // Omitted if the NFT is burned at this ledger.
+    if (not output.isBurned)
+        jv.as_object()[JS(uri)] = output.uri;
 }
 
 NFTInfoHandler::Input

--- a/unittests/rpc/handlers/NFTInfoTests.cpp
+++ b/unittests/rpc/handlers/NFTInfoTests.cpp
@@ -367,7 +367,6 @@ TEST_F(RPCNFTInfoHandlerTest, BurnedNFT)
         "issuer": "rGJUF4PvVkMNxG6Bg6AKg3avhrtQyAffcm",
         "nft_taxon": 0,
         "nft_serial": 4,
-        "uri": "757269",
         "validated": true
     })";
     MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());


### PR DESCRIPTION
According to the doc, the uri should be omitted if nft has been burned. 

https://xrpl.org/nft_info.html#nft_info