### PR TITLE
Simplify backend mock access for unittests

### DIFF
--- a/src/data/BackendFactory.h
+++ b/src/data/BackendFactory.h
@@ -55,10 +55,8 @@ make_Backend(util::Config const& config)
         throw std::runtime_error("Invalid database type");
 
     auto const rng = backend->hardFetchLedgerRangeNoThrow();
-    if (rng) {
-        backend->updateRange(rng->minSequence);
-        backend->updateRange(rng->maxSequence);
-    }
+    if (rng)
+        backend->setRange(rng->minSequence, rng->maxSequence);
 
     LOG(log.info()) << "Constructed BackendInterface Successfully";
     return backend;

--- a/src/data/BackendInterface.cpp
+++ b/src/data/BackendInterface.cpp
@@ -270,6 +270,13 @@ BackendInterface::updateRange(uint32_t newMax)
     }
 }
 
+void
+BackendInterface::setRange(uint32_t min, uint32_t max)
+{
+    std::scoped_lock const lck(rngMtx_);
+    range = {min, max};
+}
+
 LedgerPage
 BackendInterface::fetchLedgerPage(
     std::optional<ripple::uint256> const& cursor,

--- a/src/data/BackendInterface.cpp
+++ b/src/data/BackendInterface.cpp
@@ -271,9 +271,15 @@ BackendInterface::updateRange(uint32_t newMax)
 }
 
 void
-BackendInterface::setRange(uint32_t min, uint32_t max)
+BackendInterface::setRange(uint32_t min, uint32_t max, bool force)
 {
     std::scoped_lock const lck(rngMtx_);
+
+    if (!force) {
+        ASSERT(min <= max, "Range min must be less than or equal to max");
+        ASSERT(not range.has_value(), "Range was already set");
+    }
+
     range = {min, max};
 }
 

--- a/src/data/BackendInterface.h
+++ b/src/data/BackendInterface.h
@@ -196,6 +196,7 @@ public:
      *
      * @param min The new minimum sequence available
      * @param max The new maximum sequence available
+     * @param force If set to true, the range will be set even if it's already set
      */
     void
     setRange(uint32_t min, uint32_t max, bool force = false);

--- a/src/data/BackendInterface.h
+++ b/src/data/BackendInterface.h
@@ -192,6 +192,17 @@ public:
     updateRange(uint32_t newMax);
 
     /**
+     * @brief Sets the range of sequences that are stored in the DB.
+     *
+     * Warning: Use responsibly (for testing purposes).
+     *
+     * @param min The new minimum sequence available
+     * @param max The new maximum sequence available
+     */
+    void
+    setRange(uint32_t min, uint32_t max);
+
+    /**
      * @brief Fetch the fees from a specific ledger sequence.
      *
      * @param seq The sequence to fetch for

--- a/src/data/BackendInterface.h
+++ b/src/data/BackendInterface.h
@@ -194,13 +194,11 @@ public:
     /**
      * @brief Sets the range of sequences that are stored in the DB.
      *
-     * Warning: Use responsibly (for testing purposes).
-     *
      * @param min The new minimum sequence available
      * @param max The new maximum sequence available
      */
     void
