### PR TITLE
[CI] clang-tidy auto fixes (FAKE)

### DIFF
--- a/src/data/Types.h
+++ b/src/data/Types.h
@@ -23,6 +23,7 @@
 #include <ripple/protocol/AccountID.h>
 
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
This should trigger clang-tidy workflow once merged to `develop`.