### PR TITLE
Fix range deletion tool

### DIFF
--- a/tools/cassandra_delete_range/main.go
+++ b/tools/cassandra_delete_range/main.go
@@ -42,6 +42,15 @@ var (
 	userName = kingpin.Flag("username", "Username to use when connecting to the cluster").String()
 	password = kingpin.Flag("password", "Password to use when connecting to the cluster").String()
 
+	skipSuccessorTable          = kingpin.Flag("skip-successor", "Whether to skip deletion from successor table").Default("false").Bool()
+	skipObjectsTable            = kingpin.Flag("skip-objects", "Whether to skip deletion from objects table").Default("false").Bool()
+	skipLedgerHashesTable       = kingpin.Flag("skip-ledger-hashes", "Whether to skip deletion from ledger_hashes table").Default("false").Bool()
+	skipTransactionsTable       = kingpin.Flag("skip-transactions", "Whether to skip deletion from transactions table").Default("false").Bool()
+	skipDiffTable               = kingpin.Flag("skip-diff", "Whether to skip deletion from diff table").Default("false").Bool()
+	skipLedgerTransactionsTable = kingpin.Flag("skip-ledger-transactions", "Whether to skip deletion from ledger_transactions table").Default("false").Bool()
+	skipLedgersTable            = kingpin.Flag("skip-ledgers", "Whether to skip deletion from ledgers table").Default("false").Bool()
+	skipWriteLatestLedger       = kingpin.Flag("skip-write-latest-ledger", "Whether to skip writing the latest ledger index").Default("false").Bool()
+
 	numberOfParallelClientThreads = 1           // the calculated number of parallel threads the client should run
 	ranges                        []*tokenRange // the calculated ranges to be executed in parallel
 )
@@ -203,7 +212,36 @@ Page size                     : %d
 # of parallel threads         : %d
 # of ranges to be executed    : %d
 
-`, *earliestLedgerIdx, *clusterHosts, *keyspace, *clusterConsistency, cluster.Timeout/1000/1000, *clusterNumConnections, *clusterCQLVersion, *clusterPageSize, numberOfParallelClientThreads, len(ranges))
+Skip deletion of:
+- successor table             : %t
+- objects table               : %t
+- ledger_hashes table         : %t
+- transactions table          : %t
+- diff table                  : %t
+- ledger_transactions table   : %t
+- ledgers table               : %t
+
+Will rite latest ledger       : %t
+
+`,
+		*earliestLedgerIdx,
+		*clusterHosts,
+		*keyspace,
+		*clusterConsistency,
+		cluster.Timeout/1000/1000,
+		*clusterNumConnections,
+		*clusterCQLVersion,
+		*clusterPageSize,
+		numberOfParallelClientThreads,
+		len(ranges),
+		*skipSuccessorTable,
+		*skipObjectsTable,
+		*skipLedgerHashesTable,
+		*skipTransactionsTable,
+		*skipDiffTable,
+		*skipLedgerTransactionsTable,
+		*skipLedgersTable,
+		*skipWriteLatestLedger)
 
 	fmt.Println(runParameters)
 
