### PR TITLE
Fix unstable unittest

### DIFF
--- a/unittests/feed/BookChangesFeedTests.cpp
+++ b/unittests/feed/BookChangesFeedTests.cpp
@@ -24,7 +24,6 @@
 #include "util/TestObject.h"
 
 #include <boost/asio/io_context.hpp>
-#include <boost/json/parse.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <ripple/protocol/STObject.h>

--- a/unittests/feed/BookChangesFeedTests.cpp
+++ b/unittests/feed/BookChangesFeedTests.cpp
@@ -18,20 +18,20 @@
 //==============================================================================
 
 #include "data/Types.h"
-#include "feed/FeedBaseTest.h"
+#include "feed/FeedTestUtil.h"
 #include "feed/impl/BookChangesFeed.h"
 #include "feed/impl/ForwardFeed.h"
 #include "util/TestObject.h"
 
 #include <boost/asio/io_context.hpp>
 #include <boost/json/parse.hpp>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <ripple/protocol/STObject.h>
 
 #include <vector>
 
 using namespace feed::impl;
-namespace json = boost::json;
 
 constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652";
 constexpr static auto ACCOUNT1 = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn";
@@ -77,15 +77,13 @@ TEST_F(FeedBookChangeTest, Pub)
                 }
             ]
         })";
-    ctx.run();
 
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(bookChangePublish));
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(bookChangePublish))).Times(1);
+    ctx.run();
 
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->count(), 0);
-    cleanReceivedFeed();
     testFeedPtr->pub(ledgerinfo, transactions);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }

--- a/unittests/feed/FeedTestUtil.h
+++ b/unittests/feed/FeedTestUtil.h
@@ -31,8 +31,6 @@
 #include <string>
 #include <utility>
 
-namespace json = boost::json;
-
 // Base class for feed tests, providing easy way to access the received feed
 template <typename TestedFeed>
 class FeedBaseTest : public SyncAsioContextTest, public MockBackendTest {
@@ -61,6 +59,7 @@ protected:
     }
 };
 
+namespace detail {
 class SharedStringJsonEqMatcher {
     std::string expected_;
 
@@ -74,13 +73,13 @@ public:
     bool
     MatchAndExplain(std::shared_ptr<std::string> const& arg, std::ostream* /* listener */) const
     {
-        return json::parse(*arg) == json::parse(expected_);
+        return boost::json::parse(*arg) == boost::json::parse(expected_);
     }
 
     void
     DescribeTo(std::ostream* os) const
     {
-        *os << "contains json" << expected_;
+        *os << "Contains json " << expected_;
     }
 
     void
@@ -89,9 +88,10 @@ public:
         *os << "Expecting json " << expected_;
     }
 };
+}  // namespace detail
 
 inline ::testing::Matcher<std::shared_ptr<std::string>>
 SharedStringJsonEq(std::string const& expected)
 {
-    return SharedStringJsonEqMatcher(expected);
+    return detail::SharedStringJsonEqMatcher(expected);
 }

--- a/unittests/feed/ForwardFeedTests.cpp
+++ b/unittests/feed/ForwardFeedTests.cpp
@@ -17,11 +17,12 @@
 */
 //==============================================================================
 
-#include "feed/FeedBaseTest.h"
+#include "feed/FeedTestUtil.h"
 #include "feed/impl/ForwardFeed.h"
 
 #include <boost/asio/io_context.hpp>
 #include <boost/json/parse.hpp>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -47,16 +48,14 @@ TEST_F(FeedForwardTest, Pub)
     EXPECT_EQ(testFeedPtr->count(), 1);
     auto const json = json::parse(FEED).as_object();
     testFeedPtr->pub(json);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(FEED))).Times(1);
     ctx.run();
 
-    EXPECT_EQ(receivedFeedMessage(), FEED);
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->count(), 0);
-    cleanReceivedFeed();
     testFeedPtr->pub(json);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedForwardTest, AutoDisconnect)
@@ -65,8 +64,8 @@ TEST_F(FeedForwardTest, AutoDisconnect)
     EXPECT_EQ(testFeedPtr->count(), 1);
     auto const json = json::parse(FEED).as_object();
     testFeedPtr->pub(json);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(FEED))).Times(1);
     ctx.run();
