### PR TITLE
fix: Change the field name from "close_time_iso" to "closed

### DIFF
--- a/src/rpc/handlers/LedgerIndex.cpp
+++ b/src/rpc/handlers/LedgerIndex.cpp
@@ -104,7 +104,7 @@ tag_invoke(boost::json::value_from_tag, boost::json::value& jv, LedgerIndexHandl
     jv = boost::json::object{
         {JS(ledger_index), output.ledgerIndex},
         {JS(ledger_hash), output.ledgerHash},
-        {JS(close_time_iso), output.closeTimeIso},
+        {JS(closed), output.closeTimeIso},
         {JS(validated), true},
     };
 }

--- a/tests/unit/rpc/handlers/LedgerIndexTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerIndexTests.cpp
@@ -71,7 +71,7 @@ TEST_F(RPCLedgerIndexTest, NoDateGiven)
         ASSERT_TRUE(output);
         EXPECT_EQ(output.result->at("ledger_index").as_uint64(), RANGEMAX);
         EXPECT_EQ(output.result->at("ledger_hash").as_string(), LEDGERHASH);
-        EXPECT_TRUE(output.result->as_object().contains("close_time_iso"));
+        EXPECT_TRUE(output.result->as_object().contains("closed"));
     });
 }
 
@@ -163,6 +163,6 @@ TEST_P(LedgerIndexTests, SearchFromLedgerRange)
         ASSERT_TRUE(output);
         EXPECT_EQ(output.result->at("ledger_index").as_uint64(), testBundle.expectedLedgerIndex);
         EXPECT_EQ(output.result->at("ledger_hash").as_string(), LEDGERHASH);
-        EXPECT_EQ(output.result->at("close_time_iso").as_string(), testBundle.closeTimeIso);
+        EXPECT_EQ(output.result->at("closed").as_string(), testBundle.closeTimeIso);
     });
 }


### PR DESCRIPTION
@mounikakun  spotted the field was "closed" from the original design. During the implementation, I changed it to "close_time_iso", because it is used to label time in "ledger" API. Since it mimics the existing API from XRPLF , using the same field name maybe more friendly to users. 