### PR TITLE
Round 6 of gcc-12 attempts

### DIFF
--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -1,14 +1,12 @@
-FROM ubuntu:focal
+FROM rippleci/clio_gcc:12.3.0
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 USER root
-WORKDIR /root/
+WORKDIR /root
 
-ENV GCC_VERSION=11 \
-    GCC12_VERSION=12.3.0 \
-    CCACHE_VERSION=4.8.3 \
+ENV CCACHE_VERSION=4.8.3 \
     LLVM_TOOLS_VERSION=17 \
     GH_VERSION=2.40.0 \
     DOXYGEN_VERSION=1.10.0
@@ -16,38 +14,16 @@ ENV GCC_VERSION=11 \
 # Add repositories
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends --no-install-suggests gnupg wget curl software-properties-common \
-    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - \
-    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
     && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_TOOLS_VERSION} main" >> /etc/apt/sources.list \
     && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 # Install packages
 RUN apt update -qq \
-    && apt install -y --no-install-recommends --no-install-suggests cmake python3 python3-pip sudo git git-lfs libmpc-dev libgmp3-dev libmpfr-dev \
-    ninja-build make pkg-config libzstd-dev libzstd1 g++-${GCC_VERSION} flex bison jq graphviz \
-    clang-format-${LLVM_TOOLS_VERSION} clang-tidy-${LLVM_TOOLS_VERSION} clang-tools-${LLVM_TOOLS_VERSION} \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${GCC_VERSION} 100 \
+    && apt install -y --no-install-recommends --no-install-suggests cmake sudo python3 python3-pip git git-lfs ninja-build flex bison jq graphviz \
+    clang-format-${LLVM_TOOLS_VERSION} clang-tidy-${LLVM_TOOLS_VERSION} clang-tools-${LLVM_TOOLS_VERSION} \    
     && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_TOOLS_VERSION} 100 \
-    && apt-get clean && apt remove -y software-properties-common \
-    && pip3 install -q --upgrade --no-cache-dir pip \
-    && pip3 install -q --no-cache-dir conan==1.62 gcovr cmake-format
-
-WORKDIR /root/build_gcc
-
-# Install gcc-12 from source
-RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
-    && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
-    && cd "gcc-${GCC12_VERSION}" \
-    && mkdir build && cd build \
-    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-O3' \
-    && make -j$(nproc) profiledbootstrap && make install-strip
+    && pip3 install -q --upgrade --no-cache-dir pip && pip3 install -q --no-cache-dir conan==1.62 gcovr cmake-format \
+    && apt-get clean && apt remove -y software-properties-common
 
 WORKDIR /tmp
 
@@ -57,7 +33,8 @@ RUN wget "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/
     && cd "ccache-${CCACHE_VERSION}" \
     && mkdir build && cd build \
     && cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
-    && cmake --build . --target install
+    && cmake --build . --target install \
+    && rm -rf /tmp/* /var/tmp/*
 
 # Install doxygen from sounce
 RUN wget "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.src.tar.gz" \
@@ -65,21 +42,18 @@ RUN wget "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN
     && cd "doxygen-${DOXYGEN_VERSION}" \
     && mkdir build && cd build \
     && cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
-    && cmake --build . --target install
+    && cmake --build . --target install \
+    && rm -rf /tmp/* /var/tmp/*
 
 # Install gh
 RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz \
     && tar xf gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz \
-    && mv gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/bin/gh
+    && mv gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/bin/gh \
+    && rm -rf /tmp/* /var/tmp/*
 
-# Rewire to use gcc-12
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++ 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/local/bin/g++ 100 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100 \
-    && update-alternatives --install /usr/bin/ccache ccache /usr/local/bin/ccache 100
+RUN update-alternatives --install /usr/bin/ccache ccache /usr/local/bin/ccache 100
 
-WORKDIR /root/
+WORKDIR /root
 # Using root by default is not very secure but github checkout action doesn't work with any other user
 # https://github.com/actions/checkout/issues/956
 # And Github Actions doc recommends using root
@@ -91,6 +65,3 @@ RUN conan profile new default --detect \
     && conan profile update settings.compiler.cppstd=20 default \
     && conan profile update settings.compiler.libcxx=libstdc++11 default \
     && conan remote add --insert 0 conan-non-prod http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
-
-# Clean up
-RUN rm -rf /tmp/* /var/tmp/* /root/build_gcc

--- a/docker/compilers/gcc-12/dockerfile
+++ b/docker/compilers/gcc-12/dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:focal as build
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-c"]
+USER root
+WORKDIR /root
+
+ENV GCC_VERSION=11 GCC12_VERSION=12.3.0  
+
+# Add repositories
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends --no-install-suggests gnupg wget software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - \
+    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+
+# Install gcc-11
+RUN apt update -qq \
+    && apt install -y --no-install-recommends --no-install-suggests cmake sudo git libmpc-dev libgmp3-dev libmpfr-dev \
+    make pkg-config libzstd-dev libzstd1 g++-${GCC_VERSION} \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
+    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} 100 \    
+    && apt-get clean && apt remove -y software-properties-common
+
+WORKDIR /root/build_gcc
+
+# Install gcc-12 from source
+RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
+    && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
+    && cd "gcc-${GCC12_VERSION}" \
+    && mkdir build && cd build \
+    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-O3' \
+    && make -j$(nproc) profiledbootstrap && make install-strip \
+    && rm -rf /root/build_gcc
+
+# Rewire to use gcc-12
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/local/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
+
+# Clean up
+RUN rm -rf /tmp/* /var/tmp/* /root/build_gcc
+
+FROM ubuntu:focal as gcc
+WORKDIR /root
+
+# Copy gcc-12 stuff
+COPY --from=build /usr/local /usr/local
+
+# Install packages it needs
+RUN apt update -qq \
+    && apt install -y --no-install-recommends --no-install-suggests libmpc-dev libgmp3-dev libmpfr-dev libzstd-dev libzstd1


### PR DESCRIPTION
This time we compile gcc-12 outside of CI and just use it as a base image instead. Let's see if this does not fail us.
I'm leaving the runner as `heavy` and self-hosted, at least for now.