-    setRange(uint32_t min, uint32_t max);
+    setRange(uint32_t min, uint32_t max, bool force = false);
 
     /**
      * @brief Fetch the fees from a specific ledger sequence.

--- a/unittests/etl/TransformerTests.cpp
+++ b/unittests/etl/TransformerTests.cpp
@@ -92,7 +92,7 @@ TEST_F(ETLTransformerTest, StopsOnWriteConflict)
     EXPECT_CALL(ledgerPublisher_, publish(_)).Times(0);
 
     transformer_ = std::make_unique<TransformerType>(
-        dataPipe_, mockBackendPtr, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
+        dataPipe_, backend, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
     );
 
     transformer_->waitTillFinished();  // explicitly joins the thread
@@ -100,9 +100,7 @@ TEST_F(ETLTransformerTest, StopsOnWriteConflict)
 
 TEST_F(ETLTransformerTest, StopsOnEmptyFetchResponse)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->cache().setFull();  // to avoid throwing exception in updateCache
+    backend->cache().setFull();  // to avoid throwing exception in updateCache
 
     auto const blob = hexStringToBinaryString(RAW_HEADER);
     auto const response = std::make_optional<FakeFetchResponse>(blob);
@@ -112,21 +110,21 @@ TEST_F(ETLTransformerTest, StopsOnEmptyFetchResponse)
             return std::nullopt;
         return response;  // NOLINT (performance-no-automatic-move)
     });
-    ON_CALL(*rawBackendPtr, doFinishWrites).WillByDefault(Return(true));
+    ON_CALL(*backend, doFinishWrites).WillByDefault(Return(true));
 
     // TODO: most of this should be hidden in a smaller entity that is injected into the transformer thread
     EXPECT_CALL(dataPipe_, popNext).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, startWrites).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeLedger(_, _)).Times(AtLeast(1));
+    EXPECT_CALL(*backend, startWrites).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeLedger(_, _)).Times(AtLeast(1));
     EXPECT_CALL(ledgerLoader_, insertTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeAccountTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeNFTs).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeNFTTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, doFinishWrites).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeAccountTransactions).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeNFTs).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeNFTTransactions).Times(AtLeast(1));
+    EXPECT_CALL(*backend, doFinishWrites).Times(AtLeast(1));
     EXPECT_CALL(ledgerPublisher_, publish(_)).Times(AtLeast(1));
 
     transformer_ = std::make_unique<TransformerType>(
-        dataPipe_, mockBackendPtr, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
+        dataPipe_, backend, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
     );
 
     // after 10ms we start spitting out empty responses which means the extractor is finishing up
@@ -137,31 +135,29 @@ TEST_F(ETLTransformerTest, StopsOnEmptyFetchResponse)
 
 TEST_F(ETLTransformerTest, DoesNotPublishIfCanNotBuildNextLedger)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->cache().setFull();  // to avoid throwing exception in updateCache
+    backend->cache().setFull();  // to avoid throwing exception in updateCache
 
     auto const blob = hexStringToBinaryString(RAW_HEADER);
     auto const response = std::make_optional<FakeFetchResponse>(blob);
 
     ON_CALL(dataPipe_, popNext).WillByDefault(Return(response));
-    ON_CALL(*rawBackendPtr, doFinishWrites).WillByDefault(Return(false));  // emulate write failure
+    ON_CALL(*backend, doFinishWrites).WillByDefault(Return(false));  // emulate write failure
 
     // TODO: most of this should be hidden in a smaller entity that is injected into the transformer thread
     EXPECT_CALL(dataPipe_, popNext).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, startWrites).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeLedger(_, _)).Times(AtLeast(1));
+    EXPECT_CALL(*backend, startWrites).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeLedger(_, _)).Times(AtLeast(1));
     EXPECT_CALL(ledgerLoader_, insertTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeAccountTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeNFTs).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, writeNFTTransactions).Times(AtLeast(1));
-    EXPECT_CALL(*rawBackendPtr, doFinishWrites).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeAccountTransactions).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeNFTs).Times(AtLeast(1));
+    EXPECT_CALL(*backend, writeNFTTransactions).Times(AtLeast(1));
+    EXPECT_CALL(*backend, doFinishWrites).Times(AtLeast(1));
 
     // should not call publish
     EXPECT_CALL(ledgerPublisher_, publish(_)).Times(0);
 
     transformer_ = std::make_unique<TransformerType>(
-        dataPipe_, mockBackendPtr, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
+        dataPipe_, backend, ledgerLoader_, ledgerPublisher_, amendmentBlockHandler_, 0, state_
     );
 }
 

--- a/unittests/rpc/ForwardingProxyTests.cpp
+++ b/unittests/rpc/ForwardingProxyTests.cpp
@@ -71,7 +71,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfClioOnly)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -91,7 +91,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfProxied)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -111,7 +111,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfCurrentLedgerSpecified)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -131,7 +131,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfClosedLedgerSpecified)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -151,7 +151,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfAccountInfoWithQueueSpe
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -171,7 +171,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfLedgerWithQueueSpecifie
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -191,7 +191,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfLedgerWithFullSpecified
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -211,7 +211,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsTrueIfLedgerWithAccountsSpeci
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -231,7 +231,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfAccountInfoQueueIsFals
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -251,7 +251,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfLedgerQueueIsFalse)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -271,7 +271,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfLedgerFullIsFalse)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -291,7 +291,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfLedgerAccountsIsFalse)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -311,7 +311,7 @@ TEST_F(RPCForwardingProxyTest, ShouldNotForwardReturnsTrueIfAPIVersionIsV1)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -331,7 +331,7 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfAPIVersionIsV2)
     EXPECT_CALL(*rawHandlerProviderPtr, isClioOnly(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -347,7 +347,7 @@ TEST_F(RPCForwardingProxyTest, ShouldNeverForwardSubscribe)
     auto const params = json::parse("{}");
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -363,7 +363,7 @@ TEST_F(RPCForwardingProxyTest, ShouldNeverForwardUnsubscribe)
     auto const params = json::parse("{}");
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -392,7 +392,7 @@ TEST_F(RPCForwardingProxyTest, ForwardCallsBalancerWithCorrectParams)
     EXPECT_CALL(counters, rpcForwarded(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 
@@ -423,7 +423,7 @@ TEST_F(RPCForwardingProxyTest, ForwardingFailYieldsErrorStatus)
     EXPECT_CALL(counters, rpcFailedToForward(method)).Times(1);
 
     runSpawn([&](auto yield) {
-        auto const range = mockBackendPtr->fetchLedgerRange();
+        auto const range = backend->fetchLedgerRange();
         auto const ctx =
             web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
 

--- a/unittests/rpc/handlers/AccountChannelsTests.cpp
+++ b/unittests/rpc/handlers/AccountChannelsTests.cpp
@@ -56,7 +56,7 @@ class RPCAccountChannelsHandlerTest : public HandlerBaseTest {};
 TEST_F(RPCAccountChannelsHandlerTest, LimitNotInt)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -75,7 +75,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitNotInt)
 TEST_F(RPCAccountChannelsHandlerTest, LimitNagetive)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -94,7 +94,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitNagetive)
 TEST_F(RPCAccountChannelsHandlerTest, LimitZero)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -113,7 +113,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitZero)
 TEST_F(RPCAccountChannelsHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -134,7 +134,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonHexLedgerHash)
 TEST_F(RPCAccountChannelsHandlerTest, NonStringLedgerHash)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{
                 "account": "{}", 
@@ -155,7 +155,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonStringLedgerHash)
 TEST_F(RPCAccountChannelsHandlerTest, InvalidLedgerIndexString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -176,7 +176,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidLedgerIndexString)
 TEST_F(RPCAccountChannelsHandlerTest, MarkerNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -199,7 +199,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerNotString)
 TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}",
@@ -215,7 +215,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
         EXPECT_EQ(err.at("error_message").as_string(), "Malformed cursor.");
     });
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -235,7 +235,7 @@ TEST_F(RPCAccountChannelsHandlerTest, InvalidMarker)
 TEST_F(RPCAccountChannelsHandlerTest, AccountInvalidFormat)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(R"({ 
             "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jp"
         })");
@@ -251,7 +251,7 @@ TEST_F(RPCAccountChannelsHandlerTest, AccountInvalidFormat)
 TEST_F(RPCAccountChannelsHandlerTest, AccountNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(R"({ 
             "account": 12
         })");
@@ -267,12 +267,10 @@ TEST_F(RPCAccountChannelsHandlerTest, AccountNotString)
 // error case ledger non exist via hash
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
     // mock fetchLedgerByHash return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -283,7 +281,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
@@ -296,13 +294,10 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -311,7 +306,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -322,13 +317,10 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
                 "account": "{}",
@@ -337,7 +329,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -350,14 +342,11 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 31);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -367,7 +356,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -379,13 +368,10 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(0);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -394,7 +380,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -406,16 +392,13 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case account not exist
 TEST_F(RPCAccountChannelsHandlerTest, NonExistAccount)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // fetch account object return emtpy
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{
             "account": "{}",
@@ -425,7 +408,7 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistAccount)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -466,36 +449,34 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
             }
         ]
     })";
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two payment channel objects
     std::vector<Blob> bbs;
     ripple::STObject const channel1 = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
     bbs.push_back(channel1.getSerializer().peekData());
     bbs.push_back(channel1.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -504,7 +485,7 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -514,20 +495,17 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
 // normal case : limit is used
 TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(3);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -542,15 +520,15 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     // it should not appear in return marker,marker is the current page
     ownerDir.setFieldU64(ripple::sfIndexNext, 99);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(7);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(7);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(3);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(3);
 
     runSpawn([this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}",
@@ -566,7 +544,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -579,7 +557,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountChannelsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountChannelsHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -595,20 +573,17 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
 // normal case : destination is used
 TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -631,12 +606,12 @@ TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
     }
 
     ripple::STObject const ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -648,7 +623,7 @@ TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
         ACCOUNT3
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 20);
@@ -658,27 +633,24 @@ TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
 // normal case : but the lines is emtpy
 TEST_F(RPCAccountChannelsHandlerTest, EmptyChannel)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     ripple::STObject const ownerDir = CreateOwnerDirLedgerObject({}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}"
@@ -686,7 +658,7 @@ TEST_F(RPCAccountChannelsHandlerTest, EmptyChannel)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 0);
@@ -733,28 +705,26 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
             }
         ]
     })";
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two payment channel objects
     std::vector<Blob> bbs;
@@ -765,8 +735,8 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
     channel1.setFieldU32(ripple::sfDestinationTag, 400);
     bbs.push_back(channel1.getSerializer().peekData());
     bbs.push_back(channel1.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}"
@@ -774,7 +744,7 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -784,10 +754,7 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
 // normal case : test marker output correct
 TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto ownerDirKk = ripple::keylet::ownerDir(account).key;
@@ -795,12 +762,12 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
     constexpr static auto limit = 15;
     auto ownerDir2Kk = ripple::keylet::page(ripple::keylet::ownerDir(account), nextPage).key;
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto fake = Blob{'f', 'a', 'k', 'e'};
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     std::vector<Blob> bbs;
     ripple::STObject const channel1 = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -822,16 +789,16 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     ownerDir.setFieldU64(ripple::sfIndexNext, nextPage);
     // first page 's next page is 99
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
     ripple::STObject ownerDir2 = CreateOwnerDirLedgerObject(indexes, INDEX1);
     // second page's next page is 0
     ownerDir2.setFieldU64(ripple::sfIndexNext, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDir2Kk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDir2Kk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir2.getSerializer().peekData()));
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{ 
@@ -842,7 +809,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
         limit
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("marker").as_string().c_str(), fmt::format("{},{}", INDEX1, nextPage));
@@ -853,22 +820,19 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
 // normal case : handler marker correctly
 TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     constexpr static auto nextPage = 99;
     constexpr static auto limit = 15;
     auto ownerDirKk = ripple::keylet::page(ripple::keylet::ownerDir(account), nextPage).key;
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto fake = Blob{'f', 'a', 'k', 'e'};
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     std::vector<Blob> bbs;
     ripple::STObject const channel1 = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -883,11 +847,11 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     ownerDir.setFieldU64(ripple::sfIndexNext, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{ 
@@ -901,7 +865,7 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
         nextPage
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE((*output).as_object().if_contains("marker") == nullptr);
@@ -913,36 +877,33 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 
 TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two payment channel objects
     std::vector<Blob> bbs;
     ripple::STObject const channel1 = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
     bbs.push_back(channel1.getSerializer().peekData());
     bbs.push_back(channel1.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -953,7 +914,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
         AccountChannelsHandler::LIMIT_MIN - 1
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 2);
@@ -963,36 +924,33 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCAccountChannelsHandlerTest, LimitMoreThanMax)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two payment channel objects
     std::vector<Blob> bbs;
     ripple::STObject const channel1 = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
     bbs.push_back(channel1.getSerializer().peekData());
     bbs.push_back(channel1.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -1003,7 +961,7 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitMoreThanMax)
         AccountChannelsHandler::LIMIT_MAX + 1
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountChannelsHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountChannelsHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("channels").as_array().size(), 2);

--- a/unittests/rpc/handlers/AccountCurrenciesTests.cpp
+++ b/unittests/rpc/handlers/AccountCurrenciesTests.cpp
@@ -53,16 +53,13 @@ class RPCAccountCurrenciesHandlerTest : public HandlerBaseTest {};
 
 TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -70,7 +67,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -82,13 +79,10 @@ TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    backend->setRange(10, 30);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -96,7 +90,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaIntSequence)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -109,13 +103,11 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaIntSequence)
 TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
 {
     auto constexpr seq = 12;
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+
+    backend->setRange(10, 30);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(12, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    ON_CALL(*backend, fetchLedgerBySequence(12, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -125,7 +117,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
         ACCOUNT,
         seq
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -137,13 +129,10 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    backend->setRange(10, 30);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
@@ -154,7 +143,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaHash)
         ACCOUNT,
         LEDGERHASH
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -179,24 +168,22 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
             "USD"
         ]
     })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(30, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(ledgerinfo));
     // return valid account
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}, ripple::uint256{INDEX2}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // ACCOUNT can receive USD 10 from ACCOUNT2 and send USD 20 to ACCOUNT2, now
     // the balance is 100, ACCOUNT can only send USD to ACCOUNT2
@@ -212,15 +199,15 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
     bbs.push_back(line2.getSerializer().peekData());
     bbs.push_back(line3.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
     auto static const input = json::parse(fmt::format(
         R"({{
             "account":"{}"
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -230,29 +217,26 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
     // return valid account
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
     auto static const input = json::parse(fmt::format(
         R"({{
             "account":"{}",
@@ -261,7 +245,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
         ACCOUNT,
         LEDGERHASH
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -270,31 +254,27 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderSeq)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto const ledgerSeq = 29;
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, ledgerSeq);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(ledgerSeq, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(ledgerSeq, _)).WillByDefault(Return(ledgerinfo));
     // return valid account
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, ledgerSeq, _))
-        .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, ledgerSeq, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, ledgerSeq, _))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, ledgerSeq, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
     auto static const input = json::parse(fmt::format(
         R"({{
             "account":"{}",
@@ -303,7 +283,7 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderSeq)
         ACCOUNT,
         ledgerSeq
     ));
-    auto const handler = AnyHandler{AccountCurrenciesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountCurrenciesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/AccountLinesTests.cpp
+++ b/unittests/rpc/handlers/AccountLinesTests.cpp
@@ -62,7 +62,7 @@ class RPCAccountLinesHandlerTest : public HandlerBaseTest {};
 TEST_F(RPCAccountLinesHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -83,7 +83,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonHexLedgerHash)
 TEST_F(RPCAccountLinesHandlerTest, NonStringLedgerHash)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{
                 "account": "{}", 
@@ -104,7 +104,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonStringLedgerHash)
 TEST_F(RPCAccountLinesHandlerTest, InvalidLedgerIndexString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -125,7 +125,7 @@ TEST_F(RPCAccountLinesHandlerTest, InvalidLedgerIndexString)
 TEST_F(RPCAccountLinesHandlerTest, MarkerNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -148,7 +148,7 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerNotString)
 TEST_F(RPCAccountLinesHandlerTest, InvalidMarker)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}",
@@ -164,7 +164,7 @@ TEST_F(RPCAccountLinesHandlerTest, InvalidMarker)
         EXPECT_EQ(err.at("error_message").as_string(), "Malformed cursor.");
     });
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -184,7 +184,7 @@ TEST_F(RPCAccountLinesHandlerTest, InvalidMarker)
 TEST_F(RPCAccountLinesHandlerTest, AccountInvalidFormat)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jp"
@@ -202,7 +202,7 @@ TEST_F(RPCAccountLinesHandlerTest, AccountInvalidFormat)
 TEST_F(RPCAccountLinesHandlerTest, AccountNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": 12
@@ -220,7 +220,7 @@ TEST_F(RPCAccountLinesHandlerTest, AccountNotString)
 TEST_F(RPCAccountLinesHandlerTest, PeerInvalidFormat)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -238,7 +238,7 @@ TEST_F(RPCAccountLinesHandlerTest, PeerInvalidFormat)
 TEST_F(RPCAccountLinesHandlerTest, PeerNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -257,7 +257,7 @@ TEST_F(RPCAccountLinesHandlerTest, PeerNotString)
 TEST_F(RPCAccountLinesHandlerTest, LimitNotInt)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -275,7 +275,7 @@ TEST_F(RPCAccountLinesHandlerTest, LimitNotInt)
 TEST_F(RPCAccountLinesHandlerTest, LimitNagetive)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -293,7 +293,7 @@ TEST_F(RPCAccountLinesHandlerTest, LimitNagetive)
 TEST_F(RPCAccountLinesHandlerTest, LimitZero)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(
             R"({ 
                 "account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
@@ -311,12 +311,10 @@ TEST_F(RPCAccountLinesHandlerTest, LimitZero)
 // error case ledger non exist via hash
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
     // mock fetchLedgerByHash return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -327,7 +325,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
@@ -340,13 +338,10 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -355,7 +350,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerStringIndex)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -366,13 +361,10 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -381,7 +373,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIntIndex)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -394,14 +386,11 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 31);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -411,7 +400,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -423,13 +412,10 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // no need to check from db, call fetchLedgerBySequence 0 time
     // differ from previous logic
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(0);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}",
@@ -438,7 +424,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIndex2)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -450,16 +436,13 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case account not exist
 TEST_F(RPCAccountLinesHandlerTest, NonExistAccount)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // fetch account object return emtpy
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{
             "account": "{}",
@@ -469,7 +452,7 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistAccount)
         LEDGERHASH
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -481,28 +464,25 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistAccount)
 // normal case when only provide account
 TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two trust lines
     std::vector<Blob> bbs;
@@ -510,8 +490,8 @@ TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
     auto const line2 = CreateRippleStateLedgerObject("USD", ACCOUNT, 10, ACCOUNT2, 100, ACCOUNT, 200, TXNID, 123);
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(line2.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([this](auto yield) {
         auto const input = json::parse(fmt::format(
@@ -553,7 +533,7 @@ TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
                 ]
             })";
 
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -563,20 +543,17 @@ TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
 // normal case : limit is used
 TEST_F(RPCAccountLinesHandlerTest, UseLimit)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(3);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -591,15 +568,15 @@ TEST_F(RPCAccountLinesHandlerTest, UseLimit)
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     // it should not appear in return marker,marker is the current page
     ownerDir.setFieldU64(ripple::sfIndexNext, 99);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(7);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(7);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(3);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(3);
 
     runSpawn([this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}",
@@ -615,7 +592,7 @@ TEST_F(RPCAccountLinesHandlerTest, UseLimit)
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -628,7 +605,7 @@ TEST_F(RPCAccountLinesHandlerTest, UseLimit)
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{AccountLinesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountLinesHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "account": "{}", 
@@ -644,20 +621,17 @@ TEST_F(RPCAccountLinesHandlerTest, UseLimit)
 // normal case : destination is used
 TEST_F(RPCAccountLinesHandlerTest, UseDestination)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -680,12 +654,12 @@ TEST_F(RPCAccountLinesHandlerTest, UseDestination)
     }
 
     ripple::STObject const ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -697,7 +671,7 @@ TEST_F(RPCAccountLinesHandlerTest, UseDestination)
         ACCOUNT3
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("lines").as_array().size(), 20);
@@ -707,27 +681,24 @@ TEST_F(RPCAccountLinesHandlerTest, UseDestination)
 // normal case : but the lines is emtpy
 TEST_F(RPCAccountLinesHandlerTest, EmptyChannel)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     ripple::STObject const ownerDir = CreateOwnerDirLedgerObject({}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}"
@@ -735,7 +706,7 @@ TEST_F(RPCAccountLinesHandlerTest, EmptyChannel)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("lines").as_array().size(), 0);
@@ -779,13 +750,11 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
             }
         ]
     })";
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
@@ -793,15 +762,15 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
     auto fake = Blob{'f', 'a', 'k', 'e'};
 
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return few trust lines
     std::vector<Blob> bbs;
@@ -817,8 +786,8 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
     line2.setFlag(ripple::lsfLowFreeze);
     bbs.push_back(line2.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "account": "{}"
@@ -826,7 +795,7 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -836,10 +805,7 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
 // normal case : test marker output correct
 TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto ownerDirKk = ripple::keylet::ownerDir(account).key;
@@ -847,12 +813,12 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
     constexpr static auto limit = 15;
     auto ownerDir2Kk = ripple::keylet::page(ripple::keylet::ownerDir(account), nextPage).key;
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto fake = Blob{'f', 'a', 'k', 'e'};
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     std::vector<Blob> bbs;
     auto line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 0);
@@ -875,16 +841,16 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     ownerDir.setFieldU64(ripple::sfIndexNext, nextPage);
     // first page's next page is 99
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
     ripple::STObject ownerDir2 = CreateOwnerDirLedgerObject(indexes, INDEX1);
     // second page's next page is 0
     ownerDir2.setFieldU64(ripple::sfIndexNext, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDir2Kk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDir2Kk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir2.getSerializer().peekData()));
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{ 
@@ -895,7 +861,7 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
         limit
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ((*output).as_object().at("marker").as_string().c_str(), fmt::format("{},{}", INDEX1, nextPage));
@@ -906,22 +872,19 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
 // normal case : handler marker correctly
 TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     constexpr static auto nextPage = 99;
     constexpr static auto limit = 15;
     auto ownerDirKk = ripple::keylet::page(ripple::keylet::ownerDir(account), nextPage).key;
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto fake = Blob{'f', 'a', 'k', 'e'};
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     std::vector<Blob> bbs;
     auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 0);
@@ -936,11 +899,11 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
 
     ripple::STObject ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
     ownerDir.setFieldU64(ripple::sfIndexNext, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(ownerDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{ 
@@ -954,7 +917,7 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
         nextPage
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_TRUE((*output).as_object().if_contains("marker") == nullptr);
@@ -966,28 +929,25 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
 
 TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two trust lines
     std::vector<Blob> bbs;
@@ -995,8 +955,8 @@ TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
     auto const line2 = CreateRippleStateLedgerObject("USD", ACCOUNT, 10, ACCOUNT2, 100, ACCOUNT, 200, TXNID, 123);
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(line2.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([this](auto yield) {
         auto const input = json::parse(fmt::format(
@@ -1042,7 +1002,7 @@ TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
             AccountLinesHandler::LIMIT_MIN
         );
 
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);
@@ -1051,28 +1011,25 @@ TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCAccountLinesHandlerTest, LimitMoreThanMax)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // fetch account object return something
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto owneDirKk = ripple::keylet::ownerDir(account).key;
     auto fake = Blob{'f', 'a', 'k', 'e'};
     // return a non empty account
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, testing::_, testing::_)).WillByDefault(Return(fake));
 
     // return owner index containing 2 indexes
     ripple::STObject const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(owneDirKk, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     // return two trust lines
     std::vector<Blob> bbs;
@@ -1080,8 +1037,8 @@ TEST_F(RPCAccountLinesHandlerTest, LimitMoreThanMax)
     auto const line2 = CreateRippleStateLedgerObject("USD", ACCOUNT, 10, ACCOUNT2, 100, ACCOUNT, 200, TXNID, 123);
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(line2.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([this](auto yield) {
         auto const input = json::parse(fmt::format(
@@ -1127,7 +1084,7 @@ TEST_F(RPCAccountLinesHandlerTest, LimitMoreThanMax)
             AccountLinesHandler::LIMIT_MAX
         );
 
-        auto handler = AnyHandler{AccountLinesHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{AccountLinesHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(correctOutput), *output);

--- a/unittests/rpc/handlers/AccountNFTsTests.cpp
+++ b/unittests/rpc/handlers/AccountNFTsTests.cpp
@@ -163,7 +163,7 @@ TEST_P(AccountNFTParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountNFTsHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -175,13 +175,10 @@ TEST_P(AccountNFTParameterTest, InvalidParams)
 
 TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
@@ -192,7 +189,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaHash)
         ACCOUNT,
         LEDGERHASH
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -205,13 +202,11 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaHash)
 TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaStringIndex)
 {
     auto constexpr seq = 12;
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -221,7 +216,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaStringIndex)
         ACCOUNT,
         seq
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -234,13 +229,11 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaStringIndex)
 TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
 {
     auto constexpr seq = 12;
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -250,7 +243,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
         ACCOUNT,
         seq
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -262,16 +255,13 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
 
 TEST_F(RPCAccountNFTsHandlerTest, AccountNotFound)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -279,7 +269,7 @@ TEST_F(RPCAccountNFTsHandlerTest, AccountNotFound)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -318,25 +308,23 @@ TEST_F(RPCAccountNFTsHandlerTest, NormalPath)
         TAXON,
         SERIAL
     );
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
 
     auto const accountObject = CreateAccountRootObject(ACCOUNT, 0, 1, 10, 2, TXNID, 3);
     auto const accountID = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
         .WillByDefault(Return(accountObject.getSerializer().peekData()));
 
     auto const firstPage = ripple::keylet::nftpage_max(accountID).key;
     auto const pageObject =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(firstPage, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(firstPage, 30, _))
         .WillByDefault(Return(pageObject.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -344,7 +332,7 @@ TEST_F(RPCAccountNFTsHandlerTest, NormalPath)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -355,25 +343,23 @@ TEST_F(RPCAccountNFTsHandlerTest, NormalPath)
 TEST_F(RPCAccountNFTsHandlerTest, Limit)
 {
     static auto constexpr limit = 20;
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
 
     auto const accountObject = CreateAccountRootObject(ACCOUNT, 0, 1, 10, 2, TXNID, 3);
     auto const accountID = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
         .WillByDefault(Return(accountObject.getSerializer().peekData()));
 
     auto const firstPage = ripple::keylet::nftpage_max(accountID).key;
     auto const pageObject =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, firstPage);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(firstPage, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(firstPage, 30, _))
         .WillByDefault(Return(pageObject.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1 + limit);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1 + limit);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -383,7 +369,7 @@ TEST_F(RPCAccountNFTsHandlerTest, Limit)
         ACCOUNT,
         limit
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -394,24 +380,21 @@ TEST_F(RPCAccountNFTsHandlerTest, Limit)
 
 TEST_F(RPCAccountNFTsHandlerTest, Marker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
 
     auto const accountObject = CreateAccountRootObject(ACCOUNT, 0, 1, 10, 2, TXNID, 3);
     auto const accountID = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
         .WillByDefault(Return(accountObject.getSerializer().peekData()));
 
     auto const pageObject =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAGE}, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{PAGE}, 30, _))
         .WillByDefault(Return(pageObject.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -421,7 +404,7 @@ TEST_F(RPCAccountNFTsHandlerTest, Marker)
         ACCOUNT,
         PAGE
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -459,25 +442,23 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitLessThanMin)
         SERIAL,
         AccountNFTsHandler::LIMIT_MIN
     );
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
 
     auto const accountObject = CreateAccountRootObject(ACCOUNT, 0, 1, 10, 2, TXNID, 3);
     auto const accountID = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
         .WillByDefault(Return(accountObject.getSerializer().peekData()));
 
     auto const firstPage = ripple::keylet::nftpage_max(accountID).key;
     auto const pageObject =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(firstPage, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(firstPage, 30, _))
         .WillByDefault(Return(pageObject.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -487,7 +468,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitLessThanMin)
         ACCOUNT,
         AccountNFTsHandler::LIMIT_MIN - 1
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -525,25 +506,23 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitMoreThanMax)
         SERIAL,
         AccountNFTsHandler::LIMIT_MAX
     );
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
+
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
 
     auto const accountObject = CreateAccountRootObject(ACCOUNT, 0, 1, 10, 2, TXNID, 3);
     auto const accountID = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(accountID).key, 30, _))
         .WillByDefault(Return(accountObject.getSerializer().peekData()));
 
     auto const firstPage = ripple::keylet::nftpage_max(accountID).key;
     auto const pageObject =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(firstPage, 30, _))
+    ON_CALL(*backend, doFetchLedgerObject(firstPage, 30, _))
         .WillByDefault(Return(pageObject.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -553,7 +532,7 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitMoreThanMax)
         ACCOUNT,
         AccountNFTsHandler::LIMIT_MAX + 1
     ));
-    auto const handler = AnyHandler{AccountNFTsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountNFTsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/AccountObjectsTests.cpp
+++ b/unittests/rpc/handlers/AccountObjectsTests.cpp
@@ -188,7 +188,7 @@ TEST_P(AccountObjectsParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountObjectsHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -200,12 +200,9 @@ TEST_P(AccountObjectsParameterTest, InvalidParams)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerinfo
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -214,7 +211,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -226,12 +223,9 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerinfo
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::nullopt));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -240,7 +234,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -252,12 +246,9 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerinfo
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
@@ -268,7 +259,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
         ACCOUNT,
         LEDGERHASH
     ));
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -280,14 +271,11 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
 
 TEST_F(RPCAccountObjectsHandlerTest, AccountNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(std::optional<Blob>{}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -295,7 +283,7 @@ TEST_F(RPCAccountObjectsHandlerTest, AccountNotExist)
         }})",
         ACCOUNT
     ));
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -339,31 +327,27 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
                                             ]
                                         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -372,7 +356,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -382,35 +366,31 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
 
 TEST_F(RPCAccountObjectsHandlerTest, Limit)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     static auto constexpr limit = 10;
     auto count = limit * 2;
     // put 20 items in owner dir, but only return 10
     auto const ownerDir = CreateOwnerDirLedgerObject(std::vector(count, ripple::uint256{INDEX1}), INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     while (count-- != 0) {
         auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
         bbs.push_back(line1.getSerializer().peekData());
     }
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -421,7 +401,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Limit)
         limit
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -432,15 +412,12 @@ TEST_F(RPCAccountObjectsHandlerTest, Limit)
 
 TEST_F(RPCAccountObjectsHandlerTest, Marker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     static auto constexpr limit = 20;
     static auto constexpr page = 2;
@@ -448,7 +425,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
     auto const ownerDir = CreateOwnerDirLedgerObject(std::vector(count, ripple::uint256{INDEX1}), INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(GetAccountIDWithString(ACCOUNT)).key;
     auto const hintIndex = ripple::keylet::page(ownerDirKk, page).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(hintIndex, 30, _))
+    EXPECT_CALL(*backend, doFetchLedgerObject(hintIndex, 30, _))
         .Times(2)
         .WillRepeatedly(Return(ownerDir.getSerializer().peekData()));
 
@@ -457,7 +434,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
         auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
         bbs.push_back(line1.getSerializer().peekData());
     }
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -469,7 +446,7 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
         page
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -480,16 +457,13 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
 
 TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     static auto constexpr count = 10;
     static auto constexpr nextpage = 1;
@@ -499,14 +473,12 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
     ownerDir.setFieldU64(ripple::sfIndexNext, nextpage);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
     auto const page1 = ripple::keylet::page(ownerDirKk, nextpage).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(page1, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(page1, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     // 10 items per page, 2 pages
@@ -515,7 +487,7 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
         auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
         bbs.push_back(line1.getSerializer().peekData());
     }
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -526,7 +498,7 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
         2 * count
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -537,25 +509,21 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     // put 1 state and 1 offer
@@ -573,7 +541,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -583,7 +551,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -593,25 +561,21 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     // put 1 state and 1 amm
@@ -621,7 +585,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
     auto const ammObject = CreateAMMObject(ACCOUNT, "XRP", toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2);
     bbs.push_back(ammObject.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -631,7 +595,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -643,25 +607,21 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
@@ -678,7 +638,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
     bbs.push_back(line1.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -688,7 +648,7 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -698,28 +658,23 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
 
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     auto const line = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     auto const channel = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -739,7 +694,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
     bbs.push_back(channel.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -749,7 +704,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -759,27 +714,22 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     auto const line = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     auto const channel = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -788,7 +738,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
     bbs.push_back(line.getSerializer().peekData());
     bbs.push_back(channel.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -799,7 +749,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -809,27 +759,22 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     auto const offer1 = CreateOfferLedgerObject(
         ACCOUNT,
@@ -856,7 +801,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
     bbs.push_back(offer1.getSerializer().peekData());
     bbs.push_back(offer2.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -866,7 +811,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -876,26 +821,21 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithIncompatibleTypeYieldsEmptyResult)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     auto const offer1 = CreateOfferLedgerObject(
         ACCOUNT,
@@ -922,7 +862,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithIncompatibleT
     bbs.push_back(offer1.getSerializer().peekData());
     bbs.push_back(offer2.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -933,7 +873,7 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithIncompatibleT
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1006,41 +946,35 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
                                             ]
                                         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft page 1
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
     auto const nftPage2KK = ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{INDEX1}).key;
     auto const nftpage1 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, nftPage2KK);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _))
-        .WillOnce(Return(nftpage1.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(nftpage1.getSerializer().peekData()));
 
     // nft page 2 , end
     auto const nftpage2 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftPage2KK, 30, _))
-        .WillOnce(Return(nftpage2.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftPage2KK, 30, _)).WillOnce(Return(nftpage2.getSerializer().peekData()));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1049,7 +983,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1059,16 +993,13 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto current = ripple::keylet::nftpage_max(account).key;
     std::string first{INDEX1};
@@ -1079,8 +1010,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
             ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
         auto const nftpage =
             CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, previous);
-        EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-            .WillOnce(Return(nftpage.getSerializer().peekData()));
+        EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage.getSerializer().peekData()));
         current = previous;
     }
 
@@ -1093,7 +1023,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
         10
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1107,16 +1037,13 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto current = ripple::keylet::nftpage_max(account).key;
     std::string first{INDEX1};
@@ -1127,14 +1054,12 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
             ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
         auto const nftpage =
             CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, previous);
-        EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-            .WillOnce(Return(nftpage.getSerializer().peekData()));
+        EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage.getSerializer().peekData()));
         current = previous;
     }
     auto const nftpage11 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-        .WillOnce(Return(nftpage11.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage11.getSerializer().peekData()));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1145,7 +1070,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
         11
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1160,16 +1085,13 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::string first{INDEX1};
     auto current = ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
@@ -1181,20 +1103,17 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
             ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
         auto const nftpage =
             CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, previous);
-        EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-            .WillOnce(Return(nftpage.getSerializer().peekData()));
+        EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage.getSerializer().peekData()));
         current = previous;
     }
     auto const nftpage11 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-        .WillOnce(Return(nftpage11.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage11.getSerializer().peekData()));
 
     auto const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const line = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     auto const channel = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -1214,7 +1133,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
     bbs.push_back(channel.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1226,7 +1145,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
         std::numeric_limits<uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1238,22 +1157,18 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
 // when limit reached, happen to be the end of NFT page list
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir =
         CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const line = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     auto const channel = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -1273,7 +1188,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
     bbs.push_back(channel.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1285,7 +1200,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
         std::numeric_limits<uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1296,16 +1211,13 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1317,7 +1229,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
         std::numeric_limits<std::uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -1329,20 +1241,17 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     // return null for this marker
     auto const accountNftMax = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountNftMax, MAXSEQ, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountNftMax, MAXSEQ, _)).WillOnce(Return(std::nullopt));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1354,7 +1263,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
         std::numeric_limits<std::uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -1366,16 +1275,13 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::string first{INDEX1};
     auto current = ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
@@ -1387,19 +1293,16 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
             ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{first.c_str()}).key;
         auto const nftpage =
             CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, previous);
-        EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-            .WillOnce(Return(nftpage.getSerializer().peekData()));
+        EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage.getSerializer().peekData()));
         current = previous;
     }
     auto const nftpage11 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(current, 30, _))
-        .WillOnce(Return(nftpage11.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(current, 30, _)).WillOnce(Return(nftpage11.getSerializer().peekData()));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const line = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     auto const channel = CreatePaymentChannelLedgerObject(ACCOUNT, ACCOUNT2, 100, 10, 32, TXNID, 28);
@@ -1419,7 +1322,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
     bbs.push_back(channel.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1432,7 +1335,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
         std::numeric_limits<uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1485,41 +1388,35 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
                                             ]
                                         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft page 1
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
     auto const nftPage2KK = ripple::keylet::nftpage(ripple::keylet::nftpage_min(account), ripple::uint256{INDEX1}).key;
     auto const nftpage1 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, nftPage2KK);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _))
-        .WillOnce(Return(nftpage1.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(nftpage1.getSerializer().peekData()));
 
     // nft page 2 , end
     auto const nftpage2 =
         CreateNFTTokenPage(std::vector{std::make_pair<std::string, std::string>(TOKENID, "www.ok.com")}, std::nullopt);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftPage2KK, 30, _))
-        .WillOnce(Return(nftpage2.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftPage2KK, 30, _)).WillOnce(Return(nftpage2.getSerializer().peekData()));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1529,7 +1426,7 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
         ACCOUNT
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1539,31 +1436,27 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTZeroMarkerNotAffectOtherMarker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     static auto constexpr limit = 10;
     auto count = limit * 2;
     // put 20 items in owner dir, but only return 10
     auto const ownerDir = CreateOwnerDirLedgerObject(std::vector(count, ripple::uint256{INDEX1}), INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     std::vector<Blob> bbs;
     while (count-- != 0) {
         auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
         bbs.push_back(line1.getSerializer().peekData());
     }
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1577,7 +1470,7 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTZeroMarkerNotAffectOtherMarker)
         std::numeric_limits<uint32_t>::max()
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1623,31 +1516,27 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitLessThanMin)
         AccountObjectsHandler::LIMIT_MIN
     );
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1658,7 +1547,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitLessThanMin)
         AccountObjectsHandler::LIMIT_MIN - 1
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
@@ -1703,31 +1592,27 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitMoreThanMax)
         AccountObjectsHandler::LIMIT_MAX
     );
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const account = GetAccountIDWithString(ACCOUNT);
     auto const accountKk = ripple::keylet::account(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+    EXPECT_CALL(*backend, doFetchLedgerObject(accountKk, MAXSEQ, _)).WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}}, INDEX1);
     auto const ownerDirKk = ripple::keylet::ownerDir(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(ownerDirKk, 30, _))
-        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject(ownerDirKk, 30, _)).WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     // nft null
     auto const nftMaxKK = ripple::keylet::nftpage_max(account).key;
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject(nftMaxKK, 30, _)).WillOnce(Return(std::nullopt));
 
     std::vector<Blob> bbs;
     auto const line1 = CreateRippleStateLedgerObject("USD", ISSUER, 100, ACCOUNT, 10, ACCOUNT2, 20, TXNID, 123, 0);
     bbs.push_back(line1.getSerializer().peekData());
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     auto static const input = json::parse(fmt::format(
         R"({{
@@ -1738,7 +1623,7 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitMoreThanMax)
         AccountObjectsHandler::LIMIT_MAX + 1
     ));
 
-    auto const handler = AnyHandler{AccountObjectsHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{AccountObjectsHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/AccountTxTests.cpp
+++ b/unittests/rpc/handlers/AccountTxTests.cpp
@@ -398,17 +398,15 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(AccountTxParameterTest, CheckParams)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const& testBundle = GetParam();
-    auto* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     auto const req = json::parse(testBundle.testJson);
     if (testBundle.expectedError.has_value()) {
         ASSERT_TRUE(testBundle.expectedErrorMessage.has_value());
 
         runSpawn([&, this](auto yield) {
-            auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+            auto const handler = AnyHandler{AccountTxHandler{backend}};
             auto const output = handler.process(req, Context{.yield = yield, .apiVersion = testBundle.apiVersion});
             ASSERT_FALSE(output);
             auto const err = rpc::makeError(output.error());
@@ -416,10 +414,10 @@ TEST_P(AccountTxParameterTest, CheckParams)
             EXPECT_EQ(err.at("error_message").as_string(), *testBundle.expectedErrorMessage);
         });
     } else {
-        EXPECT_CALL(*rawBackendPtr, fetchAccountTransactions);
+        EXPECT_CALL(*backend, fetchAccountTransactions);
 
         runSpawn([&, this](auto yield) {
-            auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+            auto const handler = AnyHandler{AccountTxHandler{backend}};
             auto const output = handler.process(req, Context{.yield = yield, .apiVersion = testBundle.apiVersion});
             EXPECT_TRUE(output);
         });
@@ -482,15 +480,13 @@ genNFTTransactions(uint32_t seq)
 
 TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -502,7 +498,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -527,15 +523,13 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
 
 TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -547,7 +541,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -572,15 +566,13 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
 
 TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -592,7 +584,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -617,15 +609,13 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
 
 TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -637,7 +627,7 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -662,15 +652,13 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
 
 TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -682,7 +670,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -721,14 +709,12 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
 
 TEST_F(RPCAccountTxHandlerTest, BinaryTrueV2)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -740,7 +726,7 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrueV2)
         .WillOnce(Return(transCursor));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -779,15 +765,13 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrueV2)
 
 TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_, testing::_, false, testing::Optional(testing::Eq(TransactionsCursor{10, 11})), testing::_
         )
@@ -795,7 +779,7 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -822,16 +806,14 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -843,11 +825,11 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ - 1);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -869,16 +851,13 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -897,16 +876,13 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -925,16 +901,14 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -946,11 +920,11 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ - 1);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -972,16 +946,14 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -993,11 +965,11 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -1018,15 +990,13 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
 
 TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -1038,7 +1008,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -1063,15 +1033,13 @@ TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
 
 TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_,
             testing::_,
@@ -1083,7 +1051,7 @@ TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -1304,15 +1272,13 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v1)
                 "seq": 34
             }
         })";
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genNFTTransactions(MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_, testing::_, false, testing::Optional(testing::Eq(TransactionsCursor{10, 11})), testing::_
         )
@@ -1320,7 +1286,7 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v1)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -1545,15 +1511,13 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v2)
                 "seq": 34
             }
         })";
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genNFTTransactions(MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchAccountTransactions(
             testing::_, testing::_, false, testing::Optional(testing::Eq(TransactionsCursor{10, 11})), testing::_
         )
@@ -1561,10 +1525,10 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v2)
         .Times(1);
 
     auto const ledgerInfo = CreateLedgerInfo(LEDGERHASH, 11);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(transactions.size()).WillRepeatedly(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(transactions.size()).WillRepeatedly(Return(ledgerInfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "account": "{}",
@@ -2030,26 +1994,21 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchAccountTransactions).WillByDefault(Return(transCursor));
-    EXPECT_CALL(
-        *rawBackendPtr, fetchAccountTransactions(_, _, false, Optional(Eq(TransactionsCursor{MAXSEQ, INT32_MAX})), _)
-    )
+    ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
+    EXPECT_CALL(*backend, fetchAccountTransactions(_, _, false, Optional(Eq(TransactionsCursor{MAXSEQ, INT32_MAX})), _))
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).Times(Between(1, 2));
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).Times(Between(1, 2));
 
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{AccountTxHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{AccountTxHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{.yield = yield, .apiVersion = testBundle.apiVersion});
         EXPECT_TRUE(output);

--- a/unittests/rpc/handlers/BookChangesTests.cpp
+++ b/unittests/rpc/handlers/BookChangesTests.cpp
@@ -100,7 +100,7 @@ TEST_P(BookChangesParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{BookChangesHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -112,17 +112,13 @@ TEST_P(BookChangesParameterTest, InvalidParams)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _))
-        .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(R"({"ledger_index":30})");
-    auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{BookChangesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -134,16 +130,13 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaStringSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(std::nullopt));
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(std::nullopt));
 
     auto static const input = json::parse(R"({"ledger_index":"30"})");
-    auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{BookChangesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -155,13 +148,10 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerinfo
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto static const input = json::parse(fmt::format(
@@ -170,7 +160,7 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaHash)
         }})",
         LEDGERHASH
     ));
-    auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{BookChangesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
@@ -202,13 +192,10 @@ TEST_F(RPCBookChangesHandlerTest, NormalPath)
                 }
             ]
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, MAXSEQ)));
+
+    backend->setRange(MINSEQ, MAXSEQ);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, MAXSEQ)));
 
     auto transactions = std::vector<TransactionAndMetadata>{};
     auto trans1 = TransactionAndMetadata();
@@ -219,10 +206,10 @@ TEST_F(RPCBookChangesHandlerTest, NormalPath)
     trans1.metadata = metaObj.getSerializer().peekData();
     transactions.push_back(trans1);
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(MAXSEQ, _)).WillByDefault(Return(transactions));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(MAXSEQ, _)).WillByDefault(Return(transactions));
 
-    auto const handler = AnyHandler{BookChangesHandler{mockBackendPtr}};
+    auto const handler = AnyHandler{BookChangesHandler{backend}};
     runSpawn([&](auto yield) {
         auto const output = handler.process(json::parse("{}"), Context{yield});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/DepositAuthorizedTests.cpp
+++ b/unittests/rpc/handlers/DepositAuthorizedTests.cpp
@@ -180,7 +180,7 @@ TEST_P(DepositAuthorizedParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
 
@@ -194,15 +194,13 @@ TEST_P(DepositAuthorizedParameterTest, InvalidParams)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "source_account": "{}", 
@@ -225,15 +223,13 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaStringSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "source_account": "{}", 
@@ -256,15 +252,13 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "source_account": "{}", 
@@ -287,17 +281,15 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaHash)
 
 TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -311,7 +303,7 @@ TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_FALSE(output);
@@ -324,21 +316,19 @@ TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
 
 TEST_F(RPCDepositAuthorizedTest, DestinationAccountDoesNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const accountRoot = CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(_, _, _)).WillByDefault(Return(accountRoot.getSerializer().peekData()));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(_, _, _)).WillByDefault(Return(accountRoot.getSerializer().peekData()));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
         .WillByDefault(Return(std::optional<Blob>{}));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -352,7 +342,7 @@ TEST_F(RPCDepositAuthorizedTest, DestinationAccountDoesNotExist)
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_FALSE(output);
@@ -375,18 +365,16 @@ TEST_F(RPCDepositAuthorizedTest, AccountsAreEqual)
             "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const accountRoot = CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(accountRoot.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(accountRoot.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -400,7 +388,7 @@ TEST_F(RPCDepositAuthorizedTest, AccountsAreEqual)
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -420,23 +408,21 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsNoDepositAuthFlag)
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const account1Root = CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
     auto const account2Root = CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX2, 2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
         .WillByDefault(Return(account1Root.getSerializer().peekData()));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
         .WillByDefault(Return(account2Root.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -450,7 +436,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsNoDepositAuthFlag)
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -470,24 +456,22 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsFals
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const account1Root = CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
     auto const account2Root = CreateAccountRootObject(ACCOUNT2, ripple::lsfDepositAuth, 2, 200, 2, INDEX2, 2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(_, _, _)).WillByDefault(Return(std::nullopt));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(_, _, _)).WillByDefault(Return(std::nullopt));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
         .WillByDefault(Return(account1Root.getSerializer().peekData()));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
         .WillByDefault(Return(account2Root.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -501,7 +485,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsFals
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -521,24 +505,22 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsTrue
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
 
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
 
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const account1Root = CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
     auto const account2Root = CreateAccountRootObject(ACCOUNT2, ripple::lsfDepositAuth, 2, 200, 2, INDEX2, 2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(_, _, _)).WillByDefault(Return(std::optional<Blob>{{1, 2, 3}}));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(_, _, _)).WillByDefault(Return(std::optional<Blob>{{1, 2, 3}}));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, _, _))
         .WillByDefault(Return(account1Root.getSerializer().peekData()));
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, _, _))
         .WillByDefault(Return(account2Root.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(3);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(3);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -552,7 +534,7 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsTrue
     ));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{DepositAuthorizedHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{DepositAuthorizedHandler{backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/LedgerDataTests.cpp
+++ b/unittests/rpc/handlers/LedgerDataTests.cpp
@@ -117,11 +117,10 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(LedgerDataParameterTest, InvalidParams)
 {
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -133,16 +132,13 @@ TEST_P(LedgerDataParameterTest, InvalidParams)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_index": {}
@@ -159,16 +155,13 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaStringSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_index": "{}"
@@ -185,16 +178,13 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_hash": "{}"
@@ -211,21 +201,16 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaHash)
 
 TEST_F(RPCLedgerDataHandlerTest, MarkerNotExist)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _))
-        .WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "marker": "{}"
@@ -257,20 +242,17 @@ TEST_F(RPCLedgerDataHandlerTest, NoMarker)
       "closed":true
    })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     // when 'type' not specified, default to all the types
     auto limitLine = 5;
     auto limitTicket = 5;
 
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limitLine + limitTicket);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limitLine + limitTicket);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limitLine--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
@@ -282,10 +264,10 @@ TEST_F(RPCLedgerDataHandlerTest, NoMarker)
         bbs.push_back(ticket.getSerializer().peekData());
     }
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(R"({"limit":10})");
         auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -319,20 +301,17 @@ TEST_F(RPCLedgerDataHandlerTest, Version2)
       "closed": true
    })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     // When 'type' not specified, default to all the types
     auto limitLine = 5;
     auto limitTicket = 5;
 
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limitLine + limitTicket);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limitLine + limitTicket);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limitLine--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
@@ -344,10 +323,10 @@ TEST_F(RPCLedgerDataHandlerTest, Version2)
         bbs.push_back(ticket.getSerializer().peekData());
     }
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).WillOnce(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(R"({"limit":10})");
         auto output = handler.process(req, Context{.yield = yield, .apiVersion = 2});
         ASSERT_TRUE(output);
@@ -377,21 +356,17 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilter)
       "closed":true
    })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limitLine = 5;
     auto limitTicket = 5;
 
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limitLine + limitTicket);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limitLine + limitTicket);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limitLine--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
@@ -403,11 +378,11 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilter)
         bbs.push_back(ticket.getSerializer().peekData());
     }
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(R"({
             "limit":10,
             "type":"state"
@@ -445,20 +420,16 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilterAMM)
       "closed":true
    })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limitLine = 5;
 
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limitLine + 1);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limitLine + 1);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limitLine--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
@@ -468,11 +439,11 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilterAMM)
     auto const amm = CreateAMMObject(ACCOUNT, "XRP", ripple::toBase58(ripple::xrpAccount()), "JPY", ACCOUNT2);
     bbs.push_back(amm.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(R"({
             "limit":6,
             "type":"amm"
@@ -510,31 +481,26 @@ TEST_F(RPCLedgerDataHandlerTest, OutOfOrder)
       "closed":true
    })";
 
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     // page end
     // marker return seq
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(2);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(firstKey, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(ripple::uint256{INDEX2}, RANGEMAX, _))
-        .WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(2);
+    ON_CALL(*backend, doFetchSuccessorKey(firstKey, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    ON_CALL(*backend, doFetchSuccessorKey(ripple::uint256{INDEX2}, RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
     bbs.push_back(line.getSerializer().peekData());
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(R"({"limit":10, "out_of_order":true})");
         auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -550,17 +516,13 @@ TEST_F(RPCLedgerDataHandlerTest, OutOfOrder)
 
 TEST_F(RPCLedgerDataHandlerTest, Marker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _))
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _))
         .WillByDefault(
             Return(CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123)
                        .getSerializer()
@@ -569,10 +531,10 @@ TEST_F(RPCLedgerDataHandlerTest, Marker)
 
     auto limit = 10;
     std::vector<Blob> bbs;
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limit);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(ripple::uint256{INDEX1}, RANGEMAX, _))
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limit);
+    ON_CALL(*backend, doFetchSuccessorKey(ripple::uint256{INDEX1}, RANGEMAX, _))
         .WillByDefault(Return(ripple::uint256{INDEX2}));
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(ripple::uint256{INDEX2}, RANGEMAX, _))
+    ON_CALL(*backend, doFetchSuccessorKey(ripple::uint256{INDEX2}, RANGEMAX, _))
         .WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limit--) != 0) {
@@ -580,11 +542,11 @@ TEST_F(RPCLedgerDataHandlerTest, Marker)
         bbs.push_back(line.getSerializer().peekData());
     }
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "limit":10,
@@ -604,33 +566,29 @@ TEST_F(RPCLedgerDataHandlerTest, Marker)
 
 TEST_F(RPCLedgerDataHandlerTest, DiffMarker)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limit = 10;
     std::vector<LedgerObject> los;
     std::vector<Blob> bbs;
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerDiff).Times(1);
 
     while ((limit--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
         bbs.push_back(line.getSerializer().peekData());
         los.emplace_back(LedgerObject{ripple::uint256{INDEX2}, Blob{}});  // NOLINT(modernize-use-emplace)
     }
-    ON_CALL(*rawBackendPtr, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
+    ON_CALL(*backend, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "limit":10,
@@ -651,31 +609,27 @@ TEST_F(RPCLedgerDataHandlerTest, DiffMarker)
 
 TEST_F(RPCLedgerDataHandlerTest, Binary)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limit = 10;
     std::vector<Blob> bbs;
 
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(limit);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(limit);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limit--) != 0) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
         bbs.push_back(line.getSerializer().peekData());
     }
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(
             R"({
                 "limit":10,
@@ -695,31 +649,27 @@ TEST_F(RPCLedgerDataHandlerTest, Binary)
 
 TEST_F(RPCLedgerDataHandlerTest, BinaryLimitMoreThanMax)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limit = LedgerDataHandler::LIMITBINARY + 1;
     std::vector<Blob> bbs;
 
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(LedgerDataHandler::LIMITBINARY);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(LedgerDataHandler::LIMITBINARY);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limit--) != 0u) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
         bbs.push_back(line.getSerializer().peekData());
     }
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "limit":{},
@@ -740,31 +690,27 @@ TEST_F(RPCLedgerDataHandlerTest, BinaryLimitMoreThanMax)
 
 TEST_F(RPCLedgerDataHandlerTest, JsonLimitMoreThanMax)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _))
-        .WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(CreateLedgerInfo(LEDGERHASH, RANGEMAX)));
 
     auto limit = LedgerDataHandler::LIMITJSON + 1;
     std::vector<Blob> bbs;
 
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(LedgerDataHandler::LIMITJSON);
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(LedgerDataHandler::LIMITJSON);
+    ON_CALL(*backend, doFetchSuccessorKey(_, RANGEMAX, _)).WillByDefault(Return(ripple::uint256{INDEX2}));
 
     while ((limit--) != 0u) {
         auto const line = CreateRippleStateLedgerObject("USD", ACCOUNT2, 10, ACCOUNT, 100, ACCOUNT2, 200, TXNID, 123);
         bbs.push_back(line.getSerializer().peekData());
     }
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerDataHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerDataHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "limit":{},

--- a/unittests/rpc/handlers/LedgerRangeTests.cpp
+++ b/unittests/rpc/handlers/LedgerRangeTests.cpp
@@ -37,8 +37,9 @@ class RPCLedgerRangeTest : public HandlerBaseTest {};
 TEST_F(RPCLedgerRangeTest, LedgerRangeMinMaxSame)
 {
     runSpawn([this](auto yield) {
-        mockBackendPtr->updateRange(RANGEMIN);
-        auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
+        backend->updateRange(RANGEMIN);
+
+        auto const handler = AnyHandler{LedgerRangeHandler{backend}};
         auto const req = json::parse("{}");
         auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -51,9 +52,9 @@ TEST_F(RPCLedgerRangeTest, LedgerRangeMinMaxSame)
 TEST_F(RPCLedgerRangeTest, LedgerRangeFullySet)
 {
     runSpawn([this](auto yield) {
-        mockBackendPtr->updateRange(RANGEMIN);
-        mockBackendPtr->updateRange(RANGEMAX);
-        auto const handler = AnyHandler{LedgerRangeHandler{mockBackendPtr}};
+        backend->setRange(RANGEMIN, RANGEMAX);
+
+        auto const handler = AnyHandler{LedgerRangeHandler{backend}};
         auto const req = json::parse("{}");
         auto const output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/LedgerTests.cpp
+++ b/unittests/rpc/handlers/LedgerTests.cpp
@@ -177,7 +177,7 @@ TEST_P(LedgerParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -189,16 +189,13 @@ TEST_P(LedgerParameterTest, InvalidParams)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaIntSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_index": {}
@@ -215,16 +212,13 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaStringSequence)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_index": "{}"
@@ -241,16 +235,13 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);  // min
-    mockBackendPtr->updateRange(RANGEMAX);  // max
+    backend->setRange(RANGEMIN, RANGEMAX);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(fmt::format(
             R"({{
                 "ledger_hash": "{}"
@@ -287,17 +278,15 @@ TEST_F(RPCLedgerHandlerTest, Default)
                 "transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000"
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse("{}");
         auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -310,17 +299,14 @@ TEST_F(RPCLedgerHandlerTest, Default)
 // not supported fields can be set to its default value
 TEST_F(RPCLedgerHandlerTest, NotSupportedFieldsDefaultValue)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "full": false,
@@ -335,17 +321,14 @@ TEST_F(RPCLedgerHandlerTest, NotSupportedFieldsDefaultValue)
 
 TEST_F(RPCLedgerHandlerTest, QueryViaLedgerIndex)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(15, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(15, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(R"({"ledger_index": 15})");
         auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -355,17 +338,14 @@ TEST_F(RPCLedgerHandlerTest, QueryViaLedgerIndex)
 
 TEST_F(RPCLedgerHandlerTest, QueryViaLedgerHash)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{INDEX1}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{INDEX1}, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(fmt::format(R"({{"ledger_hash": "{}" }})", INDEX1));
         auto output = handler.process(req, Context{yield});
         ASSERT_TRUE(output);
@@ -385,17 +365,15 @@ TEST_F(RPCLedgerHandlerTest, BinaryTrue)
                 "closed":true
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true
@@ -429,25 +407,23 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandBinary)
                 ]
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1, t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1, t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -485,23 +461,21 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandBinaryV2)
                 ]
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1, t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1, t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -575,25 +549,23 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinary)
                 ]
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": false,
@@ -679,23 +651,21 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinaryV2)
                 ]
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": false,
@@ -713,27 +683,24 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinaryV2)
 
 TEST_F(RPCLedgerHandlerTest, TwoRequestInARowTransactionsExpandNotBinaryV2)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerinfo));
 
     auto const ledgerinfo2 = CreateLedgerInfo(LEDGERHASH, RANGEMAX - 1, 10);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX - 1, _)).WillOnce(Return(ledgerinfo2));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX - 1, _)).WillOnce(Return(ledgerinfo2));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1}));
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX - 1, _)).WillOnce(Return(std::vector{t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillOnce(Return(std::vector{t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX - 1, _)).WillOnce(Return(std::vector{t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": false,
@@ -764,21 +731,18 @@ TEST_F(RPCLedgerHandlerTest, TwoRequestInARowTransactionsExpandNotBinaryV2)
 
 TEST_F(RPCLedgerHandlerTest, TransactionsNotExpand)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionHashesInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionHashesInLedger(RANGEMAX, _))
+    EXPECT_CALL(*backend, fetchAllTransactionHashesInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionHashesInLedger(RANGEMAX, _))
         .WillByDefault(Return(std::vector{ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "transactions": true
@@ -817,18 +781,16 @@ TEST_F(RPCLedgerHandlerTest, DiffNotBinary)
                 }
             }
         ])";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     std::vector<LedgerObject> los;
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerDiff).Times(1);
 
     los.push_back(LedgerObject{ripple::uint256{INDEX2}, Blob{}});  // NOLINT(modernize-use-emplace)
     los.push_back(LedgerObject{
@@ -836,10 +798,10 @@ TEST_F(RPCLedgerHandlerTest, DiffNotBinary)
         CreateAccountRootObject(ACCOUNT, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3).getSerializer().peekData()
     });
 
-    ON_CALL(*rawBackendPtr, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
+    ON_CALL(*backend, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "diff": true
@@ -864,18 +826,16 @@ TEST_F(RPCLedgerHandlerTest, DiffBinary)
                 "object":"1100612200400000240000000125000000032B000000002D00000002551B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC62400000000000000A81144B4E9C06F24296074F7BC48F92A97916C6DC5EA9"
             }
         ])";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     std::vector<LedgerObject> los;
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerDiff).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerDiff).Times(1);
 
     los.push_back(LedgerObject{ripple::uint256{INDEX2}, Blob{}});  // NOLINT(modernize-use-emplace)
     los.push_back(LedgerObject{
@@ -883,10 +843,10 @@ TEST_F(RPCLedgerHandlerTest, DiffBinary)
         CreateAccountRootObject(ACCOUNT, ripple::lsfGlobalFreeze, 1, 10, 2, INDEX1, 3).getSerializer().peekData()
     });
 
-    ON_CALL(*rawBackendPtr, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
+    ON_CALL(*backend, fetchLedgerDiff(RANGEMAX, _)).WillByDefault(Return(los));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "diff": true,
@@ -959,25 +919,23 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsEmtpy)
                 ]
             }
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     TransactionAndMetadata t1;
     t1.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 100, 3, RANGEMAX).getSerializer().peekData();
     t1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     t1.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{t1}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": false,
@@ -1052,14 +1010,12 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryFalse)
             "ledger_index": 30,
             "validated": true
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // account doFetchLedgerObject
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -1067,14 +1023,13 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryFalse)
         CreateAccountRootObject(ACCOUNT, 0, RANGEMAX, 200 /*balance*/, 2 /*owner object*/, INDEX1, RANGEMAX - 1, 0)
             .getSerializer()
             .peekData();
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
 
     // fee object 2*2+3->7 ; balance 200 - 7 -> 193
     auto feeBlob = CreateFeeSettingBlob(1, 2 /*reserve inc*/, 3 /*reserve base*/, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _))