-    EXPECT_EQ(receivedFeedMessage(), FEED);
     sessionPtr.reset();
     EXPECT_EQ(testFeedPtr->count(), 0);
     testFeedPtr->pub(json);

--- a/unittests/feed/LedgerFeedTests.cpp
+++ b/unittests/feed/LedgerFeedTests.cpp
@@ -119,10 +119,10 @@ TEST_F(FeedLedgerTest, AutoDisconnect)
         // check the response
         EXPECT_EQ(res, json::parse(LedgerResponse));
     });
-    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(LedgerResponse))).Times(1);
     ctx.run();
     EXPECT_EQ(testFeedPtr->count(), 1);
 
+    EXPECT_CALL(*mockSessionPtr, send(_)).Times(0);
     // destroy the session
     sessionPtr.reset();
     EXPECT_EQ(testFeedPtr->count(), 0);

--- a/unittests/feed/LedgerFeedTests.cpp
+++ b/unittests/feed/LedgerFeedTests.cpp
@@ -64,6 +64,8 @@ TEST_F(FeedLedgerTest, SubPub)
         EXPECT_EQ(res, json::parse(LedgerResponse));
     });
     ctx.run();
+    EXPECT_EQ(testFeedPtr->count(), 1);
+
     constexpr static auto ledgerPub =
         R"({
             "type":"ledgerClosed",
@@ -76,14 +78,13 @@ TEST_F(FeedLedgerTest, SubPub)
             "validated_ledgers":"10-31",
             "txn_count":8
         })";
-    EXPECT_EQ(testFeedPtr->count(), 1);
-    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(ledgerPub))).Times(1);
+
     // test publish
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(ledgerPub))).Times(1);
     auto const ledgerinfo2 = CreateLedgerInfo(LEDGERHASH, 31);
     auto fee2 = ripple::Fees();
     fee2.reserve = 10;
     testFeedPtr->pub(ledgerinfo2, fee2, "10-31", 8);
-
     ctx.restart();
     ctx.run();
 
@@ -121,11 +122,11 @@ TEST_F(FeedLedgerTest, AutoDisconnect)
     });
     ctx.run();
     EXPECT_EQ(testFeedPtr->count(), 1);
-
     EXPECT_CALL(*mockSessionPtr, send(_)).Times(0);
-    // destroy the session
+
     sessionPtr.reset();
     EXPECT_EQ(testFeedPtr->count(), 0);
+
     auto const ledgerinfo2 = CreateLedgerInfo(LEDGERHASH, 31);
     auto fee2 = ripple::Fees();
     fee2.reserve = 10;

--- a/unittests/feed/ProposedTransactionFeedTests.cpp
+++ b/unittests/feed/ProposedTransactionFeedTests.cpp
@@ -28,7 +28,6 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/json/parse.hpp>
-#include <boost/json/serialize.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/unittests/feed/SingleFeedBaseTests.cpp
+++ b/unittests/feed/SingleFeedBaseTests.cpp
@@ -40,7 +40,7 @@ struct FeedBaseMockPrometheusTest : WithMockPrometheus, SyncAsioContextTest {
 protected:
     std::shared_ptr<web::ConnectionBase> sessionPtr;
     std::shared_ptr<SingleFeedBase> testFeedPtr;
-    MockSession* mockSessionPtr;
+    MockSession* mockSessionPtr = nullptr;
 
     void
     SetUp() override

--- a/unittests/feed/SingleFeedBaseTests.cpp
+++ b/unittests/feed/SingleFeedBaseTests.cpp
@@ -17,13 +17,11 @@
 */
 //==============================================================================
 
-#include "feed/FeedBaseTest.h"
+#include "feed/FeedTestUtil.h"
 #include "feed/impl/SingleFeedBase.h"
 #include "util/Fixtures.h"
 #include "util/MockPrometheus.h"
 #include "util/MockWsBase.h"
-#include "util/Taggable.h"
-#include "util/config/Config.h"
 #include "util/prometheus/Gauge.h"
 #include "web/interface/ConnectionBase.h"
 
@@ -40,16 +38,17 @@ using namespace util::prometheus;
 
 struct FeedBaseMockPrometheusTest : WithMockPrometheus, SyncAsioContextTest {
 protected:
-    util::TagDecoratorFactory tagDecoratorFactory{util::Config{}};
     std::shared_ptr<web::ConnectionBase> sessionPtr;
     std::shared_ptr<SingleFeedBase> testFeedPtr;
+    MockSession* mockSessionPtr;
 
     void
     SetUp() override
     {
         SyncAsioContextTest::SetUp();
         testFeedPtr = std::make_shared<SingleFeedBase>(ctx, "testFeed");
-        sessionPtr = std::make_shared<MockSession>(tagDecoratorFactory);
+        sessionPtr = std::make_shared<MockSession>();
+        mockSessionPtr = dynamic_cast<MockSession*>(sessionPtr.get());
     }
     void
     TearDown() override
@@ -91,29 +90,27 @@ using SingleFeedBaseTest = FeedBaseTest<NamedSingleFeedTest>;
 
 TEST_F(SingleFeedBaseTest, Test)
 {
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(FEED))).Times(1);
     testFeedPtr->sub(sessionPtr);
     EXPECT_EQ(testFeedPtr->count(), 1);
     testFeedPtr->pub(FEED);
     ctx.run();
 
-    EXPECT_EQ(receivedFeedMessage(), FEED);
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->count(), 0);
-    cleanReceivedFeed();
     testFeedPtr->pub(FEED);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(SingleFeedBaseTest, TestAutoDisconnect)
 {
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(FEED))).Times(1);
     testFeedPtr->sub(sessionPtr);
     EXPECT_EQ(testFeedPtr->count(), 1);
     testFeedPtr->pub(FEED);
     ctx.run();
 
