### PR TITLE
Fixes for gcc 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *clio*.log
 /build*/
+.devcontainer
 .build
 .cache
 .vscode

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ conan remote add --insert 0 conan-non-prod http://18.143.149.228:8081/artifactor
 ```
 Now you should be able to download prebuilt `xrpl` package on some platforms.
 
+You might need to edit the `~/.conan/remotes.json` file to ensure that this newly added artifactory is listed last. Otherwise you might see compilation errors when building the project with gcc version 13 (or newer).
+
 2. Remove old packages you may have cached: 
 ```sh 
 conan remove -f xrpl

--- a/src/util/config/detail/Helpers.h
+++ b/src/util/config/detail/Helpers.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <queue>
 #include <stdexcept>

--- a/src/util/prometheus/MetricBase.h
+++ b/src/util/prometheus/MetricBase.h
@@ -22,6 +22,8 @@
 #include "util/prometheus/Label.h"
 #include "util/prometheus/OStream.h"
 
+#include <cstdint>
+
 namespace util::prometheus {
 
 /**


### PR DESCRIPTION
This PR fixes compilation errors in gcc-13 by adding `#include <cstdint>` where needed and explains how to avoid compilation errors in `rocksdb` from conan with this compiler.

There's also a drive-by addition of `.devcontainer` to `.gitignore`