-        .WillByDefault(Return(feeBlob));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _)).WillByDefault(Return(feeBlob));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT2, 100, 300, 200).getSerializer().peekData();
@@ -1084,11 +1039,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryFalse)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": false,
@@ -1124,14 +1079,12 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
             "ledger_index": 30,
             "validated": true
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // account doFetchLedgerObject
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -1139,14 +1092,13 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
         CreateAccountRootObject(ACCOUNT, 0, RANGEMAX, 200 /*balance*/, 2 /*owner object*/, INDEX1, RANGEMAX - 1, 0)
             .getSerializer()
             .peekData();
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
 
     // fee object 2*2+3->7 ; balance 200 - 7 -> 193
     auto feeBlob = CreateFeeSettingBlob(1, 2 /*reserve inc*/, 3 /*reserve base*/, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _))
-        .WillByDefault(Return(feeBlob));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _)).WillByDefault(Return(feeBlob));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT2, 100, 300, 200).getSerializer().peekData();
@@ -1156,11 +1108,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -1177,14 +1129,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsIssuerIsSelf)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // issuer is self
     TransactionAndMetadata tx;
@@ -1194,11 +1143,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsIssuerIsSelf)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -1234,14 +1183,12 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
             "ledger_index": 30,
             "validated": true
         })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // account doFetchLedgerObject
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -1249,14 +1196,13 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
         CreateAccountRootObject(ACCOUNT, 0, RANGEMAX, 6 /*balance*/, 2 /*owner object*/, INDEX1, RANGEMAX - 1, 0)
             .getSerializer()
             .peekData();
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, RANGEMAX, _)).WillByDefault(Return(accountObject));
 
     // fee object 2*2+3->7 ; balance 6 - 7 -> -1
     auto feeBlob = CreateFeeSettingBlob(1, 2 /*reserve inc*/, 3 /*reserve base*/, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _))