-    EXPECT_EQ(receivedFeedMessage(), FEED);
     sessionPtr.reset();
     EXPECT_EQ(testFeedPtr->count(), 0);
 }

--- a/unittests/feed/SubscriptionManagerTests.cpp
+++ b/unittests/feed/SubscriptionManagerTests.cpp
@@ -23,7 +23,6 @@
 #include "util/Fixtures.h"
 #include "util/MockWsBase.h"
 #include "util/TestObject.h"
-#include "util/config/Config.h"
 #include "web/interface/ConnectionBase.h"
 
 #include <boost/asio/executor_work_guard.hpp>
@@ -31,7 +30,6 @@
 #include <boost/asio/spawn.hpp>
 #include <boost/json/object.hpp>
 #include <boost/json/parse.hpp>
-#include <boost/json/serialize.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <ripple/protocol/Book.h>
@@ -56,10 +54,9 @@ using namespace feed::impl;
 
 class SubscriptionManagerTest : public MockBackendTest, public SyncAsioContextTest {
 protected:
-    util::Config cfg;
     std::shared_ptr<SubscriptionManager> SubscriptionManagerPtr;
     std::shared_ptr<web::ConnectionBase> session;
-    MockSession* sessionPtr;
+    MockSession* sessionPtr = nullptr;
 
     void
     SetUp() override

--- a/unittests/feed/TrackableSignalTests.cpp
+++ b/unittests/feed/TrackableSignalTests.cpp
@@ -33,19 +33,17 @@ using namespace testing;
 
 struct FeedTrackableSignalTests : Test {
 protected:
-    util::TagDecoratorFactory tagDecoratorFactory{util::Config{}};
     std::shared_ptr<web::ConnectionBase> sessionPtr;
 
     void
     SetUp() override
     {
-        sessionPtr = std::make_shared<MockSession>(tagDecoratorFactory);
+        sessionPtr = std::make_shared<MockSession>();
     }
 
     void
     TearDown() override
     {
-        sessionPtr.reset();
     }
 };
 

--- a/unittests/feed/TrackableSignalTests.cpp
+++ b/unittests/feed/TrackableSignalTests.cpp
@@ -20,8 +20,6 @@
 #include "feed/impl/TrackableSignal.h"
 #include "feed/impl/TrackableSignalMap.h"
 #include "util/MockWsBase.h"
-#include "util/Taggable.h"
-#include "util/config/Config.h"
 #include "web/interface/ConnectionBase.h"
 
 #include <gtest/gtest.h>

--- a/unittests/feed/TransactionFeedTests.cpp
+++ b/unittests/feed/TransactionFeedTests.cpp
@@ -28,8 +28,6 @@
 #include "web/interface/ConnectionBase.h"
 
 #include <boost/asio/io_context.hpp>
-#include <boost/json/parse.hpp>
-#include <boost/json/serialize.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <ripple/basics/base_uint.h>

--- a/unittests/feed/TransactionFeedTests.cpp
+++ b/unittests/feed/TransactionFeedTests.cpp
@@ -18,14 +18,12 @@
 //==============================================================================
 
 #include "data/Types.h"
-#include "feed/FeedBaseTest.h"
+#include "feed/FeedTestUtil.h"
 #include "feed/impl/TransactionFeed.h"
 #include "util/Fixtures.h"
 #include "util/MockPrometheus.h"
 #include "util/MockWsBase.h"
-#include "util/Taggable.h"
 #include "util/TestObject.h"
-#include "util/config/Config.h"
 #include "util/prometheus/Gauge.h"
 #include "web/interface/ConnectionBase.h"
 
@@ -164,7 +162,6 @@ constexpr static auto TRAN_V2 =
 
 using namespace feed::impl;
 using namespace util::prometheus;
-namespace json = boost::json;
 
 using FeedTransactionTest = FeedBaseTest<TransactionFeed>;
 
@@ -181,18 +178,15 @@ TEST_F(FeedTransactionTest, SubTransactionV1)
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
 
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V1))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V1));
 
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->transactionSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubTransactionV2)
@@ -207,19 +201,16 @@ TEST_F(FeedTransactionTest, SubTransactionV2)
     trans1.ledgerSequence = 32;
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
 
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->transactionSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubAccountV1)
@@ -235,20 +226,16 @@ TEST_F(FeedTransactionTest, SubAccountV1)
     trans1.transaction = obj.getSerializer().peekData();
     trans1.ledgerSequence = 32;
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
-
     testFeedPtr->pub(trans1, ledgerinfo, backend);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V1))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V1));
 
     testFeedPtr->unsub(account, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubAccountV2)
