### PR TITLE
chore: Fix compilation for upcoming `libxrpl 2.3.0-rc1`

### DIFF
--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -950,7 +950,8 @@ accountHolds(
     auto const blob = backend.fetchLedgerObject(key, sequence, yield);
 
     if (!blob) {
-        amount.clear({currency, issuer});
+        amount.setIssue(ripple::Issue(currency, issuer));
+        amount.clear();
         return amount;
     }
 
@@ -958,7 +959,8 @@ accountHolds(
     ripple::SLE const sle{it, key};
 
     if (zeroIfFrozen && isFrozen(backend, sequence, account, currency, issuer, yield)) {
-        amount.clear(ripple::Issue(currency, issuer));
+        amount.setIssue(ripple::Issue(currency, issuer));
+        amount.clear();
     } else {
         amount = sle.getFieldAmount(ripple::sfBalance);
         if (account > issuer) {


### PR DESCRIPTION
Fixes #1715

This fixes the compilation issue in #1715 

There are 4 amendments Clio will need to support in some way for this `libxrpl` version
- AMMClawback
- Credentials
- MPTokensV1
- fixAMMv1_2