### PR TITLE
feat: Upgrade to `libxrpl 2.3.0-rc1`

### DIFF
--- a/src/data/AmendmentCenter.hpp
+++ b/src/data/AmendmentCenter.hpp
@@ -127,6 +127,10 @@ struct Amendments {
     REGISTER(fixInnerObjTemplate2);
     REGISTER(fixNFTokenPageLinks);
     REGISTER(InvariantsV1_1);
+    REGISTER(Credentials);
+    REGISTER(AMMClawback);
+    REGISTER(fixAMMv1_2);
+    REGISTER(MPTokensV1);
 
     // Obsolete but supported by libxrpl
     REGISTER(CryptoConditionsSuite);

--- a/src/data/AmendmentCenter.hpp
+++ b/src/data/AmendmentCenter.hpp
@@ -127,10 +127,10 @@ struct Amendments {
     REGISTER(fixInnerObjTemplate2);
     REGISTER(fixNFTokenPageLinks);
     REGISTER(InvariantsV1_1);
-    REGISTER(Credentials);
-    REGISTER(AMMClawback);
-    REGISTER(fixAMMv1_2);
     REGISTER(MPTokensV1);
+    REGISTER(fixAMMv1_2);
+    REGISTER(AMMClawback);
+    REGISTER(Credentials);
 
     // Obsolete but supported by libxrpl
     REGISTER(CryptoConditionsSuite);


### PR DESCRIPTION
Fixes #1717 

Note that this just silences the unit test for amendments check by listing the new 4 amendments as supported by Clio.
In reality there are separate PRs for some of them and others don't need any special treatment in Clio:
• AMMClawback - no special treatment needed
• fixAMMv1_2 - no special treatment needed
• Credentials - #1712 
• MPTokensV1 - #1147 