### PR TITLE
Fix deletion script

### DIFF
--- a/tools/cassandra_delete_range/main.go
+++ b/tools/cassandra_delete_range/main.go
@@ -484,8 +484,6 @@ func prepareDeleteQueries(cluster *gocql.ClusterConfig, fromLedgerIdx uint64, qu
 
 					var pageState []byte
 					var rowsRetrieved uint64
-					var key []byte
-					var seq uint64
 
 					for {
 						iter := preparedQuery.PageSize(*clusterPageSize).PageState(pageState).Iter()
@@ -493,6 +491,9 @@ func prepareDeleteQueries(cluster *gocql.ClusterConfig, fromLedgerIdx uint64, qu
 						scanner := iter.Scanner()
 
 						for scanner.Next() {
+							var key []byte
+							var seq uint64
+
 							err = scanner.Scan(&key, &seq)
 							if err == nil {
 								rowsRetrieved++


### PR DESCRIPTION
We could delete the data which we don't want to delete.

For example,  if we execute _go run main.go -i 5847959 -k clio 127.0.0.1_ trying to delete the data after _5847959_

```
cqlsh> select * from clio.successor where key=0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e;

 key                                                                | seq     | next
--------------------------------------------------------------------+---------+--------------------------------------------------------------------
 0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e | 5847959 | 0x14d1b1acb1237bdf47755743097a359d8f5e7e3e1b68991ac3bfe496f0090b39
```

Even 0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e is created at 5847959, the deletion  script still will delete it. 
```
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=0xebab9529dc2e9cb28a85c8ec1e474ecb483ee62d12256b9e97add029e1b05bf5][seq=5851461]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=0xebab9529dc2e9cb28a85c8ec1e474ecb483ee62d12256b9e97add029e1b05bf5][seq=5851564]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5853066]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5848284]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5851479]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5851396]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5849516]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=**0x14d1b15992706d9b7f97926051c5101f277a53148ea17119ca3e5ee66287665e**][seq=5848434]
2024/04/12 14:16:57 Executing delete query: DELETE FROM successor WHERE key = ? AND seq = ? [blob=0xfbd48492d8b63acfc6ca02abcd0ea00103c8daa0d12cca32f1bd4e95ab339e6a][seq=5849928]
```
Because the slice has not done deep clone. All the _Data_ in _deleteInfo_ will eventually refer to the last item in partition.

Please refer to "reuse slice session" from: https://pkg.go.dev/github.com/gocql/gocql#hdr-Reusing_slices