### PR TITLE
Upgrade CI docker image to gcc-12

### DIFF
--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_and_push:
     name: Build and push docker image
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, Linux]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(CheckCXXCompilerFlag)
 include(ClangTidy)
 
 add_library(clio_options INTERFACE)
+target_compile_features(clio_options INTERFACE cxx_std_23) # Clio needs c++23 but deps can remain c++20 for now
 target_include_directories(clio_options INTERFACE ${CMAKE_SOURCE_DIR}/src)
 
 # Set coverage build options

--- a/cmake/Settings.cmake
+++ b/cmake/Settings.cmake
@@ -23,6 +23,7 @@ set(COMPILER_FLAGS
     -Wno-null-dereference
     -Wno-maybe-uninitialized
     -Wno-unknown-warning-option # and this to work with clang
+    # TODO: Address these and others in https://github.com/XRPLF/clio/issues/1273
 )
 
 # TODO: reenable when we change CI #884 if (is_gcc AND NOT lint) list(APPEND COMPILER_FLAGS -Wduplicated-branches

--- a/cmake/Settings.cmake
+++ b/cmake/Settings.cmake
@@ -17,6 +17,12 @@ set(COMPILER_FLAGS
     -pedantic
     -Wpedantic
     -Wunused
+    # FIXME: The following bunch are needed for gcc12 atm.
+    -Wno-missing-requires
+    -Wno-restrict
+    -Wno-null-dereference
+    -Wno-maybe-uninitialized
+    -Wno-unknown-warning-option # and this to work with clang
 )
 
 # TODO: reenable when we change CI #884 if (is_gcc AND NOT lint) list(APPEND COMPILER_FLAGS -Wduplicated-branches

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
-
 class Clio(ConanFile):
     name = 'clio'
     license = 'ISC'
@@ -42,6 +41,7 @@ class Clio(ConanFile):
         'docs': False,
         
         'xrpl/*:tests': False,
+        'xrpl/*:rocksdb': False,
         'cassandra-cpp-driver/*:shared': False,
         'date/*:header_only': True,
         'grpc/*:shared': False,

--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -7,7 +7,7 @@ USER root
 WORKDIR /root/
 
 ENV GCC_VERSION=11 \
-    GCC12_VERSION=12.2.0 \
+    GCC12_VERSION=12.3.0 \
     CCACHE_VERSION=4.8.3 \
     LLVM_TOOLS_VERSION=17 \
     GH_VERSION=2.40.0 \
@@ -24,7 +24,7 @@ RUN apt-get -qq update \
 
 # Install packages
 RUN apt update -qq \
-    && apt install -y --no-install-recommends --no-install-suggests cmake python3 python3-pip sudo git git-lfs \
+    && apt install -y --no-install-recommends --no-install-suggests cmake python3 python3-pip sudo git git-lfs libmpc-dev libgmp3-dev libmpfr-dev \
     ninja-build make pkg-config libzstd-dev libzstd1 g++-${GCC_VERSION} flex bison jq graphviz \
     clang-format-${LLVM_TOOLS_VERSION} clang-tidy-${LLVM_TOOLS_VERSION} clang-tools-${LLVM_TOOLS_VERSION} \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
@@ -42,14 +42,12 @@ RUN apt update -qq \
 WORKDIR /tmp
 
 # Install gcc-12 from source
-RUN wget "http://mirrors.concertpass.com/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
+RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
     && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
     && cd "gcc-${GCC12_VERSION}" \
     && mkdir build && cd build \
-    && apt-get install -y libmpc-dev libgmp3-dev libmpfr-dev \
-    && ../configure --enable-languages=c,c++ --disable-multilib \
-    && make -j$(($(nproc --all) * 2)) BOOT_CFLAGS='-O3 -g0' profiledbootstrap \
-    && make install-strip
+    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-lto' \
+    && make -j$(nproc) profiledbootstrap && make install-strip
 
 # Install ccache from source
 RUN wget "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz" \

--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -7,6 +7,7 @@ USER root
 WORKDIR /root/
 
 ENV GCC_VERSION=11 \
