### PR TITLE
Change to running workflow via gh

### DIFF
--- a/.github/workflows/clang-tidy_on_fix_merged.yml
+++ b/.github/workflows/clang-tidy_on_fix_merged.yml
@@ -13,4 +13,5 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh workflow run clang-tidy.yml

--- a/.github/workflows/clang-tidy_on_fix_merged.yml
+++ b/.github/workflows/clang-tidy_on_fix_merged.yml
@@ -7,5 +7,10 @@ on:
 jobs:
   on_fix_merge:
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.title, '[CI] clang-tidy auto fixes') }}
-    uses: ./.github/workflows/clang-tidy.yml
-    secrets: inherit
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Run clang-tidy workflow
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run clang-tidy.yml


### PR DESCRIPTION
Sadly, #1114 did not work because the workflow that ran is technically not `clang-tidy.yml` itself so it would not update the button on the readme. Instead, we are trying to run `clang-tidy.yml` directly via `gh` here.