### PR TITLE
Bookbase not write to table after fetching the initial ledger

### DIFF
--- a/src/etl/impl/LedgerLoader.h
+++ b/src/etl/impl/LedgerLoader.h
@@ -206,7 +206,7 @@ public:
                         if (isBookDir(cur->key, cur->blob)) {
                             auto base = getBookBase(cur->key);
                             // make sure the base is not an actual object
-                            if (!backend_->cache().get(cur->key, sequence)) {
+                            if (!backend_->cache().get(base, sequence)) {
                                 auto succ = backend_->cache().getSuccessor(base, sequence);
                                 ASSERT(succ.has_value(), "Book base {} must have a successor", ripple::strHex(base));
                                 if (succ->key == cur->key) {


### PR DESCRIPTION
Fix #1136 
The book_offers can not find any offers as the result of lack of bookbase index when cache is loading or disable.

