### PR TITLE
Round 8 of gcc-12 attempts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.20)
 
 set(CMAKE_PROJECT_INCLUDE_BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClioVersion.cmake)
 

--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -19,10 +19,10 @@ RUN apt-get -qq update \
 
 # Install packages
 RUN apt update -qq \
-    && apt install -y --no-install-recommends --no-install-suggests cmake sudo python3 python3-pip git git-lfs ninja-build flex bison jq graphviz \
+    && apt install -y --no-install-recommends --no-install-suggests python3 python3-pip git git-lfs make ninja-build flex bison jq graphviz \
     clang-format-${LLVM_TOOLS_VERSION} clang-tidy-${LLVM_TOOLS_VERSION} clang-tools-${LLVM_TOOLS_VERSION} \    
     && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_TOOLS_VERSION} 100 \
-    && pip3 install -q --upgrade --no-cache-dir pip && pip3 install -q --no-cache-dir conan==1.62 gcovr cmake-format \
+    && pip3 install -q --upgrade --no-cache-dir pip && pip3 install -q --no-cache-dir conan==1.62 gcovr cmake cmake-format \
     && apt-get clean && apt remove -y software-properties-common
 
 WORKDIR /tmp
@@ -36,7 +36,7 @@ RUN wget "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/
     && cmake --build . --target install \
     && rm -rf /tmp/* /var/tmp/*
 
-# Install doxygen from sounce
+# Install doxygen from source
 RUN wget "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.src.tar.gz" \
     && tar xf "doxygen-${DOXYGEN_VERSION}.src.tar.gz" \
     && cd "doxygen-${DOXYGEN_VERSION}" \
@@ -51,7 +51,9 @@ RUN wget https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VER
     && mv gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/bin/gh \
     && rm -rf /tmp/* /var/tmp/*
 
-RUN update-alternatives --install /usr/bin/ccache ccache /usr/local/bin/ccache 100
+# Libstdc++ from gcc-12 got lost, probably via apt update. Let's recover it
+RUN update-alternatives --install /usr/bin/ccache ccache /usr/local/bin/ccache 100 \
+    && update-alternatives --auto libstdc++.so.6
 
 WORKDIR /root
 # Using root by default is not very secure but github checkout action doesn't work with any other user

--- a/docker/compilers/gcc-12/dockerfile
+++ b/docker/compilers/gcc-12/dockerfile
@@ -1,56 +1,38 @@
 FROM ubuntu:focal as build
+ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 
 SHELL ["/bin/bash", "-c"]
 USER root
 WORKDIR /root
 
-ENV GCC_VERSION=11 GCC12_VERSION=12.3.0  
+ENV GCC_VERSION=12.3.0  
 
-# Add repositories
-RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends --no-install-suggests gnupg wget software-properties-common \
-    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - \
-    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
-
-# Install gcc-11
 RUN apt update -qq \
-    && apt install -y --no-install-recommends --no-install-suggests cmake sudo git libmpc-dev libgmp3-dev libmpfr-dev \
-    make pkg-config libzstd-dev libzstd1 g++-${GCC_VERSION} \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${GCC_VERSION} 100 \
-    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VERSION} 100 \    
-    && apt-get clean && apt remove -y software-properties-common
+    && apt install -qq -y --no-install-recommends --no-install-suggests \
+    gnupg wget software-properties-common build-essential
 
-WORKDIR /root/build_gcc
+WORKDIR /root
 
 # Install gcc-12 from source
-RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GCC12_VERSION}/gcc-${GCC12_VERSION}.tar.gz" \
-    && tar xf "gcc-${GCC12_VERSION}.tar.gz" \
-    && cd "gcc-${GCC12_VERSION}" \
+RUN wget "https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz" \
+    && tar xf "gcc-${GCC_VERSION}.tar.gz" \
+    && cd "gcc-${GCC_VERSION}" \
+    && ./contrib/download_prerequisites \
     && mkdir build && cd build \
-    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-O3' \
+    && ../configure --enable-languages=c,c++ --disable-multilib --with-build-config='bootstrap-O3' --prefix='/opt'  \
     && make -j$(nproc) profiledbootstrap && make install-strip \
-    && rm -rf /root/build_gcc
-
-# Rewire to use gcc-12
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++ 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/local/bin/g++ 100 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
-
-# Clean up
-RUN rm -rf /tmp/* /var/tmp/* /root/build_gcc
+    && rm -rf /root/*
 
 FROM ubuntu:focal as gcc
 WORKDIR /root
 
-# Copy gcc-12 stuff
-COPY --from=build /usr/local /usr/local
+RUN apt update -qq && apt autoclean -y && apt autoremove -y 
+COPY --from=build /opt /opt
 
-# Install packages it needs
-RUN apt update -qq \
-    && apt install -y --no-install-recommends --no-install-suggests libmpc-dev libgmp3-dev libmpfr-dev libzstd-dev libzstd1
+# Rewire to use gcc-12
+RUN update-alternatives --install /usr/bin/g++ g++ /opt/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /opt/bin/g++ 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /opt/bin/gcc 100 \
+    && update-alternatives --install /usr/bin/cc cc /opt/bin/gcc 100 \
+    && update-alternatives --install /lib/*-linux-gnu/libstdc++.so.6 libstdc++.so.6 /opt/lib64/libstdc++.so.6 100

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.20)
 project(docs)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/ClioVersion.cmake)

--- a/docs/build-clio.md
+++ b/docs/build-clio.md
@@ -6,7 +6,7 @@ Clio is built with [CMake](https://cmake.org/) and uses [Conan](https://conan.io
 
 - [Python 3.7](https://www.python.org/downloads/)
 - [Conan 1.55](https://conan.io/downloads.html)
-- [CMake 3.16](https://cmake.org/download/)
+- [CMake 3.20](https://cmake.org/download/)
 - [**Optional**] [GCovr](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html): needed for code coverage generation
 - [**Optional**] [CCache](https://ccache.dev/): speeds up compilation if you are going to compile Clio often
 


### PR DESCRIPTION
Last attempt nearly worked but `doxygen` and `ccache` built from source were broken by the system using the older `libstdc++`. This PR fixes this. Also many other small changes including but not limited to
- Much newer `cmake` from `pip` (needed for `cxx_std_23` which requires at least 3.20)
- Use `/opt` for compiler installation
- Use gcc's way of pulling in the required libraries instead of installing from apt