### PR TITLE
Upgrade to 2.2.0-rc2 with manual temporary fixes

### DIFF
--- a/cmake/deps/libxrpl.cmake
+++ b/cmake/deps/libxrpl.cmake
@@ -1,1 +1,1 @@
-find_package(xrpl REQUIRED CONFIG)
+find_package(xrpl-tmp REQUIRED CONFIG)

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,10 +25,10 @@ class Clio(ConanFile):
         'boost/1.82.0',
         'cassandra-cpp-driver/2.17.0',
         'fmt/10.1.1',
-        'protobuf/3.21.12',
+        'protobuf/3.21.9',
         'grpc/1.50.1',
         'openssl/1.1.1u',
-        'xrpl/2.2.0-b1',
+        'xrpl-tmp/2.2.0-rc2',
         'libbacktrace/cci.20210118'
     ]
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
          libbacktrace::libbacktrace
          fmt::fmt
          openssl::openssl
-         xrpl::libxrpl
+         xrpl-tmp::libxrpl
          Threads::Threads
          clio_options
 )


### PR DESCRIPTION
This is needed to unblock the currently amendment-blocked devnet.
`libxrpl 2.2.0-rc1` broke linkage against generated protobuf code. This pr uses a tmp version fro artifactory that fixes the issues.
As soon as rc3 with the fixes is made available we should move over to it.