### PR TITLE
Fetch lfs files when generating docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with: 
+          lfs: true
 
       - name: Build docs
         run: |


### PR DESCRIPTION
Extra for #1258 

Turns out we need to tell the `checkout` action to fetch lfs files explicitly.