-        .WillByDefault(Return(feeBlob));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::fees().key, RANGEMAX, _)).WillByDefault(Return(feeBlob));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT2, 100, 300, 200).getSerializer().peekData();
@@ -1266,11 +1212,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -1287,14 +1233,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // mock line
     auto const line =
@@ -1305,10 +1248,9 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
                        ripple::to_currency(std::string(CURRENCY))
     )
                        .key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(lineKey, RANGEMAX, _))
-        .WillByDefault(Return(line.getSerializer().peekData()));
+    ON_CALL(*backend, doFetchLedgerObject(lineKey, RANGEMAX, _)).WillByDefault(Return(line.getSerializer().peekData()));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT2, 100, 300, 200, true).getSerializer().peekData();
@@ -1317,11 +1259,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,
@@ -1345,14 +1287,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsIgnoreFreezeLine)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(RANGEMIN);
-    mockBackendPtr->updateRange(RANGEMAX);
+    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, RANGEMAX);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerinfo));
 
     // mock line freeze
     auto const line = CreateRippleStateLedgerObject(
@@ -1373,10 +1312,9 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsIgnoreFreezeLine)
                        ripple::to_currency(std::string(CURRENCY))
     )
                        .key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(lineKey, RANGEMAX, _))
-        .WillByDefault(Return(line.getSerializer().peekData()));
+    ON_CALL(*backend, doFetchLedgerObject(lineKey, RANGEMAX, _)).WillByDefault(Return(line.getSerializer().peekData()));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT2, 100, 300, 200, true).getSerializer().peekData();
@@ -1385,11 +1323,11 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsIgnoreFreezeLine)
     tx.date = 123456;
     tx.ledgerSequence = RANGEMAX;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger).Times(1);
