### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Title with short description] (Version: [Clio version])"
+labels: bug
+assignees: ''
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+## Issue Description
+<!-- Provide a summary for your issue/bug. -->
+
+## Steps to Reproduce
+<!-- List in detail the exact steps to reproduce the unexpected behavior of the software. -->
+
+## Expected Result
+<!-- Explain in detail what behavior you expected to happen. -->
+
+## Actual Result
+<!-- Explain in detail what behavior actually happened. -->
+
+## Environment
+<!-- Please describe your environment setup (such as Ubuntu 20.04.2 with Boost 1.82). -->
+<!-- Please use the version returned by './clio_server --version' as the version number -->
+
+## Supporting Files
+<!-- If you have supporting files such as a log, feel free to post a link here using Github Gist. -->
+<!-- Consider adding configuration files with private information removed via Github Gist. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Title with short description] (Version: [Clio version])"
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+## Summary
+<!-- Provide a summary to the feature request -->
+
+## Motivation
+<!-- Why do we need this feature? -->
+
+## Solution
+<!-- What is the solution? -->
+
+## Paths Not Taken
+<!-- What other alternatives have been considered? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: A question in form of an issue
+title: "[Title with short description] (Version: Clio version)"
+labels: question
+assignees: ''
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+<!-- Consider starting a [discussion](https://github.com/XRPLF/clio/discussions) instead. -->
+
+## Question
+<!-- Your question -->
+
+## Paths Not Taken
+<!-- If applicable, what other alternatives have been considered? -->


### PR DESCRIPTION
Adding a few templates for issues - mostly copying the format of `rippled` to be consistent and align with github's project guidelines.