### PR TITLE
Improve etl check

### DIFF
--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -123,10 +123,8 @@ LoadBalancer::LoadBalancer(
         auto const stateOpt = ETLState::fetchETLStateFromSource(*source);
 
         if (!stateOpt) {
-            checkOnETLFailure(fmt::format(
-                "Failed to fetch ETL state from source = {} Please check the configuration and network",
-                source->toString()
-            ));
+            LOG(log_.warn()) << "Failed to fetch ETL state from source = " << source->toString()
+                             << " Please check the configuration and network";
         } else if (etlState_ && etlState_->networkID && stateOpt->networkID &&
                    etlState_->networkID != stateOpt->networkID) {
             checkOnETLFailure(fmt::format(
@@ -141,6 +139,9 @@ LoadBalancer::LoadBalancer(
         sources_.push_back(std::move(source));
         LOG(log_.info()) << "Added etl source - " << sources_.back()->toString();
     }
+
+    if (!etlState_)
+        checkOnETLFailure("Failed to fetch ETL state from any source. Please check the configuration and network");
 
     if (sources_.empty())
         checkOnETLFailure("No ETL sources configured. Please check the configuration");

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -109,7 +109,7 @@ TEST_F(LoadBalancerConstructorTests, forwardingTimeoutPassedToSourceFactory)
 
 TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFail)
 {
-    EXPECT_CALL(sourceFactory_, makeSource).Times(1);
+    EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(std::nullopt));
     EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(std::nullopt));
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
@@ -117,7 +117,7 @@ TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFail)
 
 TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllReturnError)
 {
-    EXPECT_CALL(sourceFactory_, makeSource).Times(1);
+    EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled)
         .WillOnce(Return(boost::json::object{{"error", "some error"}}));
     EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled)

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -107,7 +107,7 @@ TEST_F(LoadBalancerConstructorTests, forwardingTimeoutPassedToSourceFactory)
     makeLoadBalancer();
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFail)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_AllSourcesFail)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(std::nullopt));
@@ -135,6 +135,16 @@ TEST_F(LoadBalancerConstructorTests, fetchETLState_Source1Fails0OK)
     makeLoadBalancer();
 }
 
+TEST_F(LoadBalancerConstructorTests, fetchETLState_Source0Fails1OK)
+{
+    EXPECT_CALL(sourceFactory_, makeSource).Times(2);
+    EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(boost::json::object{}));
+    EXPECT_CALL(sourceFactory_.sourceAt(0), run);
+    EXPECT_CALL(sourceFactory_.sourceAt(1), run);
+    makeLoadBalancer();
+}
+
 TEST_F(LoadBalancerConstructorTests, fetchETLState_DifferentNetworkID)
 {
     auto const source1Json = boost::json::parse(R"({"result": {"info": {"network_id": 0}}})");
@@ -146,7 +156,7 @@ TEST_F(LoadBalancerConstructorTests, fetchETLState_DifferentNetworkID)
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFailButAllowNoEtlIsTrue)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_AllSourcesFailButAllowNoEtlIsTrue)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(boost::json::object{}));

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -107,30 +107,32 @@ TEST_F(LoadBalancerConstructorTests, forwardingTimeoutPassedToSourceFactory)
     makeLoadBalancer();
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_Source0Fails)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFail)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(1);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(std::nullopt));
-    EXPECT_CALL(sourceFactory_.sourceAt(0), toString);
+    EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(std::nullopt));
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_Source0ReturnsError)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllReturnError)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(1);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled)
         .WillOnce(Return(boost::json::object{{"error", "some error"}}));
-    EXPECT_CALL(sourceFactory_.sourceAt(0), toString);
+    EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled)
+        .WillOnce(Return(boost::json::object{{"error", "some error"}}));
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_Source1Fails)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_Source1Fails0OK)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(boost::json::object{}));
     EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(std::nullopt));
-    EXPECT_CALL(sourceFactory_.sourceAt(1), toString);
-    EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
+    EXPECT_CALL(sourceFactory_.sourceAt(0), run);
+    EXPECT_CALL(sourceFactory_.sourceAt(1), run);
+    makeLoadBalancer();
 }
 
 TEST_F(LoadBalancerConstructorTests, fetchETLState_DifferentNetworkID)
@@ -144,13 +146,12 @@ TEST_F(LoadBalancerConstructorTests, fetchETLState_DifferentNetworkID)
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_Source1FailsButAllowNoEtlIsTrue)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllFailButAllowNoEtlIsTrue)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(boost::json::object{}));
     EXPECT_CALL(sourceFactory_.sourceAt(0), run);
     EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(std::nullopt));
-    EXPECT_CALL(sourceFactory_.sourceAt(1), toString);
     EXPECT_CALL(sourceFactory_.sourceAt(1), run);
 
     configJson_.as_object()["allow_no_etl"] = true;

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -115,7 +115,7 @@ TEST_F(LoadBalancerConstructorTests, fetchETLState_AllSourcesFail)
     EXPECT_THROW({ makeLoadBalancer(); }, std::logic_error);
 }
 
-TEST_F(LoadBalancerConstructorTests, fetchETLState_SourceAllReturnError)
+TEST_F(LoadBalancerConstructorTests, fetchETLState_AllSourcesReturnError)
 {
     EXPECT_CALL(sourceFactory_, makeSource).Times(2);
     EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled)


### PR DESCRIPTION
When there was an ETL not working and `allow_no_etl` is false, Clio would fail to start.
This PR improved the behavior. As long as there is one ETL working, Clio should be able to start.