-    ON_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger).Times(1);
+    ON_CALL(*backend, fetchAllTransactionsInLedger(RANGEMAX, _)).WillByDefault(Return(std::vector{tx}));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{LedgerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{LedgerHandler{backend}};
         auto const req = json::parse(
             R"({
                 "binary": true,

--- a/unittests/rpc/handlers/NFTHistoryTests.cpp
+++ b/unittests/rpc/handlers/NFTHistoryTests.cpp
@@ -238,11 +238,10 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(NFTHistoryParameterTest, InvalidParams)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -279,15 +278,13 @@ genTransactions(uint32_t seq1, uint32_t seq2)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardTrue)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_, testing::_, true, testing::Optional(testing::Eq(TransactionsCursor{MINSEQ + 1, 0})), testing::_
         )
@@ -295,7 +292,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardTrue)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -422,15 +419,13 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV1)
                                     "seq": 34
                                 }
                                 })";
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -442,7 +437,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV1)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -576,14 +571,12 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV2)
                                     "seq": 34
                                 }
                                 })";
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -595,11 +588,11 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV2)
         .WillOnce(Return(transCursor));
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(2);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(2);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -619,15 +612,13 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV2)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_, testing::_, true, testing::Optional(testing::Eq(TransactionsCursor{MINSEQ, 0})), testing::_
         )
@@ -635,7 +626,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -660,15 +651,13 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -680,7 +669,7 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -705,15 +694,13 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
 
 TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV1)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -725,7 +712,7 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV1)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -764,14 +751,12 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV1)
 
 TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV2)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -783,7 +768,7 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV2)
         .WillOnce(Return(transCursor));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -822,15 +807,13 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV2)
 
 TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_, testing::_, false, testing::Optional(testing::Eq(TransactionsCursor{10, 11})), testing::_
         )
@@ -838,7 +821,7 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -865,16 +848,14 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -886,11 +867,11 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ - 1);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -912,16 +893,13 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerIntIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -940,16 +918,13 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerIntIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerStringIndex)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
 
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -968,16 +943,14 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerStringIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -989,11 +962,11 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
         .Times(1);
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ - 1);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -1015,15 +988,13 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
 
 TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -1035,7 +1006,7 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -1060,15 +1031,13 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
 
 TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -1080,7 +1049,7 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",
@@ -1105,15 +1074,13 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
 
 TEST_F(RPCNFTHistoryHandlerTest, LimitMoreThanMax)
 {
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
-    ON_CALL(*rawBackendPtr, fetchNFTTransactions).WillByDefault(Return(transCursor));
+    ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTTransactions(
             testing::_,
             testing::_,
@@ -1125,7 +1092,7 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitMoreThanMax)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTHistoryHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTHistoryHandler{backend}};
         auto const static input = json::parse(fmt::format(
             R"({{
                 "nft_id":"{}",

--- a/unittests/rpc/handlers/NFTSellOffersTests.cpp
+++ b/unittests/rpc/handlers/NFTSellOffersTests.cpp
@@ -54,7 +54,7 @@ class RPCNFTSellOffersHandlerTest : public HandlerBaseTest {};
 TEST_F(RPCNFTSellOffersHandlerTest, LimitNotInt)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -73,7 +73,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitNotInt)
 TEST_F(RPCNFTSellOffersHandlerTest, LimitNegative)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -92,7 +92,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitNegative)
 TEST_F(RPCNFTSellOffersHandlerTest, LimitZero)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -111,7 +111,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitZero)
 TEST_F(RPCNFTSellOffersHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -131,7 +131,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonHexLedgerHash)
 TEST_F(RPCNFTSellOffersHandlerTest, NonStringLedgerHash)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{
                 "nft_id": "{}", 
@@ -151,7 +151,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonStringLedgerHash)
 TEST_F(RPCNFTSellOffersHandlerTest, InvalidLedgerIndexString)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -172,7 +172,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, InvalidLedgerIndexString)
 TEST_F(RPCNFTSellOffersHandlerTest, NFTIDInvalidFormat)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(R"({ 
             "nft_id": "00080000B4F4AFC5FBCBD76873F18006173D2193467D3EE7"
         })");
@@ -188,7 +188,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NFTIDInvalidFormat)
 TEST_F(RPCNFTSellOffersHandlerTest, NFTIDNotString)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(R"({ 
             "nft_id": 12
         })");
@@ -204,12 +204,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, NFTIDNotString)
 // error case ledger non exist via hash
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
     // mock fetchLedgerByHash return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -220,7 +218,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
 
@@ -233,13 +231,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "nft_id": "{}",
@@ -248,7 +243,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
         NFTID
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -261,14 +256,11 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 31);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "nft_id": "{}",
@@ -278,7 +270,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -290,13 +282,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // no need to check from db, call fetchLedgerBySequence 0 time
     // differ from previous logic
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(0);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "nft_id": "{}",
@@ -305,7 +294,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
         NFTID
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -317,15 +306,12 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case when nft is not found
 TEST_F(RPCNFTSellOffersHandlerTest, NoNFT)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::nullopt));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::nullopt));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{
             "nft_id": "{}",
@@ -335,7 +321,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NoNFT)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -347,7 +333,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, NoNFT)
 TEST_F(RPCNFTSellOffersHandlerTest, MarkerNotString)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -369,7 +355,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, MarkerNotString)
 TEST_F(RPCNFTSellOffersHandlerTest, InvalidMarker)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}",
