### PR TITLE
fix: Use doxygen 1.12

### DIFF
--- a/.githooks/check-docs
+++ b/.githooks/check-docs
@@ -13,6 +13,7 @@ TMPDIR=${ROOT}/.cache/doxygen
 TMPFILE=${TMPDIR}/docs.log
 DOCDIR=${TMPDIR}/out
 
+# Check doxygen is at all installed
 if [ -z "$DOXYGEN" ]; then
     # No hard error if doxygen is not installed yet
     cat <<EOF
@@ -21,6 +22,24 @@ if [ -z "$DOXYGEN" ]; then
 -----------------------------------------------------------------------------
         'doxygen' is required to check documentation.
         Please install it for next time. For the time being it's on CI.
+-----------------------------------------------------------------------------
+
+EOF
+    exit 0
+fi
+
+# Check version of doxygen is at least 1.12
+version=$($DOXYGEN --version | grep -o '[0-9\.]*')
+
+if [[ "1.12.0" > "$version" ]]; then
+    # No hard error if doxygen version is not the one we want - let CI deal with it
+    cat <<EOF
+
+                                    ERROR
+-----------------------------------------------------------------------------
+        A minimum of version 1.12 of `which doxygen` is required.
+        Your version is $version.
+        Please upgrade it for next time. For the time being it's on CI.
 -----------------------------------------------------------------------------
 
 EOF

--- a/.githooks/check-docs
+++ b/.githooks/check-docs
@@ -20,8 +20,10 @@ if [ -z "$DOXYGEN" ]; then
 
                                    WARNING
 -----------------------------------------------------------------------------
-        'doxygen' is required to check documentation.
-        Please install it for next time. For the time being it's on CI.
+        'doxygen' is required to check documentation. 
+        Please install it for next time.
+
+        Your changes may fail to pass CI once pushed.
 -----------------------------------------------------------------------------
 
 EOF
@@ -38,8 +40,9 @@ if [[ "1.12.0" > "$version" ]]; then
                                     ERROR
 -----------------------------------------------------------------------------
         A minimum of version 1.12 of `which doxygen` is required.
-        Your version is $version.
-        Please upgrade it for next time. For the time being it's on CI.
+        Your version is $version. Please upgrade it for next time.
+
+        Your changes may fail to pass CI once pushed.
 -----------------------------------------------------------------------------
 
 EOF

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,6 +3,5 @@
 # This script is intended to be run from the root of the repository.
 
 source .githooks/check-format
-#source .githooks/check-docs
+source .githooks/check-docs
 
-# TODO: Fix Doxygen issue with reference links. See https://github.com/XRPLF/clio/issues/1431

--- a/docker/ci/dockerfile
+++ b/docker/ci/dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 ENV CCACHE_VERSION=4.10.2 \
     LLVM_TOOLS_VERSION=18 \
     GH_VERSION=2.40.0 \
-    DOXYGEN_VERSION=1.10.0
+    DOXYGEN_VERSION=1.12.0
  
 # Add repositories
 RUN apt-get -qq update \


### PR DESCRIPTION
Fixes #1431 

Also enables back checking docs in pre-commit hook. This means that Clio devs should upgrade to doxygen 1.12 (already on brew).