@@ -278,94 +316,108 @@ func deleteLedgerData(cluster *gocql.ClusterConfig, fromLedgerIdx uint64, toLedg
 	log.Printf("Start scanning and removing data for %d -> latest (%d according to ledger_range table)\n\n", fromLedgerIdx, toLedgerIdx)
 
 	// successor queries
-	log.Println("Generating delete queries for successor table")
-	info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
-		"SELECT key, seq FROM successor WHERE token(key) >= ? AND token(key) <= ?",
-		"DELETE FROM successor WHERE key = ? AND seq = ?")
-	log.Printf("Total delete queries: %d\n", len(info.Data))
-	log.Printf("Total traversed rows: %d\n\n", rowsCount)
-	totalErrors += errCount
-	totalRows += rowsCount
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
-	totalErrors += errCount
-	totalDeletes += deleteCount
-
-	// diff queries
-	log.Println("Generating delete queries for diff table")
-	info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
-		"SELECT key, seq FROM diff WHERE token(seq) >= ? AND token(seq) <= ?",
-		"DELETE FROM diff WHERE key = ? AND seq = ?")
-	log.Printf("Total delete queries: %d\n", len(info.Data))
-	log.Printf("Total traversed rows: %d\n\n", rowsCount)
-	totalErrors += errCount
-	totalRows += rowsCount
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipSuccessorTable {
+		log.Println("Generating delete queries for successor table")
+		info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
+			"SELECT key, seq FROM successor WHERE token(key) >= ? AND token(key) <= ?",
+			"DELETE FROM successor WHERE key = ? AND seq = ?")
+		log.Printf("Total delete queries: %d\n", len(info.Data))
+		log.Printf("Total traversed rows: %d\n\n", rowsCount)
+		totalErrors += errCount
+		totalRows += rowsCount
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// objects queries
-	log.Println("Generating delete queries for objects table")
-	info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
-		"SELECT key, sequence FROM objects WHERE token(key) >= ? AND token(key) <= ?",
-		"DELETE FROM objects WHERE key = ? AND sequence = ?")
-	log.Printf("Total delete queries: %d\n", len(info.Data))
-	log.Printf("Total traversed rows: %d\n\n", rowsCount)
-	totalErrors += errCount
-	totalRows += rowsCount
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipObjectsTable {
+		log.Println("Generating delete queries for objects table")
+		info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
+			"SELECT key, sequence FROM objects WHERE token(key) >= ? AND token(key) <= ?",
+			"DELETE FROM objects WHERE key = ? AND sequence = ?")
+		log.Printf("Total delete queries: %d\n", len(info.Data))
+		log.Printf("Total traversed rows: %d\n\n", rowsCount)
+		totalErrors += errCount
+		totalRows += rowsCount
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// ledger_hashes queries
-	log.Println("Generating delete queries for ledger_hashes table")
-	info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
-		"SELECT hash, sequence FROM ledger_hashes WHERE token(hash) >= ? AND token(hash) <= ?",
-		"DELETE FROM ledger_hashes WHERE hash = ?")
-	log.Printf("Total delete queries: %d\n", len(info.Data))
-	log.Printf("Total traversed rows: %d\n\n", rowsCount)
-	totalErrors += errCount
-	totalRows += rowsCount
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: false})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipLedgerHashesTable {
+		log.Println("Generating delete queries for ledger_hashes table")
+		info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
+			"SELECT hash, sequence FROM ledger_hashes WHERE token(hash) >= ? AND token(hash) <= ?",
+			"DELETE FROM ledger_hashes WHERE hash = ?")
+		log.Printf("Total delete queries: %d\n", len(info.Data))
+		log.Printf("Total traversed rows: %d\n\n", rowsCount)
+		totalErrors += errCount
+		totalRows += rowsCount
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: false})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// transactions queries
-	log.Println("Generating delete queries for transactions table")
-	info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
-		"SELECT hash, ledger_sequence FROM transactions WHERE token(hash) >= ? AND token(hash) <= ?",
-		"DELETE FROM transactions WHERE hash = ?")
-	log.Printf("Total delete queries: %d\n", len(info.Data))
-	log.Printf("Total traversed rows: %d\n\n", rowsCount)
-	totalErrors += errCount
-	totalRows += rowsCount
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: false})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipTransactionsTable {
+		log.Println("Generating delete queries for transactions table")
+		info, rowsCount, errCount = prepareDeleteQueries(cluster, fromLedgerIdx,
+			"SELECT hash, ledger_sequence FROM transactions WHERE token(hash) >= ? AND token(hash) <= ?",
+			"DELETE FROM transactions WHERE hash = ?")
+		log.Printf("Total delete queries: %d\n", len(info.Data))
+		log.Printf("Total traversed rows: %d\n\n", rowsCount)
+		totalErrors += errCount
+		totalRows += rowsCount
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: false})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
+
+	// diff queries
+	if !*skipDiffTable {
+		log.Println("Generating delete queries for diff table")
+		info = prepareSimpleDeleteQueries(fromLedgerIdx, toLedgerIdx,
+			"DELETE FROM diff WHERE seq = ?")
+		log.Printf("Total delete queries: %d\n\n", len(info.Data))
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: true, UseSeq: true})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// ledger_transactions queries
-	log.Println("Generating delete queries for ledger_transactions table")
-	info = prepareSimpleDeleteQueries(fromLedgerIdx, toLedgerIdx,
-		"DELETE FROM ledger_transactions WHERE ledger_sequence = ?")
-	log.Printf("Total delete queries: %d\n\n", len(info.Data))
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: false, UseSeq: true})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipLedgerTransactionsTable {
+		log.Println("Generating delete queries for ledger_transactions table")
+		info = prepareSimpleDeleteQueries(fromLedgerIdx, toLedgerIdx,
+			"DELETE FROM ledger_transactions WHERE ledger_sequence = ?")
+		log.Printf("Total delete queries: %d\n\n", len(info.Data))
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: false, UseSeq: true})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// ledgers queries
-	log.Println("Generating delete queries for ledgers table")
-	info = prepareSimpleDeleteQueries(fromLedgerIdx, toLedgerIdx,
-		"DELETE FROM ledgers WHERE sequence = ?")
-	log.Printf("Total delete queries: %d\n\n", len(info.Data))
-	deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: false, UseSeq: true})
-	totalErrors += errCount
-	totalDeletes += deleteCount
+	if !*skipLedgersTable {
+		log.Println("Generating delete queries for ledgers table")
+		info = prepareSimpleDeleteQueries(fromLedgerIdx, toLedgerIdx,
+			"DELETE FROM ledgers WHERE sequence = ?")
+		log.Printf("Total delete queries: %d\n\n", len(info.Data))
+		deleteCount, errCount = performDeleteQueries(cluster, &info, columnSettings{UseBlob: false, UseSeq: true})
+		totalErrors += errCount
+		totalDeletes += deleteCount
+	}
 
 	// TODO: tbd what to do with account_tx as it got tuple for seq_idx
 	// TODO: also, whether we need to take care of nft tables and other stuff like that
 
-	if err := updateLedgerRange(cluster, fromLedgerIdx-1); err != nil {
-		log.Printf("ERROR failed updating ledger range: %s\n", err)
-		return err
+	if !*skipWriteLatestLedger {
+		if err := updateLedgerRange(cluster, fromLedgerIdx-1); err != nil {
+			log.Printf("ERROR failed updating ledger range: %s\n", err)
+			return err
+		}
+
+		log.Printf("Updated latest ledger to %d in ledger_range table\n\n", fromLedgerIdx-1)
 	}
 
 	log.Printf("TOTAL ERRORS: %d\n", totalErrors)

--- a/tools/cassandra_delete_range/main.go
+++ b/tools/cassandra_delete_range/main.go
@@ -241,7 +241,7 @@ Will rite latest ledger       : %t
 		*skipDiffTable,
 		*skipLedgerTransactionsTable,
 		*skipLedgersTable,
-		*skipWriteLatestLedger)
+		!*skipWriteLatestLedger)
 
 	fmt.Println(runParameters)
 


### PR DESCRIPTION
Seems like the code that we copied from the example was not dealing with paging very well. The fixes in this PR appear to have helped the situation. Now after re-running the tool it's always 0 deletes across the board except for the ones generated by simply computing for each sequence (see last few tables).