@@ -385,7 +371,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, InvalidMarker)
         EXPECT_EQ(err.at("error_message").as_string(), "markerMalformed");
     });
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -422,29 +408,27 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
             }
         ]
     })";
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
     // return owner index containing 2 indexes
     auto const directory = ripple::keylet::nft_sells(ripple::uint256{NFTID});
     auto const ownerDir = CreateOwnerDirLedgerObject({ripple::uint256{INDEX1}, ripple::uint256{INDEX2}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
 
     // return two nft sell offers
     std::vector<Blob> bbs;
     auto const offer = CreateNFTSellOffer(NFTID, ACCOUNT);
     bbs.push_back(offer.getSerializer().peekData());
     bbs.push_back(offer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -453,7 +437,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
         NFTID
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -464,13 +448,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
 // normal case when provided with nft_id and limit
 TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -484,11 +465,11 @@ TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
     }
     ripple::STObject const ownerDir = CreateOwnerDirLedgerObject(indexes, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(2);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(ownerDir.getSerializer().peekData()));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(2);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -498,7 +479,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
         NFTID
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -513,13 +494,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 // normal case when provided with nft_id, limit and marker
 TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -537,19 +515,19 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
     // first is nft offer object
     auto const cursor = ripple::uint256{"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC353"};
     auto const first = ripple::keylet::nftoffer(cursor);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(first.key, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(first.key, testing::_, testing::_))
         .WillByDefault(Return(cursorSellOffer.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(first.key, testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*backend, doFetchLedgerObject(first.key, testing::_, testing::_)).Times(1);
 
     auto const directory = ripple::keylet::nft_sells(ripple::uint256{NFTID});
     auto const startHint = 0ul;  // offer node is hardcoded to 0ul
     auto const secondKey = ripple::keylet::page(directory, startHint).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(secondKey, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(3);
+    EXPECT_CALL(*backend, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(3);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -560,7 +538,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
         NFTID
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -577,13 +555,10 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 // nothing left after reading remaining 50 entries
 TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimit)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(3);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
 
     // return owner index
     std::vector<ripple::uint256> indexes;
@@ -601,22 +576,22 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
     // first is nft offer object
     auto const cursor = ripple::uint256{"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC353"};
     auto const first = ripple::keylet::nftoffer(cursor);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(first.key, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(first.key, testing::_, testing::_))
         .WillByDefault(Return(cursorSellOffer.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(first.key, testing::_, testing::_)).Times(1);
+    EXPECT_CALL(*backend, doFetchLedgerObject(first.key, testing::_, testing::_)).Times(1);
 
     auto const directory = ripple::keylet::nft_sells(ripple::uint256{NFTID});
     auto const startHint = 0ul;  // offer node is hardcoded to 0ul
     auto const secondKey = ripple::keylet::page(directory, startHint).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(secondKey, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(7);
+    EXPECT_CALL(*backend, doFetchLedgerObject(secondKey, testing::_, testing::_)).Times(7);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(3);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(3);
 
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const input = json::parse(fmt::format(
             R"({{
                 "nft_id": "{}",
@@ -635,7 +610,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -648,7 +623,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
     });
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{NFTSellOffersHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTSellOffersHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "nft_id": "{}", 
@@ -663,22 +638,19 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
 
 TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
     // return owner index containing 2 indexes
     auto const directory = ripple::keylet::nft_sells(ripple::uint256{NFTID});
     auto const ownerDir =
         CreateOwnerDirLedgerObject(std::vector{NFTSellOffersHandler::LIMIT_MIN + 1, ripple::uint256{INDEX1}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
 
     // return two nft buy offers
     std::vector<Blob> bbs;
@@ -686,8 +658,8 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
     bbs.reserve(NFTSellOffersHandler::LIMIT_MIN + 1);
     for (auto i = 0; i < NFTSellOffersHandler::LIMIT_MIN + 1; i++)
         bbs.push_back(offer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -698,7 +670,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
         NFTSellOffersHandler::LIMIT_MIN - 1
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);
@@ -709,22 +681,19 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCNFTSellOffersHandlerTest, LimitMoreThanMax)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
     // return owner index containing 2 indexes
     auto const directory = ripple::keylet::nft_sells(ripple::uint256{NFTID});
     auto const ownerDir =
         CreateOwnerDirLedgerObject(std::vector{NFTSellOffersHandler::LIMIT_MAX + 1, ripple::uint256{INDEX1}}, INDEX1);
 
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_))
+    ON_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObject(directory.key, testing::_, testing::_)).Times(2);
 
     // return two nft buy offers
     std::vector<Blob> bbs;
@@ -732,8 +701,8 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitMoreThanMax)
     bbs.reserve(NFTSellOffersHandler::LIMIT_MAX + 1);
     for (auto i = 0; i < NFTSellOffersHandler::LIMIT_MAX + 1; i++)
         bbs.push_back(offer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects).WillByDefault(Return(bbs));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    ON_CALL(*backend, doFetchLedgerObjects).WillByDefault(Return(bbs));
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -744,7 +713,7 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitMoreThanMax)
         NFTSellOffersHandler::LIMIT_MAX + 1
     ));
     runSpawn([&, this](auto yield) {
-        auto handler = AnyHandler{NFTSellOffersHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTSellOffersHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
 
         ASSERT_TRUE(output);

--- a/unittests/rpc/handlers/NFTsByIssuerTest.cpp
+++ b/unittests/rpc/handlers/NFTsByIssuerTest.cpp
@@ -95,7 +95,7 @@ class RPCNFTsByIssuerHandlerTest : public HandlerBaseTest {};
 TEST_F(RPCNFTsByIssuerHandlerTest, NonHexLedgerHash)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "issuer": "{}", 
@@ -115,7 +115,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonHexLedgerHash)
 TEST_F(RPCNFTsByIssuerHandlerTest, NonStringLedgerHash)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{
                 "issuer": "{}", 
@@ -135,7 +135,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonStringLedgerHash)
 TEST_F(RPCNFTsByIssuerHandlerTest, InvalidLedgerIndexString)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(fmt::format(
             R"({{ 
                 "issuer": "{}", 
@@ -156,7 +156,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, InvalidLedgerIndexString)
 TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerInvalidFormat)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(R"({ 
             "issuer": "xxx"
         })");
@@ -172,7 +172,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerInvalidFormat)
 TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerMissing)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(R"({})");
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
@@ -186,7 +186,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerMissing)
 TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerNotString)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const input = json::parse(R"({ 
             "issuer": 12
         })");
@@ -202,10 +202,9 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NFTIssuerNotString)
 // error case ledger non exist via hash
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
     // mock fetchLedgerByHash return empty
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillByDefault(Return(std::optional<ripple::LedgerInfo>{}));
 
     auto const input = json::parse(fmt::format(
@@ -217,7 +216,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
 
@@ -230,11 +229,9 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
     auto const input = json::parse(fmt::format(
         R"({{ 
             "issuer": "{}",
@@ -243,7 +240,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerStringIndex)
         ACCOUNT
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -254,12 +251,9 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
     auto const input = json::parse(fmt::format(
         R"({{ 
             "issuer": "{}",
@@ -268,7 +262,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIntIndex)
         ACCOUNT
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -281,14 +275,11 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 31);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "issuer": "{}",
@@ -298,7 +289,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash2)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -310,13 +301,10 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(0);
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
     auto const input = json::parse(fmt::format(
         R"({{ 
             "issuer": "{}",
@@ -325,7 +313,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIndex2)
         ACCOUNT
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{NFTsByIssuerHandler{mockBackendPtr}};
+        auto const handler = AnyHandler{NFTsByIssuerHandler{backend}};
         auto const output = handler.process(input, Context{std::ref(yield)});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -337,15 +325,12 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIndex2)
 // normal case when issuer does not exist or has no NFTs
 TEST_F(RPCNFTsByIssuerHandlerTest, AccountNotFound)
 {
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    ON_CALL(*rawBackendPtr, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerByHash).Times(1);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     auto const input = json::parse(fmt::format(
         R"({{
@@ -356,7 +341,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, AccountNotFound)
         LEDGERHASH
     ));
     runSpawn([&, this](boost::asio::yield_context yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_FALSE(output);
         auto const err = rpc::makeError(output.error());
@@ -379,20 +364,18 @@ TEST_F(RPCNFTsByIssuerHandlerTest, DefaultParameters)
         ACCOUNT,
         NFT1OUT
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {CreateNFT(NFTID1, ACCOUNT, 29)};
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(
             account, testing::Eq(std::nullopt), Const(30), testing::_, testing::Eq(std::nullopt), testing::_
         )
@@ -406,7 +389,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, DefaultParameters)
         ACCOUNT
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
@@ -438,22 +421,20 @@ TEST_F(RPCNFTsByIssuerHandlerTest, SpecificLedgerIndex)
         ACCOUNT,
         specificLedger
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, specificLedger);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(specificLedger, _)).WillByDefault(Return(ledgerInfo));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    ON_CALL(*backend, fetchLedgerBySequence(specificLedger, _)).WillByDefault(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, specificLedger, _))
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, specificLedger, _))
         .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {CreateNFT(NFTID1, ACCOUNT, specificLedger)};
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(
             account, testing::Eq(std::nullopt), Const(specificLedger), testing::_, testing::Eq(std::nullopt), testing::_
         )
@@ -469,7 +450,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, SpecificLedgerIndex)
         specificLedger
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
@@ -490,20 +471,18 @@ TEST_F(RPCNFTsByIssuerHandlerTest, TaxonParameter)
         ACCOUNT,
         NFT1OUT
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {CreateNFT(NFTID1, ACCOUNT, 29)};
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(account, testing::Optional(0), Const(30), testing::_, testing::Eq(std::nullopt), testing::_)
     )
         .Times(1);
@@ -516,7 +495,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, TaxonParameter)
         ACCOUNT
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
@@ -537,20 +516,18 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MarkerParameter)
         ACCOUNT,
         NFT3OUT
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {CreateNFT(NFTID3, ACCOUNT, 29)};
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, ripple::uint256{NFTID3}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, ripple::uint256{NFTID3}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(account, testing::_, Const(30), testing::_, testing::Eq(ripple::uint256{NFTID1}), testing::_)
     )
         .Times(1);
@@ -564,7 +541,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MarkerParameter)
         NFTID1
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
@@ -586,22 +563,20 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MultipleNFTs)
         NFT2OUT,
         NFT3OUT
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {
         CreateNFT(NFTID1, ACCOUNT, 29), CreateNFT(NFTID2, ACCOUNT, 29), CreateNFT(NFTID3, ACCOUNT, 29)
     };
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(
             account, testing::Eq(std::nullopt), Const(30), testing::_, testing::Eq(std::nullopt), testing::_
         )
@@ -615,7 +590,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MultipleNFTs)
         ACCOUNT
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);
@@ -635,20 +610,18 @@ TEST_F(RPCNFTsByIssuerHandlerTest, LimitMoreThanMAx)
         ACCOUNT,
         NFT1OUT
     );
-    MockBackend* rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
+
+    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
+    ON_CALL(*backend, doFetchLedgerObject(accountKk, 30, _)).WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     std::vector<NFT> const nfts = {CreateNFT(NFTID1, ACCOUNT, 29)};
     auto const account = GetAccountIDWithString(ACCOUNT);
-    ON_CALL(*rawBackendPtr, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
+    ON_CALL(*backend, fetchNFTsByIssuer).WillByDefault(Return(NFTsAndCursor{nfts, {}}));
     EXPECT_CALL(
-        *rawBackendPtr,
+        *backend,
         fetchNFTsByIssuer(
             account,
             testing::Eq(std::nullopt),
@@ -669,7 +642,7 @@ TEST_F(RPCNFTsByIssuerHandlerTest, LimitMoreThanMAx)
         NFTsByIssuerHandler::LIMIT_MAX + 1
     ));
     runSpawn([&, this](auto& yield) {
-        auto handler = AnyHandler{NFTsByIssuerHandler{this->mockBackendPtr}};
+        auto handler = AnyHandler{NFTsByIssuerHandler{this->backend}};
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(json::parse(currentOutput), *output);

--- a/unittests/rpc/handlers/ServerInfoTests.cpp
+++ b/unittests/rpc/handlers/ServerInfoTests.cpp
@@ -61,10 +61,7 @@ protected:
         MockSubscriptionManagerTest::SetUp();
         MockCountersTest::SetUp();
 
-        rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-        ASSERT_NE(rawBackendPtr, nullptr);
-        mockBackendPtr->updateRange(10);  // min
-        mockBackendPtr->updateRange(30);  // max
+        backend->setRange(10, 30);
     }
 
     void
@@ -156,16 +153,14 @@ protected:
         EXPECT_EQ(cache.at("object_hit_rate").as_double(), 1.0);
         EXPECT_EQ(cache.at("successor_hit_rate").as_double(), 1.0);
     }
-
-    MockBackend* rawBackendPtr = nullptr;
 };
 
 TEST_F(RPCServerInfoHandlerTest, NoLedgerInfoErrorsOutWithInternal)
 {
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::nullopt));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -182,11 +177,11 @@ TEST_F(RPCServerInfoHandlerTest, NoLedgerInfoErrorsOutWithInternal)
 TEST_F(RPCServerInfoHandlerTest, NoFeesErrorsOutWithInternal)
 {
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(std::nullopt));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -207,10 +202,10 @@ TEST_F(RPCServerInfoHandlerTest, DefaultOutputIsPresent)
     MockETLService* rawETLServicePtr = mockETLServicePtr.get();
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawBalancerPtr, forwardToRippled(testing::_, testing::Eq(CLIENTIP), testing::_))
         .WillOnce(Return(std::nullopt));
@@ -220,7 +215,7 @@ TEST_F(RPCServerInfoHandlerTest, DefaultOutputIsPresent)
     EXPECT_CALL(*rawETLServicePtr, isAmendmentBlocked).WillOnce(Return(false));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -244,10 +239,10 @@ TEST_F(RPCServerInfoHandlerTest, AmendmentBlockedIsPresentIfSet)
     MockETLService* rawETLServicePtr = mockETLServicePtr.get();
 
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawBalancerPtr, forwardToRippled(testing::_, testing::Eq(CLIENTIP), testing::_))
         .WillOnce(Return(std::nullopt));
@@ -257,7 +252,7 @@ TEST_F(RPCServerInfoHandlerTest, AmendmentBlockedIsPresentIfSet)
     EXPECT_CALL(*rawETLServicePtr, isAmendmentBlocked).WillOnce(Return(true));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -281,10 +276,10 @@ TEST_F(RPCServerInfoHandlerTest, AdminSectionPresentWhenAdminFlagIsSet)
 
     auto const empty = json::object{};
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawBalancerPtr, forwardToRippled).WillOnce(Return(empty));
 
@@ -300,7 +295,7 @@ TEST_F(RPCServerInfoHandlerTest, AdminSectionPresentWhenAdminFlagIsSet)
     EXPECT_CALL(*rawETLServicePtr, getInfo).WillOnce(Return(empty));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -321,10 +316,10 @@ TEST_F(RPCServerInfoHandlerTest, BackendCountersPresentWhenRequestWithParam)
 
     auto const empty = json::object{};
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawBalancerPtr, forwardToRippled).WillOnce(Return(empty));
 
@@ -339,10 +334,10 @@ TEST_F(RPCServerInfoHandlerTest, BackendCountersPresentWhenRequestWithParam)
 
     EXPECT_CALL(*rawETLServicePtr, getInfo).WillOnce(Return(empty));
 
-    EXPECT_CALL(*rawBackendPtr, stats).WillOnce(Return(boost::json::object{{"read_cout", 10}, {"write_count", 3}}));
+    EXPECT_CALL(*backend, stats).WillOnce(Return(boost::json::object{{"read_cout", 10}, {"write_count", 3}}));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -367,10 +362,10 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesPresent)
 
     auto const empty = json::object{};
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawCountersPtr, uptime).WillOnce(Return(std::chrono::seconds{1234}));
 
@@ -396,7 +391,7 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesPresent)
     EXPECT_CALL(*rawETLServicePtr, getInfo).WillOnce(Return(empty));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {
@@ -418,10 +413,10 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesMissingNoExceptionThrown)
 
     auto const empty = json::object{};
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, 30, 3);  // 3 seconds old
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
     auto const feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).WillOnce(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).WillOnce(Return(feeBlob));
 
     EXPECT_CALL(*rawCountersPtr, uptime).WillOnce(Return(std::chrono::seconds{1234}));
 
@@ -442,7 +437,7 @@ TEST_F(RPCServerInfoHandlerTest, RippledForwardedValuesMissingNoExceptionThrown)
     EXPECT_CALL(*rawETLServicePtr, getInfo).WillOnce(Return(empty));
 
     auto const handler = AnyHandler{TestServerInfoHandler{
-        mockBackendPtr, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
+        backend, mockSubscriptionManagerPtr, mockLoadBalancerPtr, mockETLServicePtr, *mockCountersPtr
     }};
 
     runSpawn([&](auto yield) {

--- a/unittests/rpc/handlers/SubscribeTests.cpp
+++ b/unittests/rpc/handlers/SubscribeTests.cpp
@@ -72,7 +72,7 @@ protected:
     {
         HandlerBaseTest::SetUp();
         util::Config const cfg;
-        subManager_ = feed::SubscriptionManager::make_SubscriptionManager(cfg, mockBackendPtr);
+        subManager_ = feed::SubscriptionManager::make_SubscriptionManager(cfg, backend);
         util::TagDecoratorFactory const tagDecoratorFactory{cfg};
         session_ = std::make_shared<MockSession>(tagDecoratorFactory);
     }
@@ -588,7 +588,7 @@ TEST_P(SubscribeParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -601,7 +601,7 @@ TEST_P(SubscribeParameterTest, InvalidParams)
 TEST_F(RPCSubscribeHandlerTest, EmptyResponse)
 {
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(json::parse(R"({})"), Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -617,7 +617,7 @@ TEST_F(RPCSubscribeHandlerTest, StreamsWithoutLedger)
         })"
     );
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -643,18 +643,16 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
             "reserve_base":3,
             "reserve_inc":2
         })";
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence).Times(1);
+    backend->setRange(MINSEQ, MAXSEQ);
+
+    EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, MAXSEQ);
-    ON_CALL(*rawBackendPtr, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
+    ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(ledgerinfo));
     // fee
     auto feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject).WillByDefault(Return(feeBlob));
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(1);
+    ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(feeBlob));
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(1);
 
     // ledger stream returns information about the ledgers on hand and current
     // fee schedule.
