### PR TITLE
[CI] clang-tidy auto fixes (FAKE2)

### DIFF
--- a/src/data/Types.h
+++ b/src/data/Types.h
@@ -24,6 +24,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Another attempt, this time by grepping the title instead of labels.
This is same as #1113 