### PR TITLE
proxy server_state to rippled

### DIFF
--- a/src/rpc/common/impl/ForwardingProxy.h
+++ b/src/rpc/common/impl/ForwardingProxy.h
@@ -104,6 +104,7 @@ public:
     {
         static std::unordered_set<std::string> const proxiedCommands{
             "server_definitions",
+            "server_state",
             "submit",
             "submit_multisigned",
             "fee",


### PR DESCRIPTION
Right now, the `server_state` method is unavailable when hitting the Clio interface with just the `server_state` request.
```
{"method": "server_state","id":1,"jsonrpc":"2.0"}
```

The only way to get it to be answered by rippled, is by enforcing the routing by adding `ledger_indexer` to something different to `validated`:
```
{"method": "server_state","params": [{"ledger_index": "current"}],"id":1,"jsonrpc":"2.0"}
```

By adding the method to the proxy list, it would do it automatically without needing the workaround.

Existing implementation breaks compatibility when using XRPL.js library pointing to a Clio server, as it doesn't send any additional `params`.