@@ -266,18 +253,15 @@ TEST_F(FeedTransactionTest, SubAccountV2)
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
 
     testFeedPtr->pub(trans1, ledgerinfo, backend);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
     testFeedPtr->unsub(account, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubBothTransactionAndAccount)
@@ -297,26 +281,18 @@ TEST_F(FeedTransactionTest, SubBothTransactionAndAccount)
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
 
     testFeedPtr->pub(trans1, ledgerinfo, backend);
-    ctx.run();
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(2);
 
-    EXPECT_EQ(receivedFeedMessage().size(), json::serialize(json::parse(TRAN_V2)).size() * 2);
-
-    cleanReceivedFeed();
-    testFeedPtr->pub(trans1, ledgerinfo, backend);
-    ctx.restart();
     ctx.run();
-    EXPECT_EQ(receivedFeedMessage().size(), json::serialize(json::parse(TRAN_V2)).size() * 2);
 
     testFeedPtr->unsub(account, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 0);
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->transactionSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubBookV1)
@@ -396,11 +372,8 @@ TEST_F(FeedTransactionTest, SubBookV1)
             "engine_result_message":"The transaction was applied. Only final in a validated ledger."
         })";
 
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(OrderbookPublish))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(OrderbookPublish));
-
-    cleanReceivedFeed();
 
     // trigger by offer cancel meta data
     metaObj = CreateMetaDataForCancelOffer(CURRENCY, ISSUER, 22, 3, 1);
@@ -455,8 +428,8 @@ TEST_F(FeedTransactionTest, SubBookV1)
             "engine_result_message":"The transaction was applied. Only final in a validated ledger."
         })";
     ctx.restart();
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(OrderbookCancelPublish))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(OrderbookCancelPublish));
 
     // trigger by offer create meta data
     constexpr static auto OrderbookCreatePublish =
@@ -511,19 +484,16 @@ TEST_F(FeedTransactionTest, SubBookV1)
     metaObj = CreateMetaDataForCreateOffer(CURRENCY, ISSUER, 22, 3, 1);
     trans1.metadata = metaObj.getSerializer().peekData();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
-    cleanReceivedFeed();
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(OrderbookCreatePublish))).Times(1);
     ctx.restart();
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(OrderbookCreatePublish));
 
     testFeedPtr->unsub(book, sessionPtr);
     EXPECT_EQ(testFeedPtr->bookSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubBookV2)
