### PR TITLE
Fix bug: api version change does not affect the subscribed session

### DIFF
--- a/src/feed/SubscriptionManager.cpp
+++ b/src/feed/SubscriptionManager.cpp
@@ -145,9 +145,9 @@ SubscriptionManager::forwardValidation(boost::json::object const& validationJson
 }
 
 void
-SubscriptionManager::subTransactions(SubscriberSharedPtr const& subscriber, std::uint32_t const apiVersion)
+SubscriptionManager::subTransactions(SubscriberSharedPtr const& subscriber)
 {
-    transactionFeed_.sub(subscriber, apiVersion);
+    transactionFeed_.sub(subscriber);
 }
 
 void
@@ -157,13 +157,9 @@ SubscriptionManager::unsubTransactions(SubscriberSharedPtr const& subscriber)
 }
 
 void
-SubscriptionManager::subAccount(
-    ripple::AccountID const& account,
-    SubscriberSharedPtr const& subscriber,
-    std::uint32_t const apiVersion
-)
+SubscriptionManager::subAccount(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber)
 {
-    transactionFeed_.sub(account, subscriber, apiVersion);
+    transactionFeed_.sub(account, subscriber);
 }
 
 void
@@ -173,13 +169,9 @@ SubscriptionManager::unsubAccount(ripple::AccountID const& account, SubscriberSh
 }
 
 void
-SubscriptionManager::subBook(
-    ripple::Book const& book,
-    SubscriberSharedPtr const& subscriber,
-    std::uint32_t const apiVersion
-)
+SubscriptionManager::subBook(ripple::Book const& book, SubscriberSharedPtr const& subscriber)
 {
-    transactionFeed_.sub(book, subscriber, apiVersion);
+    transactionFeed_.sub(book, subscriber);
 }
 
 void

--- a/src/feed/SubscriptionManager.hpp
+++ b/src/feed/SubscriptionManager.hpp
@@ -224,10 +224,9 @@ public:
     /**
      * @brief Subscribe to the transactions feed.
      * @param subscriber
-     * @param apiVersion The api version of feed to subscribe.
      */
     void
