### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,20 +84,23 @@ jobs:
         include:
           - os: macos14
             build_type: Release
+            integration_tests: false
           - os: heavy
             build_type: Release
             container:
-              image: rippleci/clio_ci:latest
+              image: rippleci/cio_ci:latest
+            integration_tests: true  
           - os: heavy
             build_type: Debug
             container:
               image: rippleci/clio_ci:latest
+            integration_tests: true  
     runs-on: [self-hosted, "${{ matrix.os }}"]
     container: ${{ matrix.container }}
 
     services:
       scylladb:
-        image: 'scylladb/scylla'
+        image: ${{ (matrix.integration_tests) && 'scylladb/scylla' || '' }}
         options: >-
           --health-cmd "cqlsh -e 'describe cluster'" 
           --health-interval 10s 
@@ -118,7 +121,9 @@ jobs:
           chmod +x ./clio_tests
           ./clio_tests
   
+  # To be enabled back once docker in mac runner arrives
       - name: Run clio_integration_tests
+        if: matrix.integration_tests 
         run: |
           chmod +x ./clio_integration_tests
           ./clio_integration_tests --backend_host=scylladb

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,13 +55,13 @@ jobs:
         uses: ./.github/actions/build_clio
 
       - name: Strip tests
-        run: strip build/clio_tests
+        run: strip build/clio_tests && strip build/clio_integration_tests
 
       - name: Upload clio_tests
         uses: actions/upload-artifact@v4
         with:
           name: clio_tests_${{ runner.os }}_${{ matrix.build_type }}
-          path: build/clio_tests
+          path: build/clio_*tests
 
       - name: Compress clio_server
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,6 +122,7 @@ jobs:
           ./clio_tests
   
   # To be enabled back once docker in mac runner arrives
+  # https://github.com/XRPLF/clio/issues/1400
       - name: Run clio_integration_tests
         if: matrix.integration_tests 
         run: |


### PR DESCRIPTION
Fixes #1363 

Should be fixing both issues 
- integration tests were not included in the artifact
- docker not available on mac runner so for now we disable integration tests on the mac runner