### PR TITLE
Support string type integer for oracle_document_id

### DIFF
--- a/src/rpc/common/MetaProcessors.hpp
+++ b/src/rpc/common/MetaProcessors.hpp
@@ -173,7 +173,7 @@ public:
      * @brief Constructs a validator that calls the given validator `req` and returns a custom error `err` in case `req`
      * fails.
      *
-     * @param req The requirement to validate against
+     * @param reqOrModifier The requirement to validate against
      * @param err The custom error to return in case `req` fails
      */
     WithCustomError(RequirementOrModifierType reqOrModifier, Status err)
@@ -216,6 +216,13 @@ public:
         return {};
     }
 
+    /**
+     * @brief Runs the stored modifier and produces a custom error if the wrapped modifier fails.
+     *
+     * @param value The JSON value representing the outer object. This value can be modified by the modifier.
+     * @param key The key used to retrieve the element from the outer object
+     * @return Possibly an error
+     */
     MaybeError
     modify(boost::json::value& value, std::string_view key) const
         requires SomeModifier<RequirementOrModifierType>

--- a/src/rpc/common/MetaProcessors.hpp
+++ b/src/rpc/common/MetaProcessors.hpp
@@ -20,10 +20,8 @@
 #pragma once
 
 #include "rpc/Errors.hpp"
-#include "rpc/common/Concepts.hpp"
 #include "rpc/common/Specs.hpp"
 #include "rpc/common/Types.hpp"
-#include "rpc/common/Validators.hpp"
 
 #include <boost/json/value.hpp>
 #include <fmt/core.h>

--- a/src/rpc/common/Modifiers.hpp
+++ b/src/rpc/common/Modifiers.hpp
@@ -105,13 +105,13 @@ struct ToLower final {
 };
 
 /**
- * @brief Convert input string to lower case.
+ * @brief Convert input string to integer.
  *
  * Note: the conversion is only performed if the input value is a string.
  */
 struct ToNumber final {
     /**
-     * @brief Update the input string to lower case.
+     * @brief Update the input string to integer if it can be converted to integer by stoi.
      *
      * @param value The JSON value representing the outer object
      * @param key The key used to retrieve the modified value from the outer object

--- a/src/rpc/common/Validators.cpp
+++ b/src/rpc/common/Validators.cpp
@@ -29,6 +29,7 @@
 #include <fmt/core.h>
 #include <ripple/basics/base_uint.h>
 #include <ripple/protocol/AccountID.h>
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/tokens.h>
 
@@ -45,7 +46,7 @@ namespace rpc::validation {
 [[nodiscard]] MaybeError
 Required::verify(boost::json::value const& value, std::string_view key)
 {
-    if (not value.is_object() or not value.as_object().contains(key.data()))
+    if (not value.is_object() or not value.as_object().contains(key))
         return Error{Status{RippledError::rpcINVALID_PARAMS, "Required field '" + std::string{key} + "' missing"}};
 
     return {};
@@ -54,10 +55,10 @@ Required::verify(boost::json::value const& value, std::string_view key)
 [[nodiscard]] MaybeError
 CustomValidator::verify(boost::json::value const& value, std::string_view key) const
 {
-    if (not value.is_object() or not value.as_object().contains(key.data()))
+    if (not value.is_object() or not value.as_object().contains(key))
         return {};  // ignore. field does not exist, let 'required' fail instead
 
-    return validator_(value.as_object().at(key.data()), key);
+    return validator_(value.as_object().at(key), key);
 }
 
 [[nodiscard]] bool

--- a/src/rpc/common/Validators.hpp
+++ b/src/rpc/common/Validators.hpp
@@ -402,6 +402,7 @@ public:
      * @param fn The callable/function object
      */
     template <typename Fn>
+        requires std::invocable<Fn, boost::json::value const&, std::string_view>
     explicit CustomValidator(Fn&& fn) : validator_{std::forward<Fn>(fn)}
     {
     }

--- a/src/rpc/handlers/GetAggregatePrice.hpp
+++ b/src/rpc/handlers/GetAggregatePrice.hpp
@@ -22,6 +22,7 @@
 #include "data/BackendInterface.hpp"
 #include "rpc/Errors.hpp"
 #include "rpc/JS.hpp"
+#include "rpc/common/Modifiers.hpp"
 #include "rpc/common/Specs.hpp"
 #include "rpc/common/Types.hpp"
 #include "rpc/common/Validators.hpp"
@@ -131,23 +132,26 @@ public:
         static auto constexpr ORACLES_MAX = 200;
 
         static auto const oraclesValidator =
-            validation::CustomValidator{[](boost::json::value const& value, std::string_view) -> MaybeError {
+            modifiers::CustomModifier{[](boost::json::value& value, std::string_view) -> MaybeError {
                 if (!value.is_array() or value.as_array().empty() or value.as_array().size() > ORACLES_MAX)
                     return Error{Status{RippledError::rpcORACLE_MALFORMED}};
 
-                for (auto oracle : value.as_array()) {
+                for (auto& oracle : value.as_array()) {
                     if (!oracle.is_object() or !oracle.as_object().contains(JS(oracle_document_id)) or
                         !oracle.as_object().contains(JS(account)))
                         return Error{Status{RippledError::rpcORACLE_MALFORMED}};
 
-                    auto maybeError =
-                        validation::Type<std::uint32_t>{}.verify(oracle.as_object(), JS(oracle_document_id));
+                    auto maybeError = validation::Type<std::uint32_t, std::string>{}.verify(
+                        oracle.as_object(), JS(oracle_document_id)
+                    );
+                    if (!maybeError)
+                        return maybeError;
 
+                    maybeError = modifiers::ToNumber::modify(oracle, JS(oracle_document_id));
                     if (!maybeError)
                         return maybeError;
 
                     maybeError = validation::AccountBase58Validator.verify(oracle.as_object(), JS(account));
-
                     if (!maybeError)
                         return Error{Status{RippledError::rpcINVALID_PARAMS}};
                 };

--- a/src/rpc/handlers/LedgerEntry.hpp
+++ b/src/rpc/handlers/LedgerEntry.hpp
@@ -24,6 +24,7 @@
 #include "rpc/JS.hpp"
 #include "rpc/common/Checkers.hpp"
 #include "rpc/common/MetaProcessors.hpp"
+#include "rpc/common/Modifiers.hpp"
 #include "rpc/common/Specs.hpp"
 #include "rpc/common/Types.hpp"
 #include "rpc/common/Validators.hpp"
@@ -296,8 +297,9 @@ public:
                  {JS(oracle_document_id),
                   meta::WithCustomError{validation::Required{}, Status(ClioError::rpcMALFORMED_REQUEST)},
                   meta::WithCustomError{
-                      validation::Type<uint32_t>{}, Status(ClioError::rpcMALFORMED_ORACLE_DOCUMENT_ID)
-                  }},
+                      validation::Type<uint32_t, std::string>{}, Status(ClioError::rpcMALFORMED_ORACLE_DOCUMENT_ID)
+                  },
+                  meta::WithCustomError{modifiers::ToNumber{}, Status(ClioError::rpcMALFORMED_ORACLE_DOCUMENT_ID)}},
              }}},
             {JS(ledger), check::Deprecated{}},
         };