-    subTransactions(SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    subTransactions(SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Unsubscribe to the transactions feed.
@@ -240,10 +239,9 @@ public:
      * @brief Subscribe to the transactions feed, only receive the feed when particular account is affected.
      * @param account The account to watch.
      * @param subscriber
-     * @param apiVersion The api version of feed to subscribe.
      */
     void
-    subAccount(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    subAccount(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Unsubscribe to the transactions feed for particular account.
@@ -257,10 +255,9 @@ public:
      * @brief Subscribe to the transactions feed, only receive feed when particular order book is affected.
      * @param book The book to watch.
      * @param subscriber
-     * @param apiVersion The api version of feed to subscribe.
      */
     void
-    subBook(ripple::Book const& book, SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    subBook(ripple::Book const& book, SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Unsubscribe to the transactions feed for particular order book.

--- a/src/feed/impl/TransactionFeed.cpp
+++ b/src/feed/impl/TransactionFeed.cpp
@@ -70,29 +70,23 @@ TransactionFeed::TransactionSlot::operator()(AllVersionTransactionsType const& a
 }
 
 void
-TransactionFeed::sub(SubscriberSharedPtr const& subscriber, std::uint32_t const apiVersion)
+TransactionFeed::sub(SubscriberSharedPtr const& subscriber)
 {
     auto const added = signal_.connectTrackableSlot(subscriber, TransactionSlot(*this, subscriber));
     if (added) {
         LOG(logger_.info()) << subscriber->tag() << "Subscribed transactions";
         ++subAllCount_.get();
-        subscriber->apiSubVersion = apiVersion;
         subscriber->onDisconnect.connect([this](SubscriberPtr connection) { unsubInternal(connection); });
     }
 }
 
 void
-TransactionFeed::sub(
-    ripple::AccountID const& account,
-    SubscriberSharedPtr const& subscriber,
-    std::uint32_t const apiVersion
-)
+TransactionFeed::sub(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber)
 {
     auto const added = accountSignal_.connectTrackableSlot(subscriber, account, TransactionSlot(*this, subscriber));
     if (added) {
         LOG(logger_.info()) << subscriber->tag() << "Subscribed account " << account;
         ++subAccountCount_.get();
-        subscriber->apiSubVersion = apiVersion;
         subscriber->onDisconnect.connect([this, account](SubscriberPtr connection) {
             unsubInternal(account, connection);
         });
@@ -100,13 +94,12 @@ TransactionFeed::sub(
 }
 
 void
-TransactionFeed::sub(ripple::Book const& book, SubscriberSharedPtr const& subscriber, std::uint32_t const apiVersion)
+TransactionFeed::sub(ripple::Book const& book, SubscriberSharedPtr const& subscriber)
 {
     auto const added = bookSignal_.connectTrackableSlot(subscriber, book, TransactionSlot(*this, subscriber));
     if (added) {
         LOG(logger_.info()) << subscriber->tag() << "Subscribed book " << book;
         ++subBookCount_.get();
-        subscriber->apiSubVersion = apiVersion;
         subscriber->onDisconnect.connect([this, book](SubscriberPtr connection) { unsubInternal(book, connection); });
     }
 }

--- a/src/feed/impl/TransactionFeed.hpp
+++ b/src/feed/impl/TransactionFeed.hpp
@@ -91,28 +91,25 @@ public:
     /**
      * @brief Subscribe to the transaction feed.
      * @param subscriber
-     * @param apiVersion The api version of feed.
      */
     void
-    sub(SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    sub(SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Subscribe to the transaction feed, only receive the feed when particular account is affected.
      * @param subscriber
      * @param account The account to watch.
-     * @param apiVersion The api version of feed.
      */
     void
-    sub(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    sub(ripple::AccountID const& account, SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Subscribe to the transaction feed, only receive the feed when particular order book is affected.
      * @param subscriber
      * @param book The order book to watch.
-     * @param apiVersion The api version of feed.
      */
     void
-    sub(ripple::Book const& book, SubscriberSharedPtr const& subscriber, std::uint32_t apiVersion);
+    sub(ripple::Book const& book, SubscriberSharedPtr const& subscriber);
 
     /**
      * @brief Unsubscribe to the transaction feed.

--- a/src/rpc/handlers/Subscribe.hpp
+++ b/src/rpc/handlers/Subscribe.hpp
@@ -184,7 +184,7 @@ public:
     {
         auto output = Output{};
 
-        // Mimic rippled. No matter what the request is, the api version changes for the session
+        // Mimic rippled. No matter what the request is, the api version changes for the whole session
         ctx.session->apiSubVersion = ctx.apiVersion;
 
         if (input.streams) {

--- a/src/rpc/handlers/Subscribe.hpp
+++ b/src/rpc/handlers/Subscribe.hpp
@@ -184,20 +184,23 @@ public:
     {
         auto output = Output{};
 
+        // Mimic rippled. No matter what the request is, the api version changes for the session
+        ctx.session->apiSubVersion = ctx.apiVersion;
+
         if (input.streams) {
-            auto const ledger = subscribeToStreams(ctx.yield, *(input.streams), ctx.session, ctx.apiVersion);
+            auto const ledger = subscribeToStreams(ctx.yield, *(input.streams), ctx.session);
             if (!ledger.empty())
                 output.ledger = ledger;
         }
 
         if (input.accounts)
-            subscribeToAccounts(*(input.accounts), ctx.session, ctx.apiVersion);
+            subscribeToAccounts(*(input.accounts), ctx.session);
 
         if (input.accountsProposed)
             subscribeToAccountsProposed(*(input.accountsProposed), ctx.session);
 
         if (input.books)
-            subscribeToBooks(*(input.books), ctx.session, ctx.yield, ctx.apiVersion, output);
+            subscribeToBooks(*(input.books), ctx.session, ctx.yield, output);
 
         return output;
     }
@@ -207,8 +210,7 @@ private:
     subscribeToStreams(
         boost::asio::yield_context yield,
         std::vector<std::string> const& streams,
-        std::shared_ptr<web::ConnectionBase> const& session,
-        std::uint32_t apiVersion
+        std::shared_ptr<web::ConnectionBase> const& session
     ) const
     {
         auto response = boost::json::object{};
@@ -217,7 +219,7 @@ private:
             if (stream == "ledger") {
                 response = subscriptions_->subLedger(yield, session);
             } else if (stream == "transactions") {
-                subscriptions_->subTransactions(session, apiVersion);
+                subscriptions_->subTransactions(session);
             } else if (stream == "transactions_proposed") {
                 subscriptions_->subProposedTransactions(session);
             } else if (stream == "validations") {
@@ -233,15 +235,12 @@ private:
     }
 
     void
-    subscribeToAccounts(
-        std::vector<std::string> const& accounts,
-        std::shared_ptr<web::ConnectionBase> const& session,
-        std::uint32_t apiVersion
-    ) const
+    subscribeToAccounts(std::vector<std::string> const& accounts, std::shared_ptr<web::ConnectionBase> const& session)
+        const
     {
         for (auto const& account : accounts) {
             auto const accountID = accountFromStringStrict(account);
-            subscriptions_->subAccount(*accountID, session, apiVersion);
+            subscriptions_->subAccount(*accountID, session);
         }
     }
 
@@ -262,7 +261,6 @@ private:
         std::vector<OrderBook> const& books,
         std::shared_ptr<web::ConnectionBase> const& session,
         boost::asio::yield_context yield,
-        uint32_t apiVersion,
         Output& output
     ) const
     {
@@ -304,10 +302,10 @@ private:
                 }
             }
 
-            subscriptions_->subBook(internalBook.book, session, apiVersion);
+            subscriptions_->subBook(internalBook.book, session);
 
             if (internalBook.both)
-                subscriptions_->subBook(ripple::reversed(internalBook.book), session, apiVersion);
+                subscriptions_->subBook(ripple::reversed(internalBook.book), session);
         }
     }
 

--- a/src/web/interface/ConnectionBase.hpp
+++ b/src/web/interface/ConnectionBase.hpp
@@ -50,6 +50,11 @@ public:
     std::string const clientIp;
     bool upgraded = false;
     boost::signals2::signal<void(ConnectionBase*)> onDisconnect;
+    /**
+     * @brief The API version of the web stream client.
+     * This is used to track the api version of this connection, which mainly is used by subscription. It is different
+     * from the api version in Context, which is only used for the current request.
+     */
     std::uint32_t apiSubVersion = 0;
 
     /**

--- a/tests/common/feed/FeedTestUtil.hpp
+++ b/tests/common/feed/FeedTestUtil.hpp
@@ -47,6 +47,7 @@ protected:
         MockBackendTest::SetUp();
         testFeedPtr = std::make_shared<TestedFeed>(ctx);
         sessionPtr = std::make_shared<MockSession>();
+        sessionPtr->apiSubVersion = 1;
         mockSessionPtr = dynamic_cast<MockSession*>(sessionPtr.get());
     }
 

--- a/tests/unit/feed/SubscriptionManagerTests.cpp
+++ b/tests/unit/feed/SubscriptionManagerTests.cpp
@@ -68,6 +68,7 @@ protected:
         SyncAsioContextTest::SetUp();
         SubscriptionManagerPtr = std::make_shared<SubscriptionManager>(ctx, backend);
         session = std::make_shared<MockSession>();
+        session->apiSubVersion = 1;
         sessionPtr = dynamic_cast<MockSession*>(session.get());
     }
 
@@ -159,19 +160,20 @@ TEST_F(SubscriptionManagerTest, ReportCurrentSubscriber)
     SubscriptionManagerPtr->subManifest(session2);
     SubscriptionManagerPtr->subProposedTransactions(session1);
     SubscriptionManagerPtr->subProposedTransactions(session2);
-    SubscriptionManagerPtr->subTransactions(session1, 1);
-    SubscriptionManagerPtr->subTransactions(session2, 2);
+    SubscriptionManagerPtr->subTransactions(session1);
+    session2->apiSubVersion = 2;
+    SubscriptionManagerPtr->subTransactions(session2);
     SubscriptionManagerPtr->subValidation(session1);
     SubscriptionManagerPtr->subValidation(session2);
     auto const account = GetAccountIDWithString(ACCOUNT1);
-    SubscriptionManagerPtr->subAccount(account, session1, 1);
-    SubscriptionManagerPtr->subAccount(account, session2, 2);
+    SubscriptionManagerPtr->subAccount(account, session1);
+    SubscriptionManagerPtr->subAccount(account, session2);
     SubscriptionManagerPtr->subProposedAccount(account, session1);
     SubscriptionManagerPtr->subProposedAccount(account, session2);
     auto const issue1 = GetIssue(CURRENCY, ISSUER);
     ripple::Book const book{ripple::xrpIssue(), issue1};
-    SubscriptionManagerPtr->subBook(book, session1, 1);
-    SubscriptionManagerPtr->subBook(book, session2, 2);
+    SubscriptionManagerPtr->subBook(book, session1);
+    SubscriptionManagerPtr->subBook(book, session2);
     EXPECT_EQ(SubscriptionManagerPtr->report(), json::parse(ReportReturn));
 
     // count down when unsub manually
@@ -338,9 +340,9 @@ TEST_F(SubscriptionManagerTest, TransactionTest)
     auto const issue1 = GetIssue(CURRENCY, ISSUER);
     auto const account = GetAccountIDWithString(ISSUER);
     ripple::Book const book{ripple::xrpIssue(), issue1};
-    SubscriptionManagerPtr->subBook(book, session, 1);
-    SubscriptionManagerPtr->subTransactions(session, 1);
-    SubscriptionManagerPtr->subAccount(account, session, 1);
+    SubscriptionManagerPtr->subBook(book, session);
+    SubscriptionManagerPtr->subTransactions(session);
+    SubscriptionManagerPtr->subAccount(account, session);
     EXPECT_EQ(SubscriptionManagerPtr->report()["account"], 1);
     EXPECT_EQ(SubscriptionManagerPtr->report()["transactions"], 1);
     EXPECT_EQ(SubscriptionManagerPtr->report()["books"], 1);

--- a/tests/unit/rpc/handlers/SubscribeTests.cpp
+++ b/tests/unit/rpc/handlers/SubscribeTests.cpp
@@ -1089,13 +1089,13 @@ TEST_F(RPCSubscribeHandlerTest, APIVersion)
             "streams": ["transactions_proposed"]
         })"
     );
-    auto const API_VERSION = 2;
+    auto const apiVersion = 2;
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
         auto const output =
-            handler.process(input, Context{.yield = yield, .session = session_, .apiVersion = API_VERSION});
+            handler.process(input, Context{.yield = yield, .session = session_, .apiVersion = apiVersion});
         ASSERT_TRUE(output);
-        EXPECT_EQ(session_->apiSubVersion, API_VERSION);
+        EXPECT_EQ(session_->apiSubVersion, apiVersion);
     });
 }
 

--- a/tests/unit/rpc/handlers/SubscribeTests.cpp
+++ b/tests/unit/rpc/handlers/SubscribeTests.cpp
@@ -618,7 +618,6 @@ TEST_F(RPCSubscribeHandlerTest, StreamsWithoutLedger)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output.result->as_object().empty());
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         EXPECT_EQ(report.at("transactions_proposed").as_uint64(), 1);
         EXPECT_EQ(report.at("transactions").as_uint64(), 1);
@@ -663,7 +662,6 @@ TEST_F(RPCSubscribeHandlerTest, StreamsLedger)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.result->as_object(), json::parse(expectedOutput));
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         EXPECT_EQ(report.at("ledger").as_uint64(), 1);
     });
@@ -684,7 +682,6 @@ TEST_F(RPCSubscribeHandlerTest, Accounts)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output.result->as_object().empty());
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         // filter the duplicates
         EXPECT_EQ(report.at("account").as_uint64(), 2);
@@ -706,7 +703,6 @@ TEST_F(RPCSubscribeHandlerTest, AccountsProposed)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output.result->as_object().empty());
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         // filter the duplicates
         EXPECT_EQ(report.at("accounts_proposed").as_uint64(), 2);
@@ -739,7 +735,6 @@ TEST_F(RPCSubscribeHandlerTest, JustBooks)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output.result->as_object().empty());
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         EXPECT_EQ(report.at("books").as_uint64(), 1);
     });
@@ -772,7 +767,6 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSet)
         auto const output = handler.process(input, Context{yield, session_});
         ASSERT_TRUE(output);
         EXPECT_TRUE(output.result->as_object().empty());
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         // original book + reverse book
         EXPECT_EQ(report.at("books").as_uint64(), 2);
@@ -942,7 +936,6 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothSnapshotSet)
         EXPECT_EQ(output.result->as_object().at("asks").as_array().size(), 10);
         EXPECT_EQ(output.result->as_object().at("bids").as_array()[0].as_object(), json::parse(expectedOffer));
         EXPECT_EQ(output.result->as_object().at("asks").as_array()[0].as_object(), json::parse(expectedReversedOffer));
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         // original book + reverse book
         EXPECT_EQ(report.at("books").as_uint64(), 2);
@@ -1083,10 +1076,26 @@ TEST_F(RPCSubscribeHandlerTest, BooksBothUnsetSnapshotSet)
         ASSERT_TRUE(output);
         EXPECT_EQ(output.result->as_object().at("offers").as_array().size(), 10);
         EXPECT_EQ(output.result->as_object().at("offers").as_array()[0].as_object(), json::parse(expectedOffer));
-        std::this_thread::sleep_for(milliseconds(20));
         auto const report = subManager_->report();
         // original book + reverse book
         EXPECT_EQ(report.at("books").as_uint64(), 1);
+    });
+}
+
+TEST_F(RPCSubscribeHandlerTest, APIVersion)
+{
+    auto const input = json::parse(
+        R"({
+            "streams": ["transactions_proposed"]
+        })"
+    );
+    auto const API_VERSION = 2;
+    runSpawn([&, this](auto yield) {
+        auto const handler = AnyHandler{SubscribeHandler{backend, subManager_}};
+        auto const output =
+            handler.process(input, Context{.yield = yield, .session = session_, .apiVersion = API_VERSION});
+        ASSERT_TRUE(output);
+        EXPECT_EQ(session_->apiSubVersion, API_VERSION);
     });
 }
 


### PR DESCRIPTION
Fix #1133 
When subscribing the same stream twice with different api version parameter, the Clio would ignore the second request. Thus, the api version change would not take effect. 
In this PR, mimic rippled's behavior. No matter the stream is subscribed or not, the session's api version will always be updated by the latest subscribe api.
Detail:
https://github.com/XRPLF/rippled/blob/develop/src/ripple/rpc/handlers/Subscribe.cpp#L113