### PR TITLE
Fix ETL race condition problem

### DIFF
--- a/src/data/LedgerCache.cpp
+++ b/src/data/LedgerCache.cpp
@@ -41,6 +41,14 @@ LedgerCache::latestLedgerSequence() const
 }
 
 void
+LedgerCache::waitUntilCacheContainsSeq(uint32_t seq)
+{
+    std::unique_lock lock(mtx_);
+    cv_.wait(lock, [this, seq] { return latestSeq_ >= seq; });
+    return;
+}
+
+void
 LedgerCache::update(std::vector<LedgerObject> const& objs, uint32_t seq, bool isBackground)
 {
     if (disabled_)
@@ -72,6 +80,7 @@ LedgerCache::update(std::vector<LedgerObject> const& objs, uint32_t seq, bool is
                     deletes_.insert(obj.key);
             }
         }
+        cv_.notify_all();
     }
 }
 

--- a/src/data/LedgerCache.cpp
+++ b/src/data/LedgerCache.cpp
@@ -43,6 +43,8 @@ LedgerCache::latestLedgerSequence() const
 void
 LedgerCache::waitUntilCacheContainsSeq(uint32_t seq)
 {
+    if (disabled_)
+        return;
     std::unique_lock lock(mtx_);
     cv_.wait(lock, [this, seq] { return latestSeq_ >= seq; });
     return;

--- a/src/data/LedgerCache.h
+++ b/src/data/LedgerCache.h
@@ -25,6 +25,7 @@
 #include <ripple/basics/base_uint.h>
 #include <ripple/basics/hardened_hash.h>
 
+#include <condition_variable>
 #include <map>
 #include <mutex>
 #include <shared_mutex>
@@ -67,6 +68,7 @@ class LedgerCache {
     std::map<ripple::uint256, CacheEntry> map_;
 
     mutable std::shared_mutex mtx_;
+    std::condition_variable_any cv_;
     uint32_t latestSeq_ = 0;
     std::atomic_bool full_ = false;
     std::atomic_bool disabled_ = false;
@@ -164,6 +166,9 @@ public:
      */
     float
     getSuccessorHitRate() const;
+
+    void
+    waitUntilCacheContainsSeq(uint32_t seq);
 };
 
 }  // namespace data

--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -175,8 +175,10 @@ ETLService::publishNextSequence(uint32_t nextSequence)
         // database
         constexpr size_t timeoutSeconds = 10;
         bool const success = ledgerPublisher_.publish(nextSequence, timeoutSeconds);
+
         if (!success) {
             LOG(log_.warn()) << "Failed to publish ledger with sequence = " << nextSequence << " . Beginning ETL";
+
             // returns the most recent sequence published empty optional if no sequence was published
             std::optional<uint32_t> lastPublished = runETLPipeline(nextSequence, extractorThreads_);
             LOG(log_.info()) << "Aborting ETL. Falling back to publishing";

--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -175,7 +175,6 @@ ETLService::publishNextSequence(uint32_t nextSequence)
         // database
         constexpr size_t timeoutSeconds = 10;
         bool const success = ledgerPublisher_.publish(nextSequence, timeoutSeconds);
-
         if (!success) {
             LOG(log_.warn()) << "Failed to publish ledger with sequence = " << nextSequence << " . Beginning ETL";
             // returns the most recent sequence published empty optional if no sequence was published

--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -47,7 +47,8 @@ ETLService::runETLPipeline(uint32_t startSequence, uint32_t numExtractors)
     if (finishSequence_ && startSequence > *finishSequence_)
         return {};
 
-    LOG(log_.debug()) << "Wait for cache is ready";
+    LOG(log_.debug()) << "Wait for cache containing seq " << startSequence - 1
+                      << " current cache last seq =" << backend_->cache().latestLedgerSequence();
     backend_->cache().waitUntilCacheContainsSeq(startSequence - 1);
 
     LOG(log_.debug()) << "Starting etl pipeline";

--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -175,7 +175,7 @@ ETLService::publishNextSequence(uint32_t nextSequence)
 
         if (!success) {
             LOG(log_.warn()) << "Failed to publish ledger with sequence = " << nextSequence << " . Beginning ETL";
-
+            backend_->cache().waitUntilCacheContainsSeq(nextSequence - 1);
             // returns the most recent sequence published empty optional if no sequence was published
             std::optional<uint32_t> lastPublished = runETLPipeline(nextSequence, extractorThreads_);
             LOG(log_.info()) << "Aborting ETL. Falling back to publishing";

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -91,8 +91,11 @@ public:
 
         auto const isCacheFull = backend_->cache().isFull();
         auto const isLedgerCached = backend_->cache().latestLedgerSequence() >= sequence;
-        if (isLedgerCached)
-            LOG(log_.info()) << "Fetching a ledger which has been cached before." << sequence << " is already cached";
+        if (isLedgerCached) {
+            LOG(log_.info()) << sequence << " is already cached, the current latest seq in cache is "
+                             << backend_->cache().latestLedgerSequence() << " and the cache is "
+                             << (isCacheFull ? "full" : "not full");
+        }
 
         auto response = loadBalancer_->fetchLedger(sequence, true, !isCacheFull || isLedgerCached);
         if (response)

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -89,9 +89,12 @@ public:
     {
         LOG(log_.debug()) << "Attempting to fetch ledger with sequence = " << sequence;
 
-        auto response = loadBalancer_->fetchLedger(
-            sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() + 1 < sequence
-        );
+        auto const isCacheFull = backend_->cache().isFull();
+        auto const isLedgerCached = backend_->cache().latestLedgerSequence() >= sequence;
+        if (isLedgerCached)
+            LOG(log_.info()) << "Fetching a ledger which has been cached before." << sequence << " is already cached";
+
+        auto response = loadBalancer_->fetchLedger(sequence, true, !isCacheFull || isLedgerCached);
         if (response)
             LOG(log_.trace()) << "GetLedger reply = " << response->DebugString();
 

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -90,7 +90,7 @@ public:
         LOG(log_.debug()) << "Attempting to fetch ledger with sequence = " << sequence;
 
         auto response = loadBalancer_->fetchLedger(
-            sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() != sequence - 1
+            sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() + 1 < sequence
         );
         if (response)
             LOG(log_.trace()) << "GetLedger reply = " << response->DebugString();

--- a/src/etl/impl/LedgerFetcher.h
+++ b/src/etl/impl/LedgerFetcher.h
@@ -90,7 +90,7 @@ public:
         LOG(log_.debug()) << "Attempting to fetch ledger with sequence = " << sequence;
 
         auto response = loadBalancer_->fetchLedger(
-            sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() >= sequence
+            sequence, true, !backend_->cache().isFull() || backend_->cache().latestLedgerSequence() != sequence - 1
         );
         if (response)
             LOG(log_.trace()) << "GetLedger reply = " << response->DebugString();


### PR DESCRIPTION
During the transition from a non-writer to a writer, if the previous publish has not finished ,Clio will encounter
1  the race condition here->https://github.com/XRPLF/clio/blob/develop/src/etl/impl/LedgerPublisher.h#L140 
Or 
2  the ledger from grpc arrives before the publish finishes, thus the cache not update. Get the exception here ->https://github.com/XRPLF/clio/blob/28c8fa2a9a492bd1fac1f36ecc9ef59d4e9e4f33/src/etl/impl/Transformer.h#L240

The PR adds wait before the transition.
Transition only happens when previous ledgers from DB have publish (update to cache).
