### PR TITLE
fix: Add queue size limit for websocket

### DIFF
--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -77,7 +77,7 @@
         // send a reply for each request whenever it is ready.
         "parallel_requests_limit": 10, // Optional parameter, used only if "processing_strategy" is "parallel". It limits the number of requests for one client connection processed in parallel. Infinite if not specified.
         // Max number of responses to queue up before sent successfully. If a client's waiting queue is too long, the server will close the connection.
-        "ws_max_sending_queue_size": 80000
+        "ws_max_sending_queue_size": 10000
     },
     // Time in seconds for graceful shutdown. Defaults to 10 seconds. Not fully implemented yet.
     "graceful_period": 10.0,

--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -77,7 +77,7 @@
         // send a reply for each request whenever it is ready.
         "parallel_requests_limit": 10, // Optional parameter, used only if "processing_strategy" is "parallel". It limits the number of requests for one client connection processed in parallel. Infinite if not specified.
         // Max number of responses to queue up before sent successfully. If a client's waiting queue is too long, the server will close the connection.
-        "ws_max_sending_queue_size": 10000
+        "ws_max_sending_queue_size": 1500
     },
     // Time in seconds for graceful shutdown. Defaults to 10 seconds. Not fully implemented yet.
     "graceful_period": 10.0,

--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -75,9 +75,9 @@
         // For sequent policy request from one client connection will be processed one by one and the next one will not be read before
         // the previous one is processed. For parallel policy Clio will take all requests and process them in parallel and
         // send a reply for each request whenever it is ready.
-        "parallel_requests_limit": 10 // Optional parameter, used only if "processing_strategy" is "parallel".
-        It limits the number of requests for one client connection processed in parallel. Infinite if not specified.
-
+        "parallel_requests_limit": 10, // Optional parameter, used only if "processing_strategy" is "parallel". It limits the number of requests for one client connection processed in parallel. Infinite if not specified.
+        // Max number of responses to queue up before sent successfully. If a client's waiting queue is too long, the server will close the connection.
+        "ws_max_sending_queue_size": 80000
     },
     // Time in seconds for graceful shutdown. Defaults to 10 seconds. Not fully implemented yet.
     "graceful_period": 10.0,

--- a/src/web/HttpSession.hpp
+++ b/src/web/HttpSession.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "util/Taggable.hpp"
-#include "util/config/Config.hpp"
 #include "web/PlainWsSession.hpp"
 #include "web/dosguard/DOSGuardInterface.hpp"
 #include "web/impl/HttpBase.hpp"
