### PR TITLE
Add api_version to ws response

### DIFF
--- a/src/web/impl/ErrorHandling.h
+++ b/src/web/impl/ErrorHandling.h
@@ -150,18 +150,23 @@ public:
         auto e = rpc::makeError(error);
 
         if (request_) {
-            auto const& req = request_.value();
-            auto const id = req.contains("id") ? req.at("id") : nullptr;
-            if (not id.is_null())
-                e["id"] = id;
+            auto const appendFieldIfExist = [&](auto const& field) {
+                if (request_->contains(field) and not request_->at(field).is_null())
+                    e[field] = request_->at(field);
+            };
 
-            e["request"] = req;
+            appendFieldIfExist(JS(id));
+
+            if (connection_->upgraded)
+                appendFieldIfExist(JS(api_version));
+
+            e[JS(request)] = request_.value();
         }
 
         if (connection_->upgraded) {
             return e;
         }
-        return {{"result", e}};
+        return {{JS(result), e}};
     }
 };
 

--- a/unittests/web/RPCServerHandlerTests.cpp
+++ b/unittests/web/RPCServerHandlerTests.cpp
@@ -129,7 +129,8 @@ TEST_F(WebRPCServerHandlerTest, WsNormalPath)
     session->upgraded = true;
     static auto constexpr request = R"({
                                         "command": "server_info",
-                                        "id": 99
+                                        "id": 99,
+                                        "api_version": 2
                                     })";
 
     backend->setRange(MINSEQ, MAXSEQ);
@@ -140,6 +141,7 @@ TEST_F(WebRPCServerHandlerTest, WsNormalPath)
                                         "id": 99,
                                         "status": "success",
                                         "type": "response",
+                                        "api_version": 2,
                                         "warnings": [
                                             {
                                                 "id": 2001,
@@ -291,10 +293,12 @@ TEST_F(WebRPCServerHandlerTest, WsErrorPath)
                                         "error_message": "ledgerIndexMalformed",
                                         "status": "error",
                                         "type": "response",
+                                        "api_version": 2,
                                         "request": {
                                             "command": "ledger",
                                             "ledger_index": "xx",
-                                            "id": "123"
+                                            "id": "123",
+                                            "api_version": 2
                                         },
                                         "warnings": [
                                             {
@@ -309,7 +313,8 @@ TEST_F(WebRPCServerHandlerTest, WsErrorPath)
     static auto constexpr requestJSON = R"({
                                             "command": "ledger",
                                             "ledger_index": "xx",
-                                            "id": "123"
+                                            "id": "123",
+                                            "api_version": 2
                                         })";
     EXPECT_CALL(*rpcEngine, buildResponse(testing::_))
         .WillOnce(testing::Return(rpc::Status{rpc::RippledError::rpcINVALID_PARAMS, "ledgerIndexMalformed"}));


### PR DESCRIPTION
Fix #1020 
When api_version is present, response of ws (not http request)will include api_version:
Error:
`{"api_version":2,"error":"actMalformed","error_code":35,"error_message":"Account malformed.","request":{"account":"r92yNeoiCdwULRbjh6cUBEbD71iHcqe1h","api_version":2,"command":"account_tx"},"status":"error","type":"response"}`

Normal:
`{"api_version":2,"result":{"account":"r92yNeoiCdwULRbjh6cUBEbD71iHcqe1hE","ledger_index_max":3214598,"ledger_index_min":3213733,"limit":0,"transactions":[],"validated":true},"status":"success","type":"response"}
`