### PR TITLE
Round 9 of gcc-12 attempts

### DIFF
--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches: [develop]
     paths:
-      - 'docker/ci/**'
+      - 'docker/ci/**'        # CI image must update when either its dockerfile changes
+      - 'docker/compilers/**' # or any compilers changed and were pushed by hand
       - .github/workflows/update_docker_ci.yml
   workflow_dispatch:
 

--- a/docker/compilers/gcc-12/dockerfile
+++ b/docker/compilers/gcc-12/dockerfile
@@ -35,4 +35,7 @@ RUN update-alternatives --install /usr/bin/g++ g++ /opt/bin/g++ 100 \
     && update-alternatives --install /usr/bin/c++ c++ /opt/bin/g++ 100 \
     && update-alternatives --install /usr/bin/gcc gcc /opt/bin/gcc 100 \
     && update-alternatives --install /usr/bin/cc cc /opt/bin/gcc 100 \
+    && update-alternatives --install /usr/bin/gcov gcov /opt/bin/gcov 100 \
+    && update-alternatives --install /usr/bin/gcov-dump gcov-dump /opt/bin/gcov-dump 100 \
+    && update-alternatives --install /usr/bin/gcov-tool gcov-tool /opt/bin/gcov-tool 100 \
     && update-alternatives --install /lib/*-linux-gnu/libstdc++.so.6 libstdc++.so.6 /opt/lib64/libstdc++.so.6 100


### PR DESCRIPTION
Hopefully the final fix - add `gcov` alternatives to `/usr/bin` similar to the rest of `/opt/bin` things. This should fix the coverage step on CI.
The gcc-12 compiler is already pushed by hand into docker hub.