### PR TITLE
Round 3 of gcc-12 attempts

### DIFF
--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_and_push:
     name: Build and push docker image
-    runs-on: [self-hosted, Linux, x-heavy]
+    runs-on: [self-hosted, Linux, heavy]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -46,7 +46,7 @@ RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${
     && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
     && cd "gcc-${GCC12_VERSION}" \
     && mkdir build && cd build \
-    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-lto' \
+    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-03' \
     && make -j$(nproc) profiledbootstrap && make install-strip
 
 # Install ccache from source


### PR DESCRIPTION
According to @legleux `x-heavy` may be smaller that `heavy`, so let's try that. 
Also disabling `lto` which may be too expensive for our runner to be able to handle.