### PR TITLE
Ignore checking formatting if no formatted files are staged

### DIFF
--- a/.githooks/check-format
+++ b/.githooks/check-format
@@ -4,12 +4,6 @@
 #
 # This script checks the format of the code and cmake files.
 # In many cases it will automatically fix the issues and abort the commit.
-#!/bin/bash
-
-# Note: This script is intended to be run from the root of the repository.
-#
-# This script checks the format of the code and cmake files.
-# In many cases it will automatically fix the issues and abort the commit.
 
 no_formatted_directories_staged() {
     staged_directories=$(git diff-index --cached --name-only HEAD | awk -F/ '{print $1}')

--- a/.githooks/check-format
+++ b/.githooks/check-format
@@ -5,6 +5,32 @@
 # This script checks the format of the code and cmake files.
 # In many cases it will automatically fix the issues and abort the commit.
 
+no_formatted_files_staged() {
+    staged_files=$(git diff-index --cached --name-only HEAD)
+    for file in $staged_files; do
+        extension=${file##*.}
+        if [[ "$extension" =~ (h|hpp|c|cpp)$ ]]; then
+            formatted_file_found=true
+        fi
+        if [[ "$extension" =~ (cmake|txt)$ ]]; then
+            if [ "$extension" = "cmake" ]; then
+                formatted_file_found=true
+            fi
+            if [ "$(basename $file .txt)" = "CMakeLists" ]; then
+                formatted_file_found=true
+            fi
+        fi
+        if [ "$formatted_file_found" = "true" ] ; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+if no_formatted_files_staged ; then
+    exit 0
+fi
+
 echo "+ Checking code format..."
 
 # paths to check and re-format

--- a/.githooks/check-format
+++ b/.githooks/check-format
@@ -4,30 +4,24 @@
 #
 # This script checks the format of the code and cmake files.
 # In many cases it will automatically fix the issues and abort the commit.
+#!/bin/bash
 
-no_formatted_files_staged() {
-    staged_files=$(git diff-index --cached --name-only HEAD)
-    for file in $staged_files; do
-        extension=${file##*.}
-        if [[ "$extension" =~ (h|hpp|c|cpp)$ ]]; then
-            formatted_file_found=true
-        fi
-        if [[ "$extension" =~ (cmake|txt)$ ]]; then
-            if [ "$extension" = "cmake" ]; then
-                formatted_file_found=true
-            fi
-            if [ "$(basename $file .txt)" = "CMakeLists" ]; then
-                formatted_file_found=true
-            fi
-        fi
-        if [ "$formatted_file_found" = "true" ] ; then
+# Note: This script is intended to be run from the root of the repository.
+#
+# This script checks the format of the code and cmake files.
+# In many cases it will automatically fix the issues and abort the commit.
+
+no_formatted_directories_staged() {
+    staged_directories=$(git diff-index --cached --name-only HEAD | awk -F/ '{print $1}')
+    for sd in $staged_directories; do
+        if [[ "$sd" =~ ^(benchmark|cmake|src|tests)$ ]]; then
             return 1
         fi
     done
     return 0
 }
 
-if no_formatted_files_staged ; then
+if no_formatted_directories_staged ; then
     exit 0
 fi
 


### PR DESCRIPTION
I'm constantly harassed to follow the rules when I'm not doing anything relevant.

This is an attempt to ameliorate that rather than `--no-verify` or just disabling hooks altogether. :mushroom: :cloud: 

Somebody might want to confirm `basename` is included with macOS.