### PR TITLE
Round 7 of gcc-12 attempts

### DIFF
--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_and_push:
     name: Build and push docker image
-    runs-on: [self-hosted, Linux, heavy]
+    runs-on: ubuntu-20.04
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Ok, so our `self-hosted` runner was not able to finish the job. Either way, we were using a github runner for this workflow before and it was working every time so let's hope that will still be the case now that we don't need to build the actual gcc-12 inside of CI.