@@ -603,18 +573,15 @@ TEST_F(FeedTransactionTest, SubBookV2)
             "engine_result_message":"The transaction was applied. Only final in a validated ledger."
         })";
 
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(OrderbookPublish))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(OrderbookPublish));
 
     testFeedPtr->unsub(book, sessionPtr);
     EXPECT_EQ(testFeedPtr->bookSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, TransactionContainsBothAccountsSubed)
@@ -634,27 +601,22 @@ TEST_F(FeedTransactionTest, TransactionContainsBothAccountsSubed)
     trans1.ledgerSequence = 32;
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
-
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
     testFeedPtr->unsub(account, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 1);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
-    cleanReceivedFeed();
     testFeedPtr->unsub(account2, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 0);
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubAccountRepeatWithDifferentVersion)
@@ -674,27 +636,23 @@ TEST_F(FeedTransactionTest, SubAccountRepeatWithDifferentVersion)
     trans1.ledgerSequence = 32;
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
     testFeedPtr->unsub(account, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 1);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V2))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V2));
 
     testFeedPtr->unsub(account2, sessionPtr);
     EXPECT_EQ(testFeedPtr->accountSubCount(), 0);
 
-    cleanReceivedFeed();
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubTransactionRepeatWithDifferentVersion)
@@ -713,24 +671,20 @@ TEST_F(FeedTransactionTest, SubTransactionRepeatWithDifferentVersion)
     trans1.metadata = CreatePaymentTransactionMetaObject(ACCOUNT1, ACCOUNT2, 110, 30, 22).getSerializer().peekData();
 
     testFeedPtr->pub(trans1, ledgerinfo, backend);
-
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_V1))).Times(1);
     ctx.run();
-
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_V1));
 
     testFeedPtr->unsub(sessionPtr);
     EXPECT_EQ(testFeedPtr->transactionSubCount(), 0);
-    cleanReceivedFeed();
 
     testFeedPtr->pub(trans1, ledgerinfo, backend);
     ctx.restart();
     ctx.run();
-    EXPECT_TRUE(receivedFeedMessage().empty());
 }
 
 TEST_F(FeedTransactionTest, SubRepeat)
 {
-    auto const session2 = std::make_shared<MockSession>(tagDecoratorFactory);
+    auto const session2 = std::make_shared<MockSession>();
 
     testFeedPtr->sub(sessionPtr, 1);
     testFeedPtr->sub(session2, 1);
@@ -852,8 +806,8 @@ TEST_F(FeedTransactionTest, PubTransactionWithOwnerFund)
             "engine_result_message":"The transaction was applied. Only final in a validated ledger."
         })";
 
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TransactionForOwnerFund))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TransactionForOwnerFund));
 }
 
 constexpr static auto TRAN_FROZEN =
@@ -926,9 +880,8 @@ TEST_F(FeedTransactionTest, PubTransactionOfferCreationFrozenLine)
     ON_CALL(*backend, doFetchLedgerObject(kk, testing::_, testing::_))
         .WillByDefault(testing::Return(accountRoot.getSerializer().peekData()));
     testFeedPtr->pub(trans1, ledgerinfo, backend);
-
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_FROZEN))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_FROZEN));
 }
 
 TEST_F(FeedTransactionTest, SubTransactionOfferCreationGlobalFrozen)
@@ -966,13 +919,12 @@ TEST_F(FeedTransactionTest, SubTransactionOfferCreationGlobalFrozen)
         .WillByDefault(testing::Return(accountRoot.getSerializer().peekData()));
     testFeedPtr->pub(trans1, ledgerinfo, backend);
 
+    EXPECT_CALL(*mockSessionPtr, send(SharedStringJsonEq(TRAN_FROZEN))).Times(1);
     ctx.run();
