### PR TITLE
chore: Commits for 2.3.0-b4

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,7 @@ class Clio(ConanFile):
         'protobuf/3.21.9',
         'grpc/1.50.1',
         'openssl/1.1.1u',
-        'xrpl/2.3.0-b4',
+        'xrpl/2.3.0-rc1',
         'libbacktrace/cci.20210118'
     ]
 

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -949,7 +949,8 @@ accountHolds(
     auto const blob = backend.fetchLedgerObject(key, sequence, yield);
 
     if (!blob) {
-        amount.clear({currency, issuer});
+        amount.setIssue(ripple::Issue(currency, issuer));
+        amount.clear();
         return amount;
     }
 
@@ -957,7 +958,8 @@ accountHolds(
     ripple::SLE const sle{it, key};
 
     if (zeroIfFrozen && isFrozen(backend, sequence, account, currency, issuer, yield)) {
-        amount.clear(ripple::Issue(currency, issuer));
+        amount.setIssue(ripple::Issue(currency, issuer));
+        amount.clear();
     } else {
         amount = sle.getFieldAmount(ripple::sfBalance);
         if (account > issuer) {


### PR DESCRIPTION
Use `libxrpl 2.3.0-rc1` and fix compilation errors.