### PR TITLE
Forward feature RPC

### DIFF
--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(
           handlers/BookChanges.cpp
           handlers/BookOffers.cpp
           handlers/DepositAuthorized.cpp
+          handlers/Feature.cpp
           handlers/GatewayBalances.cpp
           handlers/GetAggregatePrice.cpp
           handlers/Ledger.cpp

--- a/src/rpc/common/impl/ForwardingProxy.hpp
+++ b/src/rpc/common/impl/ForwardingProxy.hpp
@@ -55,16 +55,21 @@ public:
     bool
     shouldForward(web::Context const& ctx) const
     {
+        auto const& request = ctx.params;
+
         if (ctx.method == "subscribe" || ctx.method == "unsubscribe")
             return false;
+
+        // TODO https://github.com/XRPLF/clio/issues/1131 - remove once clio-native feature is
+        // implemented fully. For now we disallow forwarding of the admin api, only user api is allowed.
+        if (ctx.method == "feature" and not request.contains("vetoed"))
+            return true;
 
         if (handlerProvider_->isClioOnly(ctx.method))
             return false;
 
         if (isProxied(ctx.method))
             return true;
-
-        auto const& request = ctx.params;
 
         if (specifiesCurrentOrClosedLedger(request))
             return true;

--- a/src/rpc/common/impl/HandlerProvider.cpp
+++ b/src/rpc/common/impl/HandlerProvider.cpp
@@ -36,6 +36,7 @@
 #include "rpc/handlers/BookChanges.hpp"
 #include "rpc/handlers/BookOffers.hpp"
 #include "rpc/handlers/DepositAuthorized.hpp"
+#include "rpc/handlers/Feature.hpp"
 #include "rpc/handlers/GatewayBalances.hpp"
 #include "rpc/handlers/GetAggregatePrice.hpp"
 #include "rpc/handlers/Ledger.hpp"
@@ -85,6 +86,7 @@ ProductionHandlerProvider::ProductionHandlerProvider(
           {"book_changes", {BookChangesHandler{backend}}},
           {"book_offers", {BookOffersHandler{backend}}},
           {"deposit_authorized", {DepositAuthorizedHandler{backend}}},
+          {"feature", {FeatureHandler{}}},
           {"gateway_balances", {GatewayBalancesHandler{backend}}},
           {"get_aggregate_price", {GetAggregatePriceHandler{backend}}},
           {"ledger", {LedgerHandler{backend}}},

--- a/src/rpc/handlers/Feature.cpp
+++ b/src/rpc/handlers/Feature.cpp
@@ -1,0 +1,82 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2024, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include "rpc/handlers/Feature.hpp"
+
+#include "rpc/Errors.hpp"
+#include "rpc/JS.hpp"
+#include "rpc/common/MetaProcessors.hpp"
+#include "rpc/common/Specs.hpp"
+#include "rpc/common/Types.hpp"
+#include "rpc/common/Validators.hpp"
+
+#include <boost/json/conversion.hpp>
+#include <boost/json/value.hpp>
+#include <ripple/protocol/jss.h>
+
+#include <cstdint>
+#include <string>
+
+namespace rpc {
+
+FeatureHandler::Result
+FeatureHandler::process([[maybe_unused]] FeatureHandler::Input input, [[maybe_unused]] Context const& ctx) const
+{
+    // For now this handler only fires when "vetoed" is set in the request.
+    // This always leads to a `notSupported` error as we don't want anyone to be able to
+    return Output{};
+}
+
+RpcSpecConstRef
+FeatureHandler::spec([[maybe_unused]] uint32_t apiVersion)
+{
+    static RpcSpec const rpcSpec = {
+        {JS(feature), validation::Type<std::string>{}},
+        {JS(vetoed),
+         meta::WithCustomError{
+             validation::NotSupported{},
+             Status(RippledError::rpcNO_PERMISSION, "The admin portion of feature API is not available through Clio.")
+         }},
+    };
+    return rpcSpec;
+}
+
+void
+tag_invoke(boost::json::value_from_tag, boost::json::value& jv, FeatureHandler::Output const& output)
+{
+    using boost::json::value_from;
+
+    jv = {
+        {JS(validated), output.validated},
+    };
+}
+
+FeatureHandler::Input
+tag_invoke(boost::json::value_to_tag<FeatureHandler::Input>, boost::json::value const& jv)
+{
+    auto input = FeatureHandler::Input{};
+    auto const jsonObject = jv.as_object();
+
+    if (jsonObject.contains(JS(feature)))
+        input.feature = jv.at(JS(feature)).as_string();
+
+    return input;
+}
+
+}  // namespace rpc

--- a/src/rpc/handlers/Feature.hpp
+++ b/src/rpc/handlers/Feature.hpp
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2024, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include "rpc/common/Specs.hpp"
+#include "rpc/common/Types.hpp"
+
+#include <boost/json/conversion.hpp>
+#include <boost/json/value.hpp>
+#include <ripple/protocol/jss.h>
+
+#include <cstdint>
+#include <string>
+
+namespace rpc {
+
+/**
+ * @brief Contains common functionality for handling the `server_info` command
+ */
+class FeatureHandler {
+public:
+    /**
+     * @brief A struct to hold the input data for the command
+     */
+    struct Input {
+        std::string feature;
+    };
+
+    /**
+     * @brief A struct to hold the output data of the command
+     */
+    struct Output {
+        // validated should be sent via framework
+        bool validated = true;
+    };
+
+    using Result = HandlerReturnType<Output>;
+
+    /**
+     * @brief Returns the API specification for the command
+     *
+     * @param apiVersion The api version to return the spec for
+     * @return The spec for the given apiVersion
+     */
+    static RpcSpecConstRef
+    spec([[maybe_unused]] uint32_t apiVersion);
+
+    /**
+     * @brief Process the Feature command
+     *
+     * @param input The input data for the command
+     * @param ctx The context of the request
+     * @return The result of the operation
+     */
+    Result
+    process(Input input, Context const& ctx) const;  // NOLINT(readability-convert-member-functions-to-static)
+
+private:
+    /**
+     * @brief Convert the Output to a JSON object
+     *
+     * @param [out] jv The JSON object to convert to
+     * @param output The output to convert
+     */
+    friend void
+    tag_invoke(boost::json::value_from_tag, boost::json::value& jv, Output const& output);
+
+    /**
+     * @brief Convert a JSON object to Input type
+     *
+     * @param jv The JSON object to convert
+     * @return Input parsed from the JSON object
+     */
+    friend Input
+    tag_invoke(boost::json::value_to_tag<Input>, boost::json::value const& jv);
+};
+
+}  // namespace rpc

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(
           rpc/handlers/BookOffersTests.cpp
           rpc/handlers/DefaultProcessorTests.cpp
           rpc/handlers/DepositAuthorizedTests.cpp
+          rpc/handlers/FeatureTests.cpp
           rpc/handlers/GatewayBalancesTests.cpp
           rpc/handlers/GetAggregatePriceTests.cpp
           rpc/handlers/LedgerDataTests.cpp

--- a/tests/unit/rpc/ForwardingProxyTests.cpp
+++ b/tests/unit/rpc/ForwardingProxyTests.cpp
@@ -260,6 +260,38 @@ TEST_F(RPCForwardingProxyTest, ShouldForwardReturnsFalseIfAPIVersionIsV2)
     });
 }
 
+TEST_F(RPCForwardingProxyTest, ShouldForwardFeatureWithoutVetoedFlag)
+{
+    auto const apiVersion = 1u;
+    auto const method = "feature";
+    auto const params = json::parse(R"({"feature": "foo"})");
+
+    runSpawn([&](auto yield) {
+        auto const range = backend->fetchLedgerRange();
+        auto const ctx =
+            web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
+
+        auto const res = proxy.shouldForward(ctx);
+        ASSERT_TRUE(res);
+    });
+}
+
+TEST_F(RPCForwardingProxyTest, ShouldNeverForwardFeatureWithVetoedFlag)
+{
+    auto const apiVersion = 1u;
+    auto const method = "feature";
+    auto const params = json::parse(R"({"vetoed": true, "feature": "foo"})");
+
+    runSpawn([&](auto yield) {
+        auto const range = backend->fetchLedgerRange();
+        auto const ctx =
+            web::Context(yield, method, apiVersion, params.as_object(), nullptr, tagFactory, *range, CLIENT_IP, true);
+
+        auto const res = proxy.shouldForward(ctx);
+        ASSERT_FALSE(res);
+    });
+}
+
 TEST_F(RPCForwardingProxyTest, ShouldNeverForwardSubscribe)
 {
     auto const apiVersion = 1u;

--- a/tests/unit/rpc/handlers/FeatureTests.cpp
+++ b/tests/unit/rpc/handlers/FeatureTests.cpp
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2024, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include "rpc/Errors.hpp"
+#include "rpc/common/AnyHandler.hpp"
+#include "rpc/common/Types.hpp"
+#include "rpc/handlers/Feature.hpp"
+#include "util/Fixtures.hpp"
+
+#include <boost/json/parse.hpp>
+#include <gtest/gtest.h>
+
+using namespace rpc;
+
+class RPCFeatureHandlerTest : public HandlerBaseTest {};
+
+TEST_F(RPCFeatureHandlerTest, AlwaysNoPermissionForVetoed)
+{
+    runSpawn([](auto yield) {
+        auto const handler = AnyHandler{FeatureHandler{}};
+        auto const output =
+            handler.process(boost::json::parse(R"({"vetoed": true, "feature": "foo"})"), Context{yield});
+
+        ASSERT_FALSE(output);
+
+        auto const err = rpc::makeError(output.result.error());
+        EXPECT_EQ(err.at("error").as_string(), "noPermission");
+        EXPECT_EQ(
+            err.at("error_message").as_string(), "The admin portion of feature API is not available through Clio."
+        );
+    });
+}


### PR DESCRIPTION
Fixes #1436 

This is a temporary implementation of the `feature` RPC that will always return `noPermission` iff `vetoed` is set. 
If `vetoed` isn't specified, Clio will always forward the request to `rippled` instead.

In the future, #1131 will implement a Clio-native `feature` RPC. This requires specific support from `libxrpl` side and that is not going to be available till at least 2.2.1, hence the temporary forwarding.

It would be great to review the error message and code so that we pick the right one from the start.