### PR TITLE
Static linkage

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -32,9 +32,10 @@ runs:
       env:
         BUILD_OPTION: "${{ inputs.conan_cache_hit == 'true' && 'missing' || '' }}"
         CODE_COVERAGE: "${{ inputs.code_coverage == 'true' && 'True' || 'False' }}"
+        STATIC_OPTION: "${{ inputs.static == 'true' && 'True' || 'False' }}"
       run: |
         cd build
-        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:static=${{ inputs.static == 'true' && 'True' || 'False' }} -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
+        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:static="${STATIC_OPTION}" -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
 
     - name: Run cmake
       shell: bash

--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Whether conan's coverage option should be on or not
     required: true
     default: 'false'
+  static:
+    description: Whether Clio is to be statically linked
+    required: true
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -28,9 +32,10 @@ runs:
       env:
         BUILD_OPTION: "${{ inputs.conan_cache_hit == 'true' && 'missing' || '' }}"
         CODE_COVERAGE: "${{ inputs.code_coverage == 'true' && 'True' || 'False' }}"
+        STATIC_OPTION: "${{ inputs.static == 'true' && 'True' || 'False' }}"
       run: |
         cd build
-        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
+        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:static="${STATIC_OPTION}" -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
 
     - name: Run cmake
       shell: bash

--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -32,10 +32,9 @@ runs:
       env:
         BUILD_OPTION: "${{ inputs.conan_cache_hit == 'true' && 'missing' || '' }}"
         CODE_COVERAGE: "${{ inputs.code_coverage == 'true' && 'True' || 'False' }}"
-        STATIC_OPTION: "${{ inputs.static == 'true' && 'True' || 'False' }}"
       run: |
         cd build
-        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:static="${STATIC_OPTION}" -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
+        conan install .. -of . -b $BUILD_OPTION -s build_type=${{ inputs.build_type }} -o clio:static=${{ inputs.static == 'true' && 'True' || 'False' }} -o clio:tests=True -o clio:lint=False -o clio:coverage="${CODE_COVERAGE}" --profile ${{ inputs.conan_profile }}
 
     - name: Run cmake
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,27 +52,32 @@ jobs:
             build_type: Release
             conan_profile: gcc
             code_coverage: false
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Debug
             conan_profile: gcc
             code_coverage: true
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Release
             conan_profile: clang
             code_coverage: false
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Debug
             conan_profile: clang
             code_coverage: false
+            static: true
           - os: macos14
             build_type: Release
             code_coverage: false
+            static: false
     runs-on: [self-hosted, "${{ matrix.os }}"]
     container: ${{ matrix.container }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,7 @@ jobs:
           conan_cache_hit: ${{ steps.restore_cache.outputs.conan_cache_hit }}
           build_type: ${{ matrix.build_type }}
           code_coverage: ${{ matrix.code_coverage }}
+          static: ${{ matrix.static }}
 
       - name: Build Clio
         uses: ./.github/actions/build_clio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(docs "Generate doxygen docs" FALSE)
 option(coverage "Build test coverage report" FALSE)
 option(packaging "Create distribution packages" FALSE)
 option(lint "Run clang-tidy checks during compilation" FALSE)
+option(static "Statically linked Clio" FALSE)
 # ========================================================================== #
 set(san "" CACHE STRING "Add sanitizer instrumentation")
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,8 @@ class Clio(ConanFile):
     description = 'Clio RPC server'
     settings = 'os', 'compiler', 'build_type', 'arch'
     options = {
-        'fPIC': [True, False],
+        'static': [True, False],    # static linkage
+        'fPIC': [True, False],      # unused?
         'verbose': [True, False],
         'tests': [True, False],     # build unit tests; create `clio_tests` binary
         'benchmark': [True, False], # build benchmarks; create `clio_benchmarks` binary
@@ -31,6 +32,7 @@ class Clio(ConanFile):
     ]
 
     default_options = {
+        'static': False,
         'fPIC': True,
         'verbose': False,
         'tests': False,
@@ -79,6 +81,7 @@ class Clio(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables['verbose'] = self.options.verbose
+        tc.variables['static'] = self.options.static
         tc.variables['tests'] = self.options.tests
         tc.variables['coverage'] = self.options.coverage
         tc.variables['lint'] = self.options.lint

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -9,10 +9,20 @@ target_compile_features(clio PUBLIC cxx_std_23)
 add_executable(clio_server)
 target_sources(clio_server PRIVATE Main.cpp)
 target_link_libraries(clio_server PRIVATE clio)
-target_link_options(
-  # For now let's assume that we only using libstdc++ under gcc.
-  #
-  # TODO: libc++ static linkage in https://github.com/XRPLF/clio/issues/1300
-  clio_server PRIVATE $<$<AND:$<BOOL:${is_gcc}>,$<NOT:$<BOOL:${san}>>>:-static-libstdc++ -static-libgcc>
-)
+
+if (static)
+  target_link_options(clio_server PRIVATE -static)
+
+  if (is_gcc AND NOT san)
+    target_link_options(
+      # For now let's assume that we only using libstdc++ under gcc.
+      clio_server PRIVATE -static-libstdc++ -static-libgcc
+    )
+  endif ()
+
+  if (is_appleclang)
+    message(FATAL_ERROR "Static linkage not supported on AppleClang")
+  endif ()
+endif ()
+
 set_target_properties(clio_server PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Fixes #1300 

Adds a `static` option for both conan and cmake. Uses the option on CI for all linux builds.
Note: static linkage not currently supported for AppleClang path.

I'm not too happy about adding flags like `-static` manually but that's the best way i found to achieve what we wanted. If you know a more `cmake`-y way of doing it please do let me know 👍 