+    GCC12_VERSION=12.2.0 \
     CCACHE_VERSION=4.8.3 \
     LLVM_TOOLS_VERSION=17 \
     GH_VERSION=2.40.0 \
@@ -35,10 +36,20 @@ RUN apt update -qq \
     && update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${GCC_VERSION} 100 \
     && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_TOOLS_VERSION} 100 \
     && apt-get clean && apt remove -y software-properties-common \
-    && pip3 install  -q --upgrade --no-cache-dir pip \
-    && pip3 install  -q --no-cache-dir conan==1.62 gcovr cmake-format
+    && pip3 install -q --upgrade --no-cache-dir pip \
+    && pip3 install -q --no-cache-dir conan==1.62 gcovr cmake-format
 
 WORKDIR /tmp
+
+# Install gcc-12 from source
+RUN wget "http://mirrors.concertpass.com/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
+    && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
+    && cd "gcc-${GCC12_VERSION}" \
+    && mkdir build && cd build \
+    && apt-get install -y libmpc-dev libgmp3-dev libmpfr-dev \
+    && ../configure --enable-languages=c,c++ --disable-multilib \
+    && make -j$(($(nproc --all) * 2)) BOOT_CFLAGS='-O3 -g0' profiledbootstrap \
+    && make install-strip
 
 # Install ccache from source
 RUN wget "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.gz" \
@@ -61,8 +72,12 @@ RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VER
     && tar xf gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz \
     && mv gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/bin/gh
 
-# Clean up
-RUN rm -rf  /tmp/* /var/tmp/*
+# Rewire to use gcc-12
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/local/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100 \
+    && update-alternatives --install /usr/bin/ccache ccache /usr/local/bin/ccache 100
 
 WORKDIR /root/
 # Using root by default is not very secure but github checkout action doesn't work with any other user
@@ -71,9 +86,11 @@ WORKDIR /root/
 # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
 
 # Setup conan
+# Note: intentionally leaving cppstd=20
 RUN conan profile new default --detect \
     && conan profile update settings.compiler.cppstd=20 default \
     && conan profile update settings.compiler.libcxx=libstdc++11 default \
     && conan remote add --insert 0 conan-non-prod http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
 
-
+# Clean up
+RUN rm -rf /tmp/* /var/tmp/* 

--- a/docs/build-clio.md
+++ b/docs/build-clio.md
@@ -12,13 +12,16 @@ Clio is built with [CMake](https://cmake.org/) and uses [Conan](https://conan.io
 
 | Compiler    | Version |
 |-------------|---------|
-| GCC         | 11      |
-| Clang       | 14      |
-| Apple Clang | 14.0.3  |
+| GCC         | 12      |
+| Clang       | 16      |
+| Apple Clang | 15      |
 
 ### Conan Configuration
 
-Clio does not require anything but default settings in your (`~/.conan/profiles/default`) Conan profile. It's best to have no extra flags specified.
+Clio does not require anything other than `compiler.cppstd=20` in your (`~/.conan/profiles/default`) Conan profile.
+
+> [!NOTE]
+> Although Clio is built using C++23, it's required to set `compiler.cppstd=20` for the time being as some of Clio's dependencies are not yet capable of building under C++23.
 
 > Mac example:
 
@@ -29,7 +32,7 @@ os_build=Macos
 arch=armv8
 arch_build=armv8
 compiler=apple-clang
-compiler.version=14
+compiler.version=15
 compiler.libcxx=libc++
 build_type=Release
 compiler.cppstd=20
@@ -44,7 +47,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=11
+compiler.version=12
 compiler.libcxx=libstdc++11
 build_type=Release
 compiler.cppstd=20

--- a/src/util/config/impl/Helpers.hpp
+++ b/src/util/config/impl/Helpers.hpp
@@ -24,6 +24,7 @@
 #include <queue>
 #include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 namespace util::impl {
 


### PR DESCRIPTION
Fixes #1271 

Switches to `gcc-12` compiled from source. 
LLVM is left at 17 because that's what we are already using for tooling but ideally we should be using `clang-16` to compile and the tooling should use LLVM 18 as it fixes a bug where files that contain only concepts are mistakenly marked as unnecessary includes.