--- a/tests/unit/rpc/BaseTests.cpp
+++ b/tests/unit/rpc/BaseTests.cpp
@@ -605,6 +605,29 @@ TEST_F(RPCBaseTest, ToLowerModifier)
     ASSERT_EQ(passingInput4.at("str").as_string(), "");
 }
 
+TEST_F(RPCBaseTest, ToNumberModifier)
+{
+    auto spec = RpcSpec{
+        {"str", ToNumber{}},
+    };
+
+    auto passingInput = json::parse(R"({ "str": [] })");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    passingInput = json::parse(R"({ "str2": "TesT" })");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    passingInput = json::parse(R"([])");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    passingInput = json::parse(R"({ "str": "123" })");
+    ASSERT_TRUE(spec.process(passingInput));
+    ASSERT_EQ(passingInput.at("str").as_int64(), 123);
+
+    auto failingInput = json::parse(R"({ "str": "ok" })");
+    ASSERT_FALSE(spec.process(failingInput));
+}
+
 TEST_F(RPCBaseTest, CustomModifier)
 {
     auto const customModifier = CustomModifier{[](json::value& value, std::string_view /* key */) -> MaybeError {
@@ -622,6 +645,13 @@ TEST_F(RPCBaseTest, CustomModifier)
     auto passingInput = json::parse(R"({ "str": "sss" })");
     ASSERT_TRUE(spec.process(passingInput));
     ASSERT_EQ(passingInput.at("str").as_string(), "modified");
+
+    passingInput = json::parse(R"({ "strNotExist": 123 })");
+    ASSERT_TRUE(spec.process(passingInput));
+
+    // not a json object
+    passingInput = json::parse(R"([])");
+    ASSERT_TRUE(spec.process(passingInput));
 
     auto failingInput = json::parse(R"({ "str": 1 })");
     ASSERT_FALSE(spec.process(failingInput));

--- a/tests/unit/rpc/BaseTests.cpp
+++ b/tests/unit/rpc/BaseTests.cpp
@@ -607,7 +607,7 @@ TEST_F(RPCBaseTest, ToLowerModifier)
 
 TEST_F(RPCBaseTest, CustomModifier)
 {
-    auto customModifier = CustomModifier{[](json::value& value, std::string_view /* key */) -> MaybeError {
+    auto const customModifier = CustomModifier{[](json::value& value, std::string_view /* key */) -> MaybeError {
         if (value.is_string()) {
             value = json::value("modified");
             return MaybeError{};
@@ -615,7 +615,7 @@ TEST_F(RPCBaseTest, CustomModifier)
         return Error{rpc::Status{"Uh oh"}};
     }};
 
-    auto spec = RpcSpec{
+    auto const spec = RpcSpec{
         {"str", customModifier},
     };
 

--- a/tests/unit/rpc/BaseTests.cpp
+++ b/tests/unit/rpc/BaseTests.cpp
@@ -607,7 +607,7 @@ TEST_F(RPCBaseTest, ToLowerModifier)
 
 TEST_F(RPCBaseTest, ToNumberModifier)
 {
-    auto spec = RpcSpec{
+    auto const spec = RpcSpec{
         {"str", ToNumber{}},
     };
 
@@ -625,6 +625,9 @@ TEST_F(RPCBaseTest, ToNumberModifier)
     ASSERT_EQ(passingInput.at("str").as_int64(), 123);
 
     auto failingInput = json::parse(R"({ "str": "ok" })");
+    ASSERT_FALSE(spec.process(failingInput));
+
+    failingInput = json::parse(R"({ "str": "123.123" })");
     ASSERT_FALSE(spec.process(failingInput));
 }
 

--- a/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
+++ b/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
@@ -427,6 +427,55 @@ TEST_F(RPCGetAggregatePriceHandlerTest, OracleLedgerEntrySinglePriceData)
     });
 }
 
+TEST_F(RPCGetAggregatePriceHandlerTest, OracleLedgerEntryStrOracleDocumentId)
+{
+    EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
+        .WillOnce(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
+
+    auto constexpr documentId = 1;
+    mockLedgerObject(*backend, ACCOUNT, documentId, TX1, 1e3, 2);  // 10
+
+    auto const handler = AnyHandler{GetAggregatePriceHandler{backend}};
+    auto const req = json::parse(fmt::format(
+        R"({{
+                "base_asset": "USD",
+                "quote_asset": "XRP",
+                "oracles": 
+                [
+                    {{
+                        "account": "{}",
+                        "oracle_document_id": "{}"
+                    }}
+                ]
+            }})",
+        ACCOUNT,
+        documentId
+    ));
+
+    auto const expected = json::parse(fmt::format(
+        R"({{
+                "entire_set": 
+                {{
+                    "mean": "10",
+                    "size": 1,
+                    "standard_deviation": "0"
+                }},
+                "median": "10",
+                "time": 4321,
+                "ledger_index": {},
+                "ledger_hash": "{}",
+                "validated": true
+            }})",
+        RANGEMAX,
+        LEDGERHASH
+    ));
+    runSpawn([&](auto yield) {
+        auto const output = handler.process(req, Context{yield});
+        ASSERT_TRUE(output);
+        EXPECT_EQ(output.result.value(), expected);
+    });
+}
+
 TEST_F(RPCGetAggregatePriceHandlerTest, PreviousTxNotFound)
 {
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))