@@ -31,6 +30,7 @@
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/tcp_stream.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -52,31 +52,31 @@ template <SomeServerHandler HandlerType>
 class HttpSession : public impl::HttpBase<HttpSession, HandlerType>,
                     public std::enable_shared_from_this<HttpSession<HandlerType>> {
     boost::beast::tcp_stream stream_;
-    util::Config config_;
     std::reference_wrapper<util::TagDecoratorFactory const> tagFactory_;
+    std::uint32_t maxWsSendingQueueSize_;
 
 public:
     /**
      * @brief Create a new session.
      *
      * @param socket The socket. Ownership is transferred to HttpSession
-     * @param config The config for server
      * @param ip Client's IP address
      * @param adminVerification The admin verification strategy to use
      * @param tagFactory A factory that is used to generate tags to track requests and sessions
      * @param dosGuard The denial of service guard to use
      * @param handler The server handler to use
      * @param buffer Buffer with initial data received from the peer
+     * @param maxWsSendingQueueSize The maximum size of the sending queue for websocket
      */
     explicit HttpSession(
         tcp::socket&& socket,
-        util::Config config,
         std::string const& ip,
         std::shared_ptr<impl::AdminVerificationStrategy> const& adminVerification,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,
         std::shared_ptr<HandlerType> const& handler,
-        boost::beast::flat_buffer buffer
+        boost::beast::flat_buffer buffer,
+        std::uint32_t maxWsSendingQueueSize
     )
         : impl::HttpBase<HttpSession, HandlerType>(
               ip,
@@ -87,8 +87,8 @@ public:
               std::move(buffer)
           )
         , stream_(std::move(socket))
-        , config_(std::move(config))
         , tagFactory_(tagFactory)
+        , maxWsSendingQueueSize_(maxWsSendingQueueSize)
     {
     }
 
@@ -127,14 +127,14 @@ public:
     {
         std::make_shared<WsUpgrader<HandlerType>>(
             std::move(stream_),
-            config_,
             this->clientIp,
             tagFactory_,
             this->dosGuard_,
             this->handler_,
             std::move(this->buffer_),
             std::move(this->req_),
-            ConnectionBase::isAdmin()
+            ConnectionBase::isAdmin(),
+            maxWsSendingQueueSize_
         )
             ->run();
     }

--- a/src/web/HttpSession.hpp
+++ b/src/web/HttpSession.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "util/Taggable.hpp"
+#include "util/config/Config.hpp"
 #include "web/PlainWsSession.hpp"
 #include "web/dosguard/DOSGuardInterface.hpp"
 #include "web/impl/HttpBase.hpp"
@@ -51,6 +52,7 @@ template <SomeServerHandler HandlerType>
 class HttpSession : public impl::HttpBase<HttpSession, HandlerType>,
                     public std::enable_shared_from_this<HttpSession<HandlerType>> {
     boost::beast::tcp_stream stream_;
+    util::Config config_;
     std::reference_wrapper<util::TagDecoratorFactory const> tagFactory_;
 
 public:
@@ -58,6 +60,7 @@ public:
      * @brief Create a new session.
      *
      * @param socket The socket. Ownership is transferred to HttpSession
+     * @param config The config for server
      * @param ip Client's IP address
      * @param adminVerification The admin verification strategy to use
      * @param tagFactory A factory that is used to generate tags to track requests and sessions
@@ -67,6 +70,7 @@ public:
      */
     explicit HttpSession(
         tcp::socket&& socket,
+        util::Config config,
         std::string const& ip,
         std::shared_ptr<impl::AdminVerificationStrategy> const& adminVerification,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
@@ -83,6 +87,7 @@ public:
               std::move(buffer)
           )
         , stream_(std::move(socket))
+        , config_(std::move(config))
         , tagFactory_(tagFactory)
     {
     }
@@ -122,6 +127,7 @@ public:
     {
         std::make_shared<WsUpgrader<HandlerType>>(
             std::move(stream_),
+            config_,
             this->clientIp,
             tagFactory_,
             this->dosGuard_,

--- a/src/web/Server.hpp
+++ b/src/web/Server.hpp
@@ -41,6 +41,7 @@
 #include <fmt/core.h>
 
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -78,42 +79,42 @@ class Detector : public std::enable_shared_from_this<Detector<PlainSessionType, 
 
     util::Logger log_{"WebServer"};
     boost::beast::tcp_stream stream_;
-    util::Config config_;
     std::optional<std::reference_wrapper<boost::asio::ssl::context>> ctx_;
     std::reference_wrapper<util::TagDecoratorFactory const> tagFactory_;
     std::reference_wrapper<dosguard::DOSGuardInterface> const dosGuard_;
     std::shared_ptr<HandlerType> const handler_;
     boost::beast::flat_buffer buffer_;
     std::shared_ptr<impl::AdminVerificationStrategy> const adminVerification_;
+    std::uint32_t maxWsSendingQueueSize_;
 
 public:
     /**
      * @brief Create a new detector.
      *
      * @param socket The socket. Ownership is transferred
-     * @param config The config for server
      * @param ctx The SSL context if any
      * @param tagFactory A factory that is used to generate tags to track requests and sessions
      * @param dosGuard The denial of service guard to use
      * @param handler The server handler to use
      * @param adminVerification The admin verification strategy to use
+     * @param maxWsSendingQueueSize The maximum size of the sending queue for websocket
      */
     Detector(
         tcp::socket&& socket,
-        util::Config config,
         std::optional<std::reference_wrapper<boost::asio::ssl::context>> ctx,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,
         std::shared_ptr<HandlerType> handler,
-        std::shared_ptr<impl::AdminVerificationStrategy> adminVerification
+        std::shared_ptr<impl::AdminVerificationStrategy> adminVerification,
+        std::uint32_t maxWsSendingQueueSize
     )
         : stream_(std::move(socket))
-        , config_(std::move(config))
         , ctx_(ctx)
         , tagFactory_(std::cref(tagFactory))
         , dosGuard_(dosGuard)
         , handler_(std::move(handler))
         , adminVerification_(std::move(adminVerification))
+        , maxWsSendingQueueSize_(maxWsSendingQueueSize)
     {
     }
 
@@ -165,14 +166,14 @@ public:
 
             std::make_shared<SslSessionType<HandlerType>>(
                 stream_.release_socket(),
-                config_,
                 ip,
                 adminVerification_,
                 *ctx_,
                 tagFactory_,
                 dosGuard_,
                 handler_,
-                std::move(buffer_)
+                std::move(buffer_),
+                maxWsSendingQueueSize_
             )
                 ->run();
             return;
@@ -180,13 +181,13 @@ public:
 
         std::make_shared<PlainSessionType<HandlerType>>(
             stream_.release_socket(),
-            config_,
             ip,
             adminVerification_,
             tagFactory_,
             dosGuard_,
             handler_,
-            std::move(buffer_)
+            std::move(buffer_),
+            maxWsSendingQueueSize_
         )
             ->run();
     }
@@ -209,7 +210,6 @@ class Server : public std::enable_shared_from_this<Server<PlainSessionType, SslS
     using std::enable_shared_from_this<Server<PlainSessionType, SslSessionType, HandlerType>>::shared_from_this;
 
     util::Logger log_{"WebServer"};
-    util::Config config_;
     std::reference_wrapper<boost::asio::io_context> ioc_;
     std::optional<boost::asio::ssl::context> ctx_;
     util::TagDecoratorFactory tagFactory_;
@@ -217,12 +217,12 @@ class Server : public std::enable_shared_from_this<Server<PlainSessionType, SslS
     std::shared_ptr<HandlerType> handler_;
     tcp::acceptor acceptor_;
     std::shared_ptr<impl::AdminVerificationStrategy> adminVerification_;
+    std::uint32_t maxWsSendingQueueSize_;
 
 public:
     /**
      * @brief Create a new instance of the web server.
      *
-     * @param config The config for server
      * @param ioc The io_context to run the server on
      * @param ctx The SSL context if any
      * @param endpoint The endpoint to listen on
@@ -230,25 +230,26 @@ public:
      * @param dosGuard The denial of service guard to use
      * @param handler The server handler to use
      * @param adminPassword The optional password to verify admin role in requests
+     * @param maxWsSendingQueueSize The maximum size of the sending queue for websocket
      */
     Server(
-        util::Config config,
         boost::asio::io_context& ioc,
         std::optional<boost::asio::ssl::context> ctx,
         tcp::endpoint endpoint,
         util::TagDecoratorFactory tagFactory,
         dosguard::DOSGuardInterface& dosGuard,
         std::shared_ptr<HandlerType> handler,
-        std::optional<std::string> adminPassword
+        std::optional<std::string> adminPassword,
+        std::uint32_t maxWsSendingQueueSize
     )
-        : config_(std::move(config))
-        , ioc_(std::ref(ioc))
+        : ioc_(std::ref(ioc))
         , ctx_(std::move(ctx))
         , tagFactory_(tagFactory)
         , dosGuard_(std::ref(dosGuard))
         , handler_(std::move(handler))
         , acceptor_(boost::asio::make_strand(ioc))
         , adminVerification_(impl::make_AdminVerificationStrategy(std::move(adminPassword)))
+        , maxWsSendingQueueSize_(maxWsSendingQueueSize)
     {
         boost::beast::error_code ec;
 
@@ -302,7 +303,13 @@ private:
                 ctx_ ? std::optional<std::reference_wrapper<boost::asio::ssl::context>>{ctx_.value()} : std::nullopt;
 
             std::make_shared<Detector<PlainSessionType, SslSessionType, HandlerType>>(
-                std::move(socket), config_, ctxRef, std::cref(tagFactory_), dosGuard_, handler_, adminVerification_
+                std::move(socket),
+                ctxRef,
+                std::cref(tagFactory_),
+                dosGuard_,
+                handler_,
+                adminVerification_,
+                maxWsSendingQueueSize_
             )
                 ->run();
         }
@@ -364,15 +371,19 @@ make_HttpServer(
         throw std::logic_error("Admin config error, one method must be specified to authorize admin.");
     }
 
+    // If the transactions number is 200 per ledger, A client which subscribes everything will send 400 feeds for
+    // each ledger. Assume 1s per ledger, we allow user delay 10000/400 = 25s
+    auto const maxWsSendingQueueSize = config.valueOr("ws_max_sending_queue_size", 10000);
+
     auto server = std::make_shared<HttpServer<HandlerType>>(
-        serverConfig,
         ioc,
         std::move(expectedSslContext).value(),
         boost::asio::ip::tcp::endpoint{address, port},
         util::TagDecoratorFactory(config),
         dosGuard,
         handler,
-        std::move(adminPassword)
+        std::move(adminPassword),
+        maxWsSendingQueueSize
     );
 
     server->run();

--- a/src/web/Server.hpp
+++ b/src/web/Server.hpp
@@ -373,7 +373,7 @@ make_HttpServer(
 
     // If the transactions number is 200 per ledger, A client which subscribes everything will send 400 feeds for
     // each ledger. Assume 1s per ledger, we allow user delay 10000/400 = 25s
-    auto const maxWsSendingQueueSize = config.valueOr("ws_max_sending_queue_size", 10000);
+    auto const maxWsSendingQueueSize = serverConfig.valueOr("ws_max_sending_queue_size", 10000);
 
     auto server = std::make_shared<HttpServer<HandlerType>>(
         ioc,

--- a/src/web/Server.hpp
+++ b/src/web/Server.hpp
@@ -78,6 +78,7 @@ class Detector : public std::enable_shared_from_this<Detector<PlainSessionType, 
 
     util::Logger log_{"WebServer"};
     boost::beast::tcp_stream stream_;
+    util::Config config_;
     std::optional<std::reference_wrapper<boost::asio::ssl::context>> ctx_;
     std::reference_wrapper<util::TagDecoratorFactory const> tagFactory_;
     std::reference_wrapper<dosguard::DOSGuardInterface> const dosGuard_;
@@ -90,6 +91,7 @@ public:
      * @brief Create a new detector.
      *
      * @param socket The socket. Ownership is transferred
+     * @param config The config for server
      * @param ctx The SSL context if any
      * @param tagFactory A factory that is used to generate tags to track requests and sessions
      * @param dosGuard The denial of service guard to use
@@ -98,6 +100,7 @@ public:
      */
     Detector(
         tcp::socket&& socket,
+        util::Config config,
         std::optional<std::reference_wrapper<boost::asio::ssl::context>> ctx,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,
@@ -105,6 +108,7 @@ public:
         std::shared_ptr<impl::AdminVerificationStrategy> adminVerification
     )
         : stream_(std::move(socket))
+        , config_(std::move(config))
         , ctx_(ctx)
         , tagFactory_(std::cref(tagFactory))
         , dosGuard_(dosGuard)
@@ -161,6 +165,7 @@ public:
 
             std::make_shared<SslSessionType<HandlerType>>(
                 stream_.release_socket(),
+                config_,
                 ip,
                 adminVerification_,
                 *ctx_,
@@ -174,7 +179,14 @@ public:
         }
 
         std::make_shared<PlainSessionType<HandlerType>>(
-            stream_.release_socket(), ip, adminVerification_, tagFactory_, dosGuard_, handler_, std::move(buffer_)
+            stream_.release_socket(),
+            config_,
+            ip,
+            adminVerification_,
+            tagFactory_,
+            dosGuard_,
+            handler_,
+            std::move(buffer_)
         )
             ->run();
     }
@@ -197,6 +209,7 @@ class Server : public std::enable_shared_from_this<Server<PlainSessionType, SslS
     using std::enable_shared_from_this<Server<PlainSessionType, SslSessionType, HandlerType>>::shared_from_this;
 
     util::Logger log_{"WebServer"};
+    util::Config config_;
     std::reference_wrapper<boost::asio::io_context> ioc_;
     std::optional<boost::asio::ssl::context> ctx_;
     util::TagDecoratorFactory tagFactory_;
@@ -209,6 +222,7 @@ public:
     /**
      * @brief Create a new instance of the web server.
      *
+     * @param config The config for server
      * @param ioc The io_context to run the server on
      * @param ctx The SSL context if any
      * @param endpoint The endpoint to listen on
@@ -218,6 +232,7 @@ public:
      * @param adminPassword The optional password to verify admin role in requests
      */
     Server(
+        util::Config config,
         boost::asio::io_context& ioc,
         std::optional<boost::asio::ssl::context> ctx,
         tcp::endpoint endpoint,
@@ -226,7 +241,8 @@ public:
         std::shared_ptr<HandlerType> handler,
         std::optional<std::string> adminPassword
     )
-        : ioc_(std::ref(ioc))
+        : config_(std::move(config))
+        , ioc_(std::ref(ioc))
         , ctx_(std::move(ctx))
         , tagFactory_(tagFactory)
         , dosGuard_(std::ref(dosGuard))
@@ -286,7 +302,7 @@ private:
                 ctx_ ? std::optional<std::reference_wrapper<boost::asio::ssl::context>>{ctx_.value()} : std::nullopt;
 
             std::make_shared<Detector<PlainSessionType, SslSessionType, HandlerType>>(
-                std::move(socket), ctxRef, std::cref(tagFactory_), dosGuard_, handler_, adminVerification_
+                std::move(socket), config_, ctxRef, std::cref(tagFactory_), dosGuard_, handler_, adminVerification_
             )
                 ->run();
         }
@@ -349,6 +365,7 @@ make_HttpServer(
     }
 
     auto server = std::make_shared<HttpServer<HandlerType>>(
+        serverConfig,
         ioc,
         std::move(expectedSslContext).value(),
         boost::asio::ip::tcp::endpoint{address, port},

--- a/src/web/Server.hpp
+++ b/src/web/Server.hpp
@@ -371,9 +371,9 @@ make_HttpServer(
         throw std::logic_error("Admin config error, one method must be specified to authorize admin.");
     }
 
-    // If the transactions number is 200 per ledger, A client which subscribes everything will send 400 feeds for
-    // each ledger. Assume 1s per ledger, we allow user delay 10000/400 = 25s
-    auto const maxWsSendingQueueSize = serverConfig.valueOr("ws_max_sending_queue_size", 10000);
+    // If the transactions number is 200 per ledger, A client which subscribes everything will send 400+ feeds for
+    // each ledger. we allow user delay 3 ledgers by default
+    auto const maxWsSendingQueueSize = serverConfig.valueOr("ws_max_sending_queue_size", 1500);
 
     auto server = std::make_shared<HttpServer<HandlerType>>(
         ioc,

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -101,19 +101,19 @@ protected:
 
 public:
     explicit WsBase(
-        util::Config const& config,
         std::string ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,
         std::shared_ptr<HandlerType> const& handler,
-        boost::beast::flat_buffer&& buffer
+        boost::beast::flat_buffer&& buffer,
+        std::uint32_t maxSendingQueueSize
     )
-        : ConnectionBase(tagFactory, ip), buffer_(std::move(buffer)), dosGuard_(dosGuard), handler_(handler)
+        : ConnectionBase(tagFactory, ip)
+        , buffer_(std::move(buffer))
+        , dosGuard_(dosGuard)
+        , handler_(handler)
+        , maxSendingQueueSize_(maxSendingQueueSize)
     {
-        // If the transactions number is 200 per ledger, A client which subscribes everything will send 400 feeds for
-        // each ledger. Assume 2s per ledger, we allow user delay 80000/400 * 2 = 400s
-        maxSendingQueueSize_ = config.valueOr("ws_max_sending_queue_size", 80000);
-
         upgraded = true;  // NOLINT (cppcoreguidelines-pro-type-member-init)
 
         LOG(perfLog_.debug()) << tag() << "session created";

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -89,10 +89,8 @@ protected:
     wsFail(boost::beast::error_code ec, char const* what)
     {
         // Don't log if the WebSocket stream was gracefully closed at both endpoints
-        if (ec != boost::beast::websocket::error::closed) {
-            LOG(perfLog_.error()) << tag() << ": " << what << ": " << ec.message() << ": " << ec.value();
+        if (ec != boost::beast::websocket::error::closed)
             LOG(log_.error()) << tag() << ": " << what << ": " << ec.message() << ": " << ec.value();
-        }
 
         if (!ec_ && ec != boost::asio::error::operation_aborted) {
             ec_ = ec;

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -91,6 +91,7 @@ protected:
         // Don't log if the WebSocket stream was gracefully closed at both endpoints
         if (ec != boost::beast::websocket::error::closed) {
             LOG(perfLog_.error()) << tag() << ": " << what << ": " << ec.message() << ": " << ec.value();
+            LOG(log_.error()) << tag() << ": " << what << ": " << ec.message() << ": " << ec.value();
         }
 
         if (!ec_ && ec != boost::asio::error::operation_aborted) {


### PR DESCRIPTION
For slow clients, we will disconnect with it if the message queue is too long.