### PR TITLE
fix: Static linkage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,28 +52,28 @@ jobs:
             build_type: Release
             conan_profile: gcc
             code_coverage: false
-            static: false
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Debug
             conan_profile: gcc
             code_coverage: true
-            static: false
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Release
             conan_profile: clang
             code_coverage: false
-            static: false
+            static: true
           - os: heavy
             container:
               image: rippleci/clio_ci:latest
             build_type: Debug
             conan_profile: clang
             code_coverage: false
-            static: false
+            static: true
           - os: macos14
             build_type: Release
             code_coverage: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,12 +17,15 @@ jobs:
         include:
           - os: macos14
             build_type: Release
+            static: false
           - os: heavy
             build_type: Release
+            static: true
             container:
               image: rippleci/clio_ci:latest
           - os: heavy
             build_type: Debug
+            static: true
             container:
               image: rippleci/clio_ci:latest
     runs-on: [self-hosted, "${{ matrix.os }}"]
@@ -54,6 +57,7 @@ jobs:
           conan_profile: ${{ steps.conan.outputs.conan_profile }}
           conan_cache_hit: ${{ steps.restore_cache.outputs.conan_cache_hit }}
           build_type: ${{ matrix.build_type }}
+          static: ${{ matrix.static }}
 
       - name: Build Clio
         uses: ./.github/actions/build_clio

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,17 +11,15 @@ target_sources(clio_server PRIVATE Main.cpp)
 target_link_libraries(clio_server PRIVATE clio)
 
 if (static)
-  target_link_options(clio_server PRIVATE -static)
-
-  if (is_gcc AND NOT san)
+  if (san)
+    message(FATAL_ERROR "Static linkage not allowed when using sanitizers")
+  elseif (is_appleclang)
+    message(FATAL_ERROR "Static linkage not supported on AppleClang")
+  else ()
     target_link_options(
-      # For now let's assume that we only using libstdc++ under gcc.
+      # Note: -static-libstdc++ can statically link both libstdc++ and libc++
       clio_server PRIVATE -static-libstdc++ -static-libgcc
     )
-  endif ()
-
-  if (is_appleclang)
-    message(FATAL_ERROR "Static linkage not supported on AppleClang")
   endif ()
 endif ()
 


### PR DESCRIPTION
Fixes #1507 

Researched AppImage but it seems like it's a bit of an overkill for our use case.
This PR works for both clang and gcc. The only dynamically linked libraries are glibc and its bits. This means that when Clio is statically linked on an older system it will work on a newer one (tested on newer Ubuntu while linked on 20.04).