### PR TITLE
Fix missing tx from account_tx

### DIFF
--- a/src/data/CassandraBackend.hpp
+++ b/src/data/CassandraBackend.hpp
@@ -172,11 +172,6 @@ public:
             if (--numRows == 0) {
                 LOG(log_.debug()) << "Setting cursor";
                 cursor = data;
-
-                // forward queries by ledger/tx sequence `>=`
-                // so we have to advance the index by one
-                if (forward)
-                    ++cursor->transactionIndex;
             }
         }
 


### PR DESCRIPTION
Since our selectAccountTxForward is no longer inclusive, we should adjust this place.
Fix #1389 