### PR TITLE
Fix invalid syntax in example-config.json

### DIFF
--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -67,7 +67,7 @@
         "local_amdin": false
     },
     // Time in seconds for graceful shutdown. Defaults to 10 seconds. Not fully implemented yet.
-    "graceful_period": 10.,
+    "graceful_period": 10,
     // Overrides log level on a per logging channel.
     // Defaults to global "log_level" for each unspecified channel.
     "log_channels": [

--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -67,7 +67,7 @@
         "local_amdin": false
     },
     // Time in seconds for graceful shutdown. Defaults to 10 seconds. Not fully implemented yet.
-    "graceful_period": 10,
+    "graceful_period": 10.0,
     // Overrides log level on a per logging channel.
     // Defaults to global "log_level" for each unspecified channel.
     "log_channels": [


### PR DESCRIPTION
remove "." fixes syntax for example-config; runs with ./clio_server