@@ -664,7 +662,7 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
         })"
     );
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object(), json::parse(expectedOutput));
@@ -685,7 +683,7 @@ TEST_F(RPCSubscribeHandlerTest, Accounts)
         ACCOUNT2
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -707,7 +705,7 @@ TEST_F(RPCSubscribeHandlerTest, AccountsProposed)
         ACCOUNT2
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -740,7 +738,7 @@ TEST_F(RPCSubscribeHandlerTest, JustBooks)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -773,7 +771,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSet)
         ACCOUNT
     ));
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -807,10 +805,8 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
         }})",
         ACCOUNT
     ));
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const issuer = GetAccountIDWithString(ACCOUNT);
 
     auto const getsXRPPaysUSDBook = getBookBase(std::get<ripple::Book>(
@@ -821,44 +817,40 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
         rpc::parseBook(ripple::xrpCurrency(), ripple::xrpAccount(), ripple::to_currency("USD"), issuer)
     ));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(getsXRPPaysUSDBook, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(getsXRPPaysUSDBook, MAXSEQ, _))
         .WillByDefault(Return(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(std::nullopt));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(reversedBook, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(reversedBook, MAXSEQ, _))
         .WillByDefault(Return(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(4);
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(4);
 
     // 2 book dirs + 2 issuer global freeze + 2 transferRate + 1 owner root + 1 fee
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(8);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(8);
 
     auto const indexes = std::vector<ripple::uint256>(10, ripple::uint256{INDEX2});
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes, INDEX1).getSerializer().peekData()));
 
     // for reverse
     auto const indexes2 = std::vector<ripple::uint256>(10, ripple::uint256{INDEX1});
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes2, INDEX2).getSerializer().peekData()));
 
     // offer owner account root
-    ON_CALL(
-        *rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, MAXSEQ, _)
-    )
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, MAXSEQ, _))
         .WillByDefault(Return(CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX1, 2).getSerializer().peekData()));
 
     // issuer account root
-    ON_CALL(
-        *rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, MAXSEQ, _)
-    )
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, MAXSEQ, _))
         .WillByDefault(Return(CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2).getSerializer().peekData()));
 
     // fee
     auto feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, MAXSEQ, _)).WillByDefault(Return(feeBlob));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::fees().key, MAXSEQ, _)).WillByDefault(Return(feeBlob));
 
     auto const gets10XRPPays20USDOffer = CreateOfferLedgerObject(
         ACCOUNT2,
@@ -885,13 +877,13 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
     );
 
     std::vector<Blob> const bbs(10, gets10XRPPays20USDOffer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(indexes, MAXSEQ, _)).WillByDefault(Return(bbs));
+    ON_CALL(*backend, doFetchLedgerObjects(indexes, MAXSEQ, _)).WillByDefault(Return(bbs));
 
     // for reverse
     std::vector<Blob> const bbs2(10, gets10USDPays20XRPOffer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(indexes2, MAXSEQ, _)).WillByDefault(Return(bbs2));
+    ON_CALL(*backend, doFetchLedgerObjects(indexes2, MAXSEQ, _)).WillByDefault(Return(bbs2));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(2);
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(2);
 
     static auto const expectedOffer = fmt::format(
         R"({{
@@ -946,7 +938,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
         ACCOUNT
     );
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("bids").as_array().size(), 10);
@@ -982,10 +974,8 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
         }})",
         ACCOUNT
     ));
-    mockBackendPtr->updateRange(MINSEQ);
-    mockBackendPtr->updateRange(MAXSEQ);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+    backend->setRange(MINSEQ, MAXSEQ);
+
     auto const issuer = GetAccountIDWithString(ACCOUNT);
 
     auto const getsXRPPaysUSDBook = getBookBase(std::get<ripple::Book>(
@@ -996,43 +986,39 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
         rpc::parseBook(ripple::xrpCurrency(), ripple::xrpAccount(), ripple::to_currency("USD"), issuer)
     ));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(getsXRPPaysUSDBook, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(getsXRPPaysUSDBook, MAXSEQ, _))
         .WillByDefault(Return(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(std::nullopt));
 
-    ON_CALL(*rawBackendPtr, doFetchSuccessorKey(reversedBook, MAXSEQ, _))
+    ON_CALL(*backend, doFetchSuccessorKey(reversedBook, MAXSEQ, _))
         .WillByDefault(Return(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchSuccessorKey).Times(2);
+    EXPECT_CALL(*backend, doFetchSuccessorKey).Times(2);
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObject).Times(5);
+    EXPECT_CALL(*backend, doFetchLedgerObject).Times(5);
 
     auto const indexes = std::vector<ripple::uint256>(10, ripple::uint256{INDEX2});
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{PAYS20USDGETS10XRPBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes, INDEX1).getSerializer().peekData()));
 
     // for reverse
     auto const indexes2 = std::vector<ripple::uint256>(10, ripple::uint256{INDEX1});
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}, MAXSEQ, _))
+    ON_CALL(*backend, doFetchLedgerObject(ripple::uint256{PAYS20XRPGETS10USDBOOKDIR}, MAXSEQ, _))
         .WillByDefault(Return(CreateOwnerDirLedgerObject(indexes2, INDEX2).getSerializer().peekData()));
 
     // offer owner account root
-    ON_CALL(
-        *rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, MAXSEQ, _)
-    )
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT2)).key, MAXSEQ, _))
         .WillByDefault(Return(CreateAccountRootObject(ACCOUNT2, 0, 2, 200, 2, INDEX1, 2).getSerializer().peekData()));
 
     // issuer account root
-    ON_CALL(
-        *rawBackendPtr, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, MAXSEQ, _)
-    )
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key, MAXSEQ, _))
         .WillByDefault(Return(CreateAccountRootObject(ACCOUNT, 0, 2, 200, 2, INDEX1, 2).getSerializer().peekData()));
 
     // fee
     auto feeBlob = CreateFeeSettingBlob(1, 2, 3, 4, 0);
-    ON_CALL(*rawBackendPtr, doFetchLedgerObject(ripple::keylet::fees().key, MAXSEQ, _)).WillByDefault(Return(feeBlob));
+    ON_CALL(*backend, doFetchLedgerObject(ripple::keylet::fees().key, MAXSEQ, _)).WillByDefault(Return(feeBlob));
 
     auto const gets10XRPPays20USDOffer = CreateOfferLedgerObject(
         ACCOUNT2,
@@ -1059,13 +1045,13 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
     );
 
     std::vector<Blob> const bbs(10, gets10XRPPays20USDOffer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(indexes, MAXSEQ, _)).WillByDefault(Return(bbs));
+    ON_CALL(*backend, doFetchLedgerObjects(indexes, MAXSEQ, _)).WillByDefault(Return(bbs));
 
     // for reverse
     std::vector<Blob> const bbs2(10, gets10USDPays20XRPOffer.getSerializer().peekData());
-    ON_CALL(*rawBackendPtr, doFetchLedgerObjects(indexes2, MAXSEQ, _)).WillByDefault(Return(bbs2));
+    ON_CALL(*backend, doFetchLedgerObjects(indexes2, MAXSEQ, _)).WillByDefault(Return(bbs2));
 
-    EXPECT_CALL(*rawBackendPtr, doFetchLedgerObjects).Times(1);
+    EXPECT_CALL(*backend, doFetchLedgerObjects).Times(1);
 
     static auto const expectedOffer = fmt::format(
         R"({{
@@ -1095,7 +1081,7 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
     );
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{SubscribeHandler{mockBackendPtr, subManager_}};
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output->as_object().at("offers").as_array().size(), 10);

--- a/unittests/rpc/handlers/TxTests.cpp
+++ b/unittests/rpc/handlers/TxTests.cpp
@@ -140,7 +140,7 @@ class RPCTxTest : public HandlerBaseTest {};
 TEST_F(RPCTxTest, ExcessiveLgrRange)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -161,22 +161,20 @@ TEST_F(RPCTxTest, ExcessiveLgrRange)
 
 TEST_F(RPCTxTest, InvalidBinaryV1)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
         CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -193,7 +191,7 @@ TEST_F(RPCTxTest, InvalidBinaryV1)
 TEST_F(RPCTxTest, InvalidBinaryV2)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -214,7 +212,7 @@ TEST_F(RPCTxTest, InvalidBinaryV2)
 TEST_F(RPCTxTest, InvalidLgrRange)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -235,9 +233,7 @@ TEST_F(RPCTxTest, InvalidLgrRange)
 
 TEST_F(RPCTxTest, TxnNotFound)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _))
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _))
         .WillOnce(Return(std::optional<TransactionAndMetadata>{}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
@@ -245,7 +241,7 @@ TEST_F(RPCTxTest, TxnNotFound)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -264,11 +260,8 @@ TEST_F(RPCTxTest, TxnNotFound)
 
 TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllFalse)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(10);  // min
-    mockBackendPtr->updateRange(30);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _))
+    backend->setRange(10, 30);
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _))
         .WillOnce(Return(std::optional<TransactionAndMetadata>{}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
@@ -276,7 +269,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllFalse)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -298,11 +291,8 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllFalse)
 
 TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllTrue)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(1);     // min
-    mockBackendPtr->updateRange(1000);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _))
+    backend->setRange(1, 1000);
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _))
         .WillOnce(Return(std::optional<TransactionAndMetadata>{}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
@@ -310,7 +300,7 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllTrue)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -333,11 +323,8 @@ TEST_F(RPCTxTest, TxnNotFoundInGivenRangeSearchAllTrue)
 // when ledger range and ctid are provided, searched_all should not be present, because the seq is specified in ctid
 TEST_F(RPCTxTest, CtidNotFoundSearchAllFalse)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-    mockBackendPtr->updateRange(1);     // min
-    mockBackendPtr->updateRange(1000);  // max
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _))
+    backend->setRange(1, 1000);
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _))
         .WillOnce(Return(std::vector<TransactionAndMetadata>{}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
@@ -345,7 +332,7 @@ TEST_F(RPCTxTest, CtidNotFoundSearchAllFalse)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{2}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "ctid": "{}",
@@ -366,9 +353,6 @@ TEST_F(RPCTxTest, CtidNotFoundSearchAllFalse)
 
 TEST_F(RPCTxTest, DefaultParameter_API_v1)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
@@ -376,14 +360,14 @@ TEST_F(RPCTxTest, DefaultParameter_API_v1)
     tx.date = 123456;
     tx.ledgerSequence = 100;
 
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -400,23 +384,20 @@ TEST_F(RPCTxTest, DefaultParameter_API_v1)
 
 TEST_F(RPCTxTest, PaymentTx_API_v1)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
     TransactionAndMetadata tx;
     tx.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 2, 3, 300).getSerializer().peekData();
     tx.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
 
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -433,24 +414,21 @@ TEST_F(RPCTxTest, PaymentTx_API_v1)
 
 TEST_F(RPCTxTest, PaymentTx_API_v2)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
     TransactionAndMetadata tx;
     tx.transaction = CreatePaymentTransactionObject(ACCOUNT, ACCOUNT2, 2, 3, 300).getSerializer().peekData();
     tx.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
 
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(tx.ledgerSequence, _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(tx.ledgerSequence, _)).WillOnce(Return(std::nullopt));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -468,9 +446,6 @@ TEST_F(RPCTxTest, PaymentTx_API_v2)
 
 TEST_F(RPCTxTest, DefaultParameter_API_v2)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
-
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
@@ -478,16 +453,16 @@ TEST_F(RPCTxTest, DefaultParameter_API_v2)
     tx.date = 123456;
     tx.ledgerSequence = 100;
 
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
     auto const ledgerinfo = CreateLedgerInfo(LEDGERHASH, tx.ledgerSequence);
-    EXPECT_CALL(*rawBackendPtr, fetchLedgerBySequence(tx.ledgerSequence, _)).WillOnce(Return(ledgerinfo));
+    EXPECT_CALL(*backend, fetchLedgerBySequence(tx.ledgerSequence, _)).WillOnce(Return(ledgerinfo));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -513,22 +488,21 @@ TEST_F(RPCTxTest, ReturnBinary)
         "inLedger": 100,
         "validated": true
     })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
         CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -557,22 +531,21 @@ TEST_F(RPCTxTest, ReturnBinaryWithCTID)
         "ctid": "C000006400640002",
         "validated": true
     })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
         CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{.networkID = 2}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -649,18 +622,17 @@ TEST_F(RPCTxTest, MintNFT)
         NFTID
     );
     TransactionAndMetadata tx = CreateMintNFTTxWithMetadata(ACCOUNT, 1, 50, 123, NFTID);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -677,18 +649,17 @@ TEST_F(RPCTxTest, MintNFT)
 TEST_F(RPCTxTest, NFTAcceptOffer)
 {
     TransactionAndMetadata tx = CreateAcceptNFTOfferTxWithMetadata(ACCOUNT, 1, 50, NFTID);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -706,18 +677,17 @@ TEST_F(RPCTxTest, NFTCancelOffer)
 {
     std::vector<std::string> ids{NFTID, NFTID2};
     TransactionAndMetadata tx = CreateCancelNFTOffersTxWithMetadata(ACCOUNT, 1, 50, ids);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this, &ids](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -742,18 +712,17 @@ TEST_F(RPCTxTest, NFTCancelOffer)
 TEST_F(RPCTxTest, NFTCreateOffer)
 {
     TransactionAndMetadata tx = CreateCreateNFTOfferTxWithMetadata(ACCOUNT, 1, 50, NFTID, 123, NFTID2);
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
-    ASSERT_NE(rawBackendPtr, nullptr);
+
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -770,7 +739,7 @@ TEST_F(RPCTxTest, NFTCreateOffer)
 TEST_F(RPCTxTest, CTIDAndTransactionBothProvided)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -792,7 +761,7 @@ TEST_F(RPCTxTest, CTIDAndTransactionBothProvided)
 TEST_F(RPCTxTest, CTIDAndTransactionBothNotProvided)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(R"({ "command": "tx"})");
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -806,7 +775,7 @@ TEST_F(RPCTxTest, CTIDAndTransactionBothNotProvided)
 TEST_F(RPCTxTest, CTIDInvalidType)
 {
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(R"({ "command": "tx", "ctid": 123})");
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -824,7 +793,7 @@ TEST_F(RPCTxTest, CTIDInvalidString)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{.networkID = 5}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(R"({ "command": "tx", "ctid": "B002807000010002"})");
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -842,7 +811,7 @@ TEST_F(RPCTxTest, CTIDNotMatch)
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{.networkID = 5}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -908,21 +877,21 @@ TEST_F(RPCTxTest, ReturnCTIDForTxInput)
             "inLedger":100,
             "validated": true
     })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
+
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
         CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{.networkID = 2}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -981,21 +950,21 @@ TEST_F(RPCTxTest, NotReturnCTIDIfETLNotAvaiable)
             "inLedger":100,
             "validated": true
     })";
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
+
     TransactionAndMetadata tx;
     tx.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 100, 200, 300).getSerializer().peekData();
     tx.transaction =
         CreateCreateOfferTransactionObject(ACCOUNT, 2, 100, CURRENCY, ACCOUNT2, 200, 300).getSerializer().peekData();
     tx.date = 123456;
     tx.ledgerSequence = 100;
-    EXPECT_CALL(*rawBackendPtr, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
+    EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(std::nullopt));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -1060,7 +1029,7 @@ TEST_F(RPCTxTest, ViaCTID)
         SEQ_FROM_CTID,
         SEQ_FROM_CTID
     );
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
+
     TransactionAndMetadata tx1;
     tx1.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 1, 200, 300).getSerializer().peekData();
     tx1.transaction =