--- a/tests/unit/rpc/handlers/LedgerEntryTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerEntryTests.cpp
@@ -2315,13 +2315,40 @@ generateTestValuesForNormalPathTest()
             CreateChainOwnedClaimIDObject(ACCOUNT, ACCOUNT, ACCOUNT2, "JPY", ACCOUNT3, ACCOUNT)
         },
         NormalPathTestBundle{
-            "OracleEntryFoundViaObject",
+            "OracleEntryFoundViaIntOracleDocumentId",
             fmt::format(
                 R"({{
                     "binary": true,
                     "oracle": {{
                         "account": "{}",
                         "oracle_document_id": 1
+                    }}
+                }})",
+                ACCOUNT
+            ),
+            ripple::keylet::oracle(GetAccountIDWithString(ACCOUNT), 1).key,
+            CreateOracleObject(
+                ACCOUNT,
+                "70726F7669646572",
+                32u,
+                1234u,
+                ripple::Blob(8, 's'),
+                ripple::Blob(8, 's'),
+                RANGEMAX - 2,
+                ripple::uint256{"E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321"},
+                CreatePriceDataSeries(
+                    {CreateOraclePriceData(2e4, ripple::to_currency("XRP"), ripple::to_currency("USD"), 3)}
+                )
+            )
+        },
+        NormalPathTestBundle{
+            "OracleEntryFoundViaStrOracleDocumentId",
+            fmt::format(
+                R"({{
+                    "binary": true,
+                    "oracle": {{
+                        "account": "{}",
+                        "oracle_document_id": "1"
                     }}
                 }})",
                 ACCOUNT


### PR DESCRIPTION
Seems like rippled supports string-type int for integer field of input json, Clio will starts supporting it.

This PR changed the field oracle_document_id to support both integer type and integer but string-type. For example 1 and "1".

