### PR TITLE
chore: Revert Cassandra driver

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class Clio(ConanFile):
 
     requires = [
         'boost/1.82.0',
-        'cassandra-cpp-driver/2.17.1',
+        'cassandra-cpp-driver/2.17.0',
         'fmt/10.1.1',
         'protobuf/3.21.9',
         'grpc/1.50.1',

--- a/docs/build-clio.md
+++ b/docs/build-clio.md
@@ -168,7 +168,7 @@ Sometimes, during development, you need to build against a custom version of `li
     # ... (excerpt from conanfile.py)
         requires = [
         'boost/1.82.0',
-        'cassandra-cpp-driver/2.17.1',
+        'cassandra-cpp-driver/2.17.0',
         'fmt/10.1.1',
         'protobuf/3.21.9',
         'grpc/1.50.1',


### PR DESCRIPTION
Reverts XRPLF/clio#1646
Cassandra Driver Version 2.17.1 introduced a bug where it prevents calling `cass_future_error_code()` in the callback. 
More info found in [their repo discussion](https://github.com/datastax/cpp-driver/pull/559/files)