-    EXPECT_EQ(json::parse(receivedFeedMessage()), json::parse(TRAN_FROZEN));
 }
 
 struct TransactionFeedMockPrometheusTest : WithMockPrometheus, SyncAsioContextTest {
 protected:
-    util::TagDecoratorFactory tagDecoratorFactory{util::Config{}};
     std::shared_ptr<web::ConnectionBase> sessionPtr;
     std::shared_ptr<TransactionFeed> testFeedPtr;
 
@@ -981,7 +933,7 @@ protected:
     {
         SyncAsioContextTest::SetUp();
         testFeedPtr = std::make_shared<TransactionFeed>(ctx);
-        sessionPtr = std::make_shared<MockSession>(tagDecoratorFactory);
+        sessionPtr = std::make_shared<MockSession>();
     }
     void
     TearDown() override

--- a/unittests/rpc/handlers/SubscribeTests.cpp
+++ b/unittests/rpc/handlers/SubscribeTests.cpp
@@ -27,9 +27,7 @@
 #include "util/Fixtures.h"
 #include "util/MockPrometheus.h"
 #include "util/MockWsBase.h"
-#include "util/Taggable.h"
 #include "util/TestObject.h"
-#include "util/config/Config.h"
 #include "web/interface/ConnectionBase.h"
 
 #include <boost/json/parse.hpp>

--- a/unittests/rpc/handlers/SubscribeTests.cpp
+++ b/unittests/rpc/handlers/SubscribeTests.cpp
@@ -72,8 +72,7 @@ protected:
         HandlerBaseTest::SetUp();
 
         subManager_ = std::make_shared<feed::SubscriptionManager>(ctx, backend);
-        util::TagDecoratorFactory const tagDecoratorFactory{util::Config{}};
-        session_ = std::make_shared<MockSession>(tagDecoratorFactory);
+        session_ = std::make_shared<MockSession>();
     }
     void
     TearDown() override

--- a/unittests/rpc/handlers/UnsubscribeTests.cpp
+++ b/unittests/rpc/handlers/UnsubscribeTests.cpp
@@ -56,9 +56,7 @@ protected:
     {
         HandlerBaseTest::SetUp();
         MockSubscriptionManagerTest::SetUp();
-        util::Config const cfg;
-        util::TagDecoratorFactory const tagDecoratorFactory{cfg};
-        session_ = std::make_shared<MockSession>(tagDecoratorFactory);
+        session_ = std::make_shared<MockSession>();
     }
     void
     TearDown() override

--- a/unittests/rpc/handlers/UnsubscribeTests.cpp
+++ b/unittests/rpc/handlers/UnsubscribeTests.cpp
@@ -25,8 +25,6 @@
 #include "util/Fixtures.h"
 #include "util/MockSubscriptionManager.h"
 #include "util/MockWsBase.h"
-#include "util/Taggable.h"
-#include "util/config/Config.h"
 #include "web/interface/ConnectionBase.h"
 
 #include <boost/json/parse.hpp>

--- a/unittests/util/MockWsBase.h
+++ b/unittests/util/MockWsBase.h
@@ -20,29 +20,21 @@
 #pragma once
 
 #include "util/Taggable.h"
+#include "util/config/Config.h"
 #include "web/interface/ConnectionBase.h"
 
 #include <boost/beast/http/status.hpp>
+#include <gmock/gmock.h>
 
 #include <memory>
 #include <string>
 
 struct MockSession : public web::ConnectionBase {
-    std::string message;
-    void
-    send(std::shared_ptr<std::string> msg_type) override
-    {
-        message += std::string(msg_type->data());
-    }
+    MOCK_METHOD(void, send, (std::shared_ptr<std::string>), (override));
+    MOCK_METHOD(void, send, (std::string&&, boost::beast::http::status), (override));
+    util::TagDecoratorFactory tagDecoratorFactory{util::Config{}};
 
-    void
-    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    send(std::string&& msg, boost::beast::http::status = boost::beast::http::status::ok) override
-    {
-        message += msg;
-    }
-
-    MockSession(util::TagDecoratorFactory const& factory) : web::ConnectionBase(factory, "")
+    MockSession() : web::ConnectionBase(tagDecoratorFactory, "")
     {
     }
 };


### PR DESCRIPTION
We had a test failing at Debug build due to the data race happening in the MockSession. The MockSession was not properly mocked. We verified the "message" value from it. Because "message" is not thread safe, we had a SubscriptionManager test failing uncertainly. It has nothing to do with SubscriptionManager , it is an issue of MockSession. This PR changed MockSession to a proper mock. We verified the mock calls, make sure we only test the target we wanna test.
 