### PR TITLE
fix: Don't forward ledger API if 'full' is a string

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -1276,8 +1276,10 @@ specifiesCurrentOrClosedLedger(boost::json::object const& request)
 bool
 isAdminCmd(std::string const& method, boost::json::object const& request)
 {
+    // rippled considers the string as true: https://github.com/XRPLF/rippled/issues/5119
     auto const isFieldSet = [&request](auto const field) {
-        return request.contains(field) and request.at(field).is_bool() and request.at(field).as_bool();
+        return request.contains(field) and
+            ((request.at(field).is_bool() and request.at(field).as_bool()) or request.at(field).is_string());
     };
 
     if (method == JS(ledger)) {

--- a/tests/unit/rpc/RPCHelpersTests.cpp
+++ b/tests/unit/rpc/RPCHelpersTests.cpp
@@ -562,7 +562,11 @@ generateTestValuesForParametersTest()
         {"ledgerFullFalse", "ledger", R"({"full": false})", false},
         {"ledgerAccountsFalse", "ledger", R"({"accounts": false})", false},
         {"ledgerTypeFalse", "ledger", R"({"type": false})", false},
-        {"ledgerEntry", "ledger_entry", R"({"type": false})", false}
+        {"ledgerEntry", "ledger_entry", R"({"type": false})", false},
+        {"ledgerFullIsStr", "ledger", R"({"full": "String"})", true},
+        {"ledgerAccoutsIsStr", "ledger", R"({"accounts": "String"})", true},
+        {"ledgerTypeIsStr", "ledger", R"({"type": "String"})", true},
+        {"featureVetoedIsStr", "feature", R"({"vetoed": "String"})", true},
     };
 }
 


### PR DESCRIPTION
Fix #1635 