### PR TITLE
docs: Use non-admin WS port

### DIFF
--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -31,7 +31,7 @@
     "etl_sources": [
         {
             "ip": "127.0.0.1",
-            "ws_port": "6006",
+            "ws_port": "6005",
             "grpc_port": "50051"
         }
     ],


### PR DESCRIPTION
Changes the default config file to match `rippled`'s defaults where port 6006 is admin WS API and 6005 (commented out by default) for non-admin WS.

Clio should use a non-admin connection to `rippled`. Users will have to modify their `rippled` server config to enable the non-admin WS port as part of setup though.