@@ -1073,14 +1042,14 @@ TEST_F(RPCTxTest, ViaCTID)
     tx2.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     tx2.ledgerSequence = SEQ_FROM_CTID;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _)).WillOnce(Return(std::vector{tx1, tx2}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _)).WillOnce(Return(std::vector{tx1, tx2}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
     EXPECT_CALL(*rawETLPtr, getETLState).WillOnce(Return(etl::ETLState{.networkID = 2}));
 
     runSpawn([this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",
@@ -1096,7 +1065,6 @@ TEST_F(RPCTxTest, ViaCTID)
 
 TEST_F(RPCTxTest, ViaLowercaseCTID)
 {
-    auto const rawBackendPtr = dynamic_cast<MockBackend*>(mockBackendPtr.get());
     TransactionAndMetadata tx1;
     tx1.metadata = CreateMetaDataForCreateOffer(CURRENCY, ACCOUNT, 1, 200, 300).getSerializer().peekData();
     tx1.transaction =
@@ -1109,7 +1077,7 @@ TEST_F(RPCTxTest, ViaLowercaseCTID)
     tx2.metadata = CreatePaymentTransactionMetaObject(ACCOUNT, ACCOUNT2, 110, 30).getSerializer().peekData();
     tx2.ledgerSequence = SEQ_FROM_CTID;
 
-    EXPECT_CALL(*rawBackendPtr, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _)).WillOnce(Return(std::vector{tx1, tx2}));
+    EXPECT_CALL(*backend, fetchAllTransactionsInLedger(SEQ_FROM_CTID, _)).WillOnce(Return(std::vector{tx1, tx2}));
 
     auto const rawETLPtr = dynamic_cast<MockETLService*>(mockETLServicePtr.get());
     ASSERT_NE(rawETLPtr, nullptr);
@@ -1119,7 +1087,7 @@ TEST_F(RPCTxTest, ViaLowercaseCTID)
     std::transform(ctid.begin(), ctid.end(), ctid.begin(), ::tolower);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestTxHandler{mockBackendPtr, mockETLServicePtr}};
+        auto const handler = AnyHandler{TestTxHandler{backend, mockETLServicePtr}};
         auto const req = json::parse(fmt::format(
             R"({{ 
                 "command": "tx",

--- a/unittests/rpc/handlers/UnsubscribeTests.cpp
+++ b/unittests/rpc/handlers/UnsubscribeTests.cpp
@@ -532,7 +532,7 @@ TEST_P(UnsubscribeParameterTest, InvalidParams)
 {
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const req = json::parse(testBundle.testJson);
         auto const output = handler.process(req, Context{yield});
         ASSERT_FALSE(output);
@@ -545,7 +545,7 @@ TEST_P(UnsubscribeParameterTest, InvalidParams)
 TEST_F(RPCUnsubscribeTest, EmptyResponse)
 {
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(json::parse(R"({})"), Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -569,7 +569,7 @@ TEST_F(RPCUnsubscribeTest, Streams)
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubProposedTransactions).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -591,7 +591,7 @@ TEST_F(RPCUnsubscribeTest, Accounts)
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubAccount(rpc::accountFromStringStrict(ACCOUNT2).value(), _)).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -615,7 +615,7 @@ TEST_F(RPCUnsubscribeTest, AccountsProposed)
         .Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -650,7 +650,7 @@ TEST_F(RPCUnsubscribeTest, Books)
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubBook(ripple::reversed(book), _)).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());
@@ -683,7 +683,7 @@ TEST_F(RPCUnsubscribeTest, SingleBooks)
     EXPECT_CALL(*rawSubscriptionManagerPtr, unsubBook(book, _)).Times(1);
 
     runSpawn([&, this](auto yield) {
-        auto const handler = AnyHandler{TestUnsubscribeHandler{mockBackendPtr, mockSubscriptionManagerPtr}};
+        auto const handler = AnyHandler{TestUnsubscribeHandler{backend, mockSubscriptionManagerPtr}};
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output->as_object().empty());

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -195,12 +195,11 @@ struct MockBackendTestBase : virtual public NoLoggerFixture {
     {
         NoLoggerFixture::SetUp();
         backend.reset();
-        mockBackendPtr = backend;
     }
+
     void
     TearDown() override
     {
-        mockBackendPtr.reset();
         NoLoggerFixture::TearDown();
     }
 
@@ -232,6 +231,11 @@ struct MockBackendTestBase : virtual public NoLoggerFixture {
             return backend;
         }
 
+        operator std::shared_ptr<BackendInterface const>() const
+        {
+            return backend;
+        }
+
         operator MockBackend*()
         {
             MockBackend* ret = dynamic_cast<MockBackend*>(backend.get());
@@ -242,7 +246,6 @@ struct MockBackendTestBase : virtual public NoLoggerFixture {
 
 protected:
     BackendProxy backend;
-    std::shared_ptr<BackendInterface> mockBackendPtr;  // legacy compat
 };
 
 using MockBackendTest = MockBackendTestBase<true>;

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -188,26 +188,65 @@ protected:
     boost::asio::io_context ctx;
 };
 
-/**
- * @brief Fixture with a mock backend
- */
-struct MockBackendTest : virtual public NoLoggerFixture {
+template <bool IsNice = true>
+struct MockBackendTestBase : virtual public NoLoggerFixture {
     void
     SetUp() override
     {
         NoLoggerFixture::SetUp();
-        util::Config const cfg;
-        mockBackendPtr = std::make_shared<MockBackend>(cfg);
+        backend.reset();
+        mockBackendPtr = backend;
     }
     void
     TearDown() override
     {
         mockBackendPtr.reset();
+        NoLoggerFixture::TearDown();
     }
 
+    class BackendProxy {
+        std::shared_ptr<BackendInterface> backend;
+
+    private:
+        void
+        reset()
+        {
+            if constexpr (IsNice) {
+                backend = std::make_shared<::testing::NiceMock<MockBackend>>(util::Config{});
+            } else {
+                backend = std::make_shared<MockBackend>(util::Config{});
+            }
+        }
+
+        friend MockBackendTestBase;
+
+    public:
+        auto
+        operator->()
+        {
+            return backend.get();
+        }
+
+        operator std::shared_ptr<BackendInterface>()
+        {
+            return backend;
+        }
+
+        operator MockBackend*()
+        {
+            MockBackend* ret = dynamic_cast<MockBackend*>(backend.get());
+            [&] { ASSERT_NE(ret, nullptr); }();
+            return ret;
+        }
+    };
+
 protected:
-    std::shared_ptr<BackendInterface> mockBackendPtr;
+    BackendProxy backend;
+    std::shared_ptr<BackendInterface> mockBackendPtr;  // legacy compat
 };
+
+using MockBackendTest = MockBackendTestBase<true>;
+using MockBackendTestNaggy = MockBackendTestBase<false>;
 
 /**
  * @brief Fixture with a mock subscription manager
@@ -293,12 +332,13 @@ protected:
  * @brief Fixture with an mock backend and an embedded boost::asio context
  * Handler unittest base class
  */
-struct HandlerBaseTest : public MockBackendTest, public SyncAsioContextTest, public MockETLServiceTest {
+template <bool IsNice = true>
+struct HandlerBaseTestBase : public MockBackendTestBase<IsNice>, public SyncAsioContextTest, public MockETLServiceTest {
 protected:
     void
     SetUp() override
     {
-        MockBackendTest::SetUp();
+        MockBackendTestBase<IsNice>::SetUp();
         SyncAsioContextTest::SetUp();
         MockETLServiceTest::SetUp();
     }
@@ -308,6 +348,9 @@ protected:
     {
         MockETLServiceTest::TearDown();
         SyncAsioContextTest::TearDown();
-        MockBackendTest::TearDown();
+        MockBackendTestBase<IsNice>::TearDown();
     }
 };
+
+using HandlerBaseTest = HandlerBaseTestBase<true>;
+using HandlerBaseTestNaggy = HandlerBaseTestBase<false>;

--- a/unittests/util/Fixtures.h
+++ b/unittests/util/Fixtures.h
@@ -248,7 +248,23 @@ protected:
     BackendProxy backend;
 };
 
+/**
+ * @brief Fixture with a "nice" mock backend.
+ *
+ * Use @see MockBackendTestNaggy during development to get unset call expectation warnings.
+ * Once the test is ready and you are happy you can switch to this fixture to mute the warnings.
+ *
+ * A fixture that is based off of this MockBackendTest or MockBackendTestNaggy get a `backend` member
+ * that is a `BackendProxy` that can be used to access the mock backend. It can be used wherever a
+ * `std::shared_ptr<BackendInterface>` is expected as well as `*backend` can be used with EXPECT_CALL and ON_CALL.
+ */
 using MockBackendTest = MockBackendTestBase<true>;
+
+/**
+ * @brief Fixture with a "naggy" mock backend.
+ *
+ * Use this during development to get unset call expectation warnings.
+ */
 using MockBackendTestNaggy = MockBackendTestBase<false>;
 
 /**
@@ -332,8 +348,9 @@ protected:
 };
 
 /**
- * @brief Fixture with an mock backend and an embedded boost::asio context
- * Handler unittest base class
+ * @brief Fixture with an mock backend and an embedded boost::asio context.
+ *
+ * Use as a handler unittest base fixture thru either @see HandlerBaseTest or @see HandlerBaseTestNaggy.
  */
 template <bool IsNice = true>
 struct HandlerBaseTestBase : public MockBackendTestBase<IsNice>, public SyncAsioContextTest, public MockETLServiceTest {
@@ -355,5 +372,19 @@ protected:
     }
 };
 
+/**
+ * @brief Fixture with an "nice" backend mock and an embedded boost::asio context.
+ *
+ * Use @see HandlerBaseTest during development to get unset call expectation warnings from the backend mock.
+ * Once the test is ready and you are happy you can switch to this fixture to mute the warnings.
+ *
+ * @see BackendBaseTest for more details on the injected backend mock.
+ */
 using HandlerBaseTest = HandlerBaseTestBase<true>;
+
+/**
+ * @brief Fixture with an "naggy" backend mock and an embedded boost::asio context.
+ *
+ * Use this during development to get unset call expectation warnings from the backend mock.
+ */
 using HandlerBaseTestNaggy = HandlerBaseTestBase<false>;

--- a/unittests/web/RPCServerHandlerTests.cpp
+++ b/unittests/web/RPCServerHandlerTests.cpp
@@ -76,10 +76,10 @@ protected:
         etl = std::make_shared<MockETLService>();
         rpcEngine = std::make_shared<MockAsyncRPCEngine>();
         tagFactory = std::make_shared<util::TagDecoratorFactory>(cfg);
-        subManager = std::make_shared<SubscriptionManager>(cfg, mockBackendPtr);
+        subManager = std::make_shared<SubscriptionManager>(cfg, backend);
         session = std::make_shared<MockWsBase>(*tagFactory);
         handler = std::make_shared<RPCServerHandler<MockAsyncRPCEngine, MockETLService>>(
-            cfg, mockBackendPtr, rpcEngine, etl, subManager
+            cfg, backend, rpcEngine, etl, subManager
         );
     }
 
@@ -105,8 +105,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPDefaultPath)
                                         "params": [{}]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = "{}";
     static auto constexpr response = R"({
@@ -138,8 +137,7 @@ TEST_F(WebRPCServerHandlerTest, WsNormalPath)
                                         "id": 99
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = "{}";
     static auto constexpr response = R"({
@@ -171,8 +169,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPForwardedPath)
                                         "params": [{}]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = R"({
                                         "result": {
@@ -211,8 +208,7 @@ TEST_F(WebRPCServerHandlerTest, WsForwardedPath)
                                         "id": 99
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = R"({
                                         "result": {
@@ -271,8 +267,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPErrorPath)
                                         ]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "method": "ledger",
@@ -314,8 +309,7 @@ TEST_F(WebRPCServerHandlerTest, WsErrorPath)
                                         ]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "command": "ledger",
@@ -395,8 +389,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPInvalidAPIVersion)
                                         }]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = "invalid_API_version";
 
@@ -415,8 +408,7 @@ TEST_F(WebRPCServerHandlerTest, WSInvalidAPIVersion)
                                         "api_version": null
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = R"({
                                         "error": "invalid_API_version",
@@ -440,8 +432,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPBadSyntaxWhenRequestSubscribe)
 {
     static auto constexpr request = R"({"method": "subscribe"})";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = R"({
                                         "result": {
@@ -467,8 +458,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPMissingCommand)
 {
     static auto constexpr request = R"({"method2": "server_info"})";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = "Null method";
 
@@ -483,8 +473,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandNotString)
 {
     static auto constexpr request = R"({"method": 1})";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = "method is not string";
 
@@ -499,8 +488,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPCommandIsEmpty)
 {
     static auto constexpr request = R"({"method": ""})";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = "method is empty";
 
@@ -519,8 +507,7 @@ TEST_F(WebRPCServerHandlerTest, WsMissingCommand)
                                         "id": 99
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response = R"({
                                         "error": "missingCommand",
@@ -545,8 +532,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableNotArray)
 {
     static auto constexpr response = "params unparseable";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "method": "ledger",
@@ -564,8 +550,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPParamsUnparseableArrayWithDigit)
 {
     static auto constexpr response = "params unparseable";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "method": "ledger",
@@ -595,8 +580,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPInternalError)
                                         }
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "method": "ledger",
@@ -627,8 +611,7 @@ TEST_F(WebRPCServerHandlerTest, WsInternalError)
                                         }
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr requestJSON = R"({
                                             "command": "ledger",
@@ -649,8 +632,7 @@ TEST_F(WebRPCServerHandlerTest, HTTPOutDated)
                                         "params": [{}]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = "{}";
     static auto constexpr response = R"({
@@ -687,8 +669,7 @@ TEST_F(WebRPCServerHandlerTest, WsOutdated)
                                         "id": 99
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr result = "{}";
     static auto constexpr response = R"({
@@ -723,15 +704,14 @@ TEST_F(WebRPCServerHandlerTest, WsTooBusy)
 
     auto localRpcEngine = std::make_shared<MockRPCEngine>();
     auto localHandler = std::make_shared<RPCServerHandler<MockRPCEngine, MockETLService>>(
-        cfg, mockBackendPtr, localRpcEngine, etl, subManager
+        cfg, backend, localRpcEngine, etl, subManager
     );
     static auto constexpr request = R"({
                                         "command": "server_info",
                                         "id": 99
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response =
         R"({
@@ -753,15 +733,14 @@ TEST_F(WebRPCServerHandlerTest, HTTPTooBusy)
 {
     auto localRpcEngine = std::make_shared<MockRPCEngine>();
     auto localHandler = std::make_shared<RPCServerHandler<MockRPCEngine, MockETLService>>(
-        cfg, mockBackendPtr, localRpcEngine, etl, subManager
+        cfg, backend, localRpcEngine, etl, subManager
     );
     static auto constexpr request = R"({
                                         "method": "server_info",
                                         "params": [{}]
                                     })";
 
-    mockBackendPtr->updateRange(MINSEQ);  // min
-    mockBackendPtr->updateRange(MAXSEQ);  // max
+    backend->setRange(MINSEQ, MAXSEQ);
 
     static auto constexpr response =
         R"({


### PR DESCRIPTION
- Remove the need for dynamic_cast everywhere
- Refactor impacted unittest code for readability and conciseness
- Add a setRange(min, max) member function in BackendInterface (to be used for testing purposes)