### PR TITLE
chore: Disable a flaky test

### DIFF
--- a/tests/unit/etlng/GrpcSourceTests.cpp
+++ b/tests/unit/etlng/GrpcSourceTests.cpp
@@ -223,8 +223,11 @@ TEST_F(GrpcSourceNgLoadInitialLedgerTests, ObserverCalledCorrectly)
     EXPECT_EQ(data, std::vector<std::string>(4, keyStr));
 }
 
+// TODO(godexsoft): Enable after fixing in #1752
 TEST_F(GrpcSourceNgLoadInitialLedgerTests, DataTransferredAndObserverCalledCorrectly)
 {
+    GTEST_SKIP() << "Skipping flaky test. Will be fixed in #1752.";
+
     auto const totalKeys = 256uz;
     auto const totalPerMarker = totalKeys / numMarkers_;
     auto const batchSize = totalPerMarker / 4uz;


### PR DESCRIPTION
For #1752 

Disables `DataTransferredAndObserverCalledCorrectly` until it's fixed in #1752 