### PR TITLE
refactor: setRange in tests

### DIFF
--- a/tests/common/util/HandlerBaseTestFixture.hpp
+++ b/tests/common/util/HandlerBaseTestFixture.hpp
@@ -24,6 +24,8 @@
 #include "util/MockETLServiceTestFixture.hpp"
 #include "util/MockPrometheus.hpp"
 
+#include <gmock/gmock.h>
+
 /**
  * @brief Fixture with an mock backend and an embedded boost::asio context.
  *

--- a/tests/unit/data/BackendInterfaceTests.cpp
+++ b/tests/unit/data/BackendInterfaceTests.cpp
@@ -41,12 +41,16 @@ using namespace testing;
 constexpr static auto MAXSEQ = 30;
 constexpr static auto MINSEQ = 10;
 
-struct BackendInterfaceTest : WithPrometheus, MockBackendTestNaggy, SyncAsioContextTest {};
+struct BackendInterfaceTest : WithPrometheus, MockBackendTestNaggy, SyncAsioContextTest {
+    BackendInterfaceTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 TEST_F(BackendInterfaceTest, FetchFeesSuccessPath)
 {
     using namespace ripple;
-    backend->setRange(MINSEQ, MAXSEQ);
 
     // New fee setting (after XRPFees amendment)
     EXPECT_CALL(*backend, doFetchLedgerObject(keylet::fees().key, MAXSEQ, _))
@@ -65,7 +69,6 @@ TEST_F(BackendInterfaceTest, FetchFeesSuccessPath)
 TEST_F(BackendInterfaceTest, FetchFeesLegacySuccessPath)
 {
     using namespace ripple;
-    backend->setRange(MINSEQ, MAXSEQ);
 
     // Legacy fee setting (before XRPFees amendment)
     EXPECT_CALL(*backend, doFetchLedgerObject(keylet::fees().key, MAXSEQ, _))
@@ -84,7 +87,6 @@ TEST_F(BackendInterfaceTest, FetchFeesLegacySuccessPath)
 TEST_F(BackendInterfaceTest, FetchLedgerPageSuccessPath)
 {
     using namespace ripple;
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto state = etl::SystemState{};
     backend->setCorruptionDetector(etl::CorruptionDetector{state, backend->cache()});
@@ -102,7 +104,6 @@ TEST_F(BackendInterfaceTest, FetchLedgerPageSuccessPath)
 TEST_F(BackendInterfaceTest, FetchLedgerPageDisablesCacheOnMissingData)
 {
     using namespace ripple;
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto state = etl::SystemState{};
     backend->setCorruptionDetector(etl::CorruptionDetector{state, backend->cache()});
@@ -123,7 +124,6 @@ TEST_F(BackendInterfaceTest, FetchLedgerPageDisablesCacheOnMissingData)
 TEST_F(BackendInterfaceTest, FetchLedgerPageWithoutCorruptionDetectorDoesNotDisableCacheOnMissingData)
 {
     using namespace ripple;
-    backend->setRange(MINSEQ, MAXSEQ);
 
     EXPECT_FALSE(backend->cache().isDisabled());
     EXPECT_CALL(*backend, doFetchSuccessorKey(_, _, _))

--- a/tests/unit/rpc/handlers/AMMInfoTests.cpp
+++ b/tests/unit/rpc/handlers/AMMInfoTests.cpp
@@ -58,7 +58,12 @@ constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A
 constexpr static auto INDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC";
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
 
-class RPCAMMInfoHandlerTest : public HandlerBaseTest {};
+struct RPCAMMInfoHandlerTest : HandlerBaseTest {
+    RPCAMMInfoHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 struct AMMInfoParamTestCaseBundle {
     std::string testName;
@@ -67,7 +72,7 @@ struct AMMInfoParamTestCaseBundle {
     std::string expectedErrorMessage;
 };
 
-struct AMMInfoParameterTest : public RPCAMMInfoHandlerTest, public WithParamInterface<AMMInfoParamTestCaseBundle> {};
+struct AMMInfoParameterTest : RPCAMMInfoHandlerTest, WithParamInterface<AMMInfoParamTestCaseBundle> {};
 
 static auto
 generateTestValuesForParametersTest()
@@ -119,8 +124,6 @@ TEST_P(AMMInfoParameterTest, InvalidParams)
 
 TEST_F(RPCAMMInfoHandlerTest, AccountNotFound)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     auto const missingAccountKey = GetAccountKey(NOTFOUND_ACCOUNT);
     auto const accountRoot = CreateAccountRootObject(AMM_ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
@@ -154,8 +157,6 @@ TEST_F(RPCAMMInfoHandlerTest, AccountNotFound)
 
 TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotExist)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(lgrInfo));
     ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
@@ -179,8 +180,6 @@ TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotExist)
 
 TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotInDBIsMalformed)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(lgrInfo));
     ON_CALL(*backend, doFetchLedgerObject).WillByDefault(Return(std::optional<Blob>{}));
@@ -205,8 +204,6 @@ TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotInDBIsMalformed)
 
 TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotFoundMissingAmmField)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     auto const accountRoot = CreateAccountRootObject(AMM_ACCOUNT, 0, 2, 200, 2, INDEX1, 2);
 
@@ -233,8 +230,6 @@ TEST_F(RPCAMMInfoHandlerTest, AMMAccountNotFoundMissingAmmField)
 
 TEST_F(RPCAMMInfoHandlerTest, AMMAccountAmmBlobNotFound)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     auto const accountKey = GetAccountKey(AMM_ACCOUNT);
     auto const ammId = ripple::uint256{AMMID};
@@ -270,8 +265,6 @@ TEST_F(RPCAMMInfoHandlerTest, AMMAccountAmmBlobNotFound)
 
 TEST_F(RPCAMMInfoHandlerTest, AMMAccountAccBlobNotFound)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, 30);
     auto const accountKey = GetAccountKey(AMM_ACCOUNT);
     auto const account2Key = GetAccountKey(AMM_ACCOUNT2);
@@ -311,8 +304,6 @@ TEST_F(RPCAMMInfoHandlerTest, AMMAccountAccBlobNotFound)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathMinimalFirstXRPNoTrustline)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -385,8 +376,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathMinimalFirstXRPNoTrustline)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAccount)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -469,8 +458,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAccount)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathMinimalSecondXRPNoTrustline)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -543,8 +530,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathMinimalSecondXRPNoTrustline)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathNonXRPNoTrustlines)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -622,8 +607,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathNonXRPNoTrustlines)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathFrozen)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -713,8 +696,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathFrozen)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathFrozenIssuer)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -805,8 +786,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathFrozenIssuer)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithTrustline)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -882,8 +861,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathWithTrustline)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithVoteSlots)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -975,8 +952,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathWithVoteSlots)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAuctionSlot)
 {
-    backend->setRange(10, 30);
-
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
@@ -1074,8 +1049,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAuctionSlot)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAssetsMatchingInputOrder)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);
@@ -1185,8 +1158,6 @@ TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAssetsMatchingInputOrder)
 
 TEST_F(RPCAMMInfoHandlerTest, HappyPathWithAssetsPreservesInputOrder)
 {
-    backend->setRange(10, 30);
-
     auto const lgrInfo = CreateLedgerHeader(LEDGERHASH, SEQ);
     auto const account1 = GetAccountIDWithString(AMM_ACCOUNT);
     auto const account2 = GetAccountIDWithString(AMM_ACCOUNT2);

--- a/tests/unit/rpc/handlers/AccountChannelsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountChannelsTests.cpp
@@ -52,7 +52,12 @@ constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B25
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 constexpr static auto TXNID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD";
 
-class RPCAccountChannelsHandlerTest : public HandlerBaseTest {};
+struct RPCAccountChannelsHandlerTest : HandlerBaseTest {
+    RPCAccountChannelsHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCAccountChannelsHandlerTest, LimitNotInt)
 {
@@ -295,7 +300,6 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -318,7 +322,6 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -343,7 +346,6 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -369,7 +371,6 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -393,7 +394,6 @@ TEST_F(RPCAccountChannelsHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case account not exist
 TEST_F(RPCAccountChannelsHandlerTest, NonExistAccount)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -451,7 +451,6 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
         ]
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -496,7 +495,6 @@ TEST_F(RPCAccountChannelsHandlerTest, DefaultParameterTest)
 // normal case : limit is used
 TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
@@ -574,7 +572,6 @@ TEST_F(RPCAccountChannelsHandlerTest, UseLimit)
 // normal case : destination is used
 TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -634,7 +631,6 @@ TEST_F(RPCAccountChannelsHandlerTest, UseDestination)
 // normal case : but the lines is emtpy
 TEST_F(RPCAccountChannelsHandlerTest, EmptyChannel)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -707,7 +703,6 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
         ]
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -755,7 +750,6 @@ TEST_F(RPCAccountChannelsHandlerTest, OptionalResponseField)
 // normal case : test marker output correct
 TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
 {
-    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto ownerDirKk = ripple::keylet::ownerDir(account).key;
@@ -824,7 +818,6 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerOutput)
 // normal case : handler marker correctly
 TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 {
-    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     constexpr static auto nextPage = 99;
@@ -881,7 +874,6 @@ TEST_F(RPCAccountChannelsHandlerTest, MarkerInput)
 
 TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -928,7 +920,6 @@ TEST_F(RPCAccountChannelsHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCAccountChannelsHandlerTest, LimitMoreThanMax)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);

--- a/tests/unit/rpc/handlers/AccountCurrenciesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountCurrenciesTests.cpp
@@ -51,11 +51,15 @@ constexpr static auto INDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B2501
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
 constexpr static auto TXNID = "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879";
 
-class RPCAccountCurrenciesHandlerTest : public HandlerBaseTest {};
+struct RPCAccountCurrenciesHandlerTest : HandlerBaseTest {
+    RPCAccountCurrenciesHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -81,7 +85,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, AccountNotExist)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaIntSequence)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -106,7 +109,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(12, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -131,7 +133,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, LedgerNonExistViaHash)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -171,7 +172,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
         ]
     })";
 
-    backend->setRange(10, 30);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -219,7 +219,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, DefaultParameter)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
 {
-    backend->setRange(10, 30);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -256,7 +255,6 @@ TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderHash)
 
 TEST_F(RPCAccountCurrenciesHandlerTest, RequestViaLegderSeq)
 {
-    backend->setRange(10, 30);
     auto const ledgerSeq = 29;
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);

--- a/tests/unit/rpc/handlers/AccountInfoTests.cpp
+++ b/tests/unit/rpc/handlers/AccountInfoTests.cpp
@@ -54,6 +54,11 @@ constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A
 constexpr static auto INDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC";
 
 struct RPCAccountInfoHandlerTest : HandlerBaseTest {
+    RPCAccountInfoHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+
 protected:
     StrictMockAmendmentCenterSharedPtr mockAmendmentCenterPtr;
 };
@@ -66,8 +71,7 @@ struct AccountInfoParamTestCaseBundle {
 };
 
 // parameterized test cases for parameters check
-struct AccountInfoParameterTest : public RPCAccountInfoHandlerTest,
-                                  public WithParamInterface<AccountInfoParamTestCaseBundle> {};
+struct AccountInfoParameterTest : RPCAccountInfoHandlerTest, WithParamInterface<AccountInfoParamTestCaseBundle> {};
 
 static auto
 generateTestValuesForParametersTest()
@@ -149,8 +153,6 @@ TEST_F(AccountInfoParameterTest, ApiV1SignerListIsNotBool)
 
 TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaIntSequence)
 {
-    backend->setRange(10, 30);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -174,7 +176,6 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaStringSequence)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::nullopt));
@@ -198,7 +199,6 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaHash)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -224,7 +224,6 @@ TEST_F(RPCAccountInfoHandlerTest, LedgerNonExistViaHash)
 
 TEST_F(RPCAccountInfoHandlerTest, AccountNotExist)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -250,7 +249,6 @@ TEST_F(RPCAccountInfoHandlerTest, AccountNotExist)
 
 TEST_F(RPCAccountInfoHandlerTest, AccountInvalid)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -277,7 +275,6 @@ TEST_F(RPCAccountInfoHandlerTest, AccountInvalid)
 
 TEST_F(RPCAccountInfoHandlerTest, SignerListsInvalid)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -381,7 +378,6 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrueV2)
         LEDGERHASH
     );
 
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -483,7 +479,6 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrueV1)
         LEDGERHASH
     );
 
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -551,7 +546,6 @@ TEST_F(RPCAccountInfoHandlerTest, Flags)
         LEDGERHASH
     );
 
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -591,7 +585,6 @@ TEST_F(RPCAccountInfoHandlerTest, Flags)
 
 TEST_F(RPCAccountInfoHandlerTest, IdentAndSignerListsFalse)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -659,7 +652,6 @@ TEST_F(RPCAccountInfoHandlerTest, DisallowIncoming)
         LEDGERHASH
     );
 
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -735,7 +727,6 @@ TEST_F(RPCAccountInfoHandlerTest, Clawback)
         LEDGERHASH
     );
 
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));

--- a/tests/unit/rpc/handlers/AccountLinesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountLinesTests.cpp
@@ -55,7 +55,12 @@ constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B25
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 constexpr static auto TXNID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD";
 
-class RPCAccountLinesHandlerTest : public HandlerBaseTest {};
+struct RPCAccountLinesHandlerTest : HandlerBaseTest {
+    RPCAccountLinesHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 // TODO: a lot of the tests are copy-pasted from AccountChannelsTest
 // because the logic is mostly the same but currently implemented in
@@ -341,7 +346,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -364,7 +368,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -389,7 +392,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -415,7 +417,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db, call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -439,7 +440,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case account not exist
 TEST_F(RPCAccountLinesHandlerTest, NonExistAccount)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -467,7 +467,6 @@ TEST_F(RPCAccountLinesHandlerTest, NonExistAccount)
 // normal case when only provide account
 TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -546,7 +545,6 @@ TEST_F(RPCAccountLinesHandlerTest, DefaultParameterTest)
 // normal case : limit is used
 TEST_F(RPCAccountLinesHandlerTest, UseLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
@@ -624,7 +622,6 @@ TEST_F(RPCAccountLinesHandlerTest, UseLimit)
 // normal case : destination is used
 TEST_F(RPCAccountLinesHandlerTest, UseDestination)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -684,7 +681,6 @@ TEST_F(RPCAccountLinesHandlerTest, UseDestination)
 // normal case : but the lines is emtpy
 TEST_F(RPCAccountLinesHandlerTest, EmptyChannel)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -754,7 +750,6 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
         ]
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -808,7 +803,6 @@ TEST_F(RPCAccountLinesHandlerTest, OptionalResponseField)
 // normal case : test marker output correct
 TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
 {
-    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     auto ownerDirKk = ripple::keylet::ownerDir(account).key;
@@ -878,7 +872,6 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerOutput)
 // normal case : handler marker correctly
 TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
 {
-    backend->setRange(10, 30);
     auto account = GetAccountIDWithString(ACCOUNT);
     auto accountKk = ripple::keylet::account(account).key;
     constexpr static auto nextPage = 99;
@@ -935,7 +928,6 @@ TEST_F(RPCAccountLinesHandlerTest, MarkerInput)
 
 TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -1017,7 +1009,6 @@ TEST_F(RPCAccountLinesHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCAccountLinesHandlerTest, LimitMoreThanMax)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);

--- a/tests/unit/rpc/handlers/AccountNFTsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountNFTsTests.cpp
@@ -57,7 +57,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCAccountNFTsHandlerTest : public HandlerBaseTest {};
+struct RPCAccountNFTsHandlerTest : HandlerBaseTest {
+    RPCAccountNFTsHandlerTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 struct AccountNFTParamTestCaseBundle {
     std::string testName;
@@ -166,7 +171,6 @@ TEST_P(AccountNFTParameterTest, InvalidParams)
 
 TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaHash)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -194,7 +198,6 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaStringIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -221,7 +224,6 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -246,7 +248,6 @@ TEST_F(RPCAccountNFTsHandlerTest, LedgerNotFoundViaIntIndex)
 
 TEST_F(RPCAccountNFTsHandlerTest, AccountNotFound)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -300,7 +301,6 @@ TEST_F(RPCAccountNFTsHandlerTest, NormalPath)
         SERIAL
     );
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -335,7 +335,6 @@ TEST_F(RPCAccountNFTsHandlerTest, Limit)
 {
     static auto constexpr limit = 20;
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -371,7 +370,6 @@ TEST_F(RPCAccountNFTsHandlerTest, Limit)
 
 TEST_F(RPCAccountNFTsHandlerTest, Marker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -405,7 +403,6 @@ TEST_F(RPCAccountNFTsHandlerTest, Marker)
 
 TEST_F(RPCAccountNFTsHandlerTest, InvalidMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -435,7 +432,6 @@ TEST_F(RPCAccountNFTsHandlerTest, InvalidMarker)
 
 TEST_F(RPCAccountNFTsHandlerTest, AccountWithNoNFT)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -461,7 +457,6 @@ TEST_F(RPCAccountNFTsHandlerTest, AccountWithNoNFT)
 
 TEST_F(RPCAccountNFTsHandlerTest, invalidPage)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -526,7 +521,6 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitLessThanMin)
         AccountNFTsHandler::LIMIT_MIN
     );
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
@@ -590,7 +584,6 @@ TEST_F(RPCAccountNFTsHandlerTest, LimitMoreThanMax)
         AccountNFTsHandler::LIMIT_MAX
     );
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));

--- a/tests/unit/rpc/handlers/AccountObjectsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountObjectsTests.cpp
@@ -61,7 +61,12 @@ constexpr static auto TOKENID = "000827103B94ECBB7BF0A0A6ED62B3607801A27B65F4679
 constexpr static auto MAXSEQ = 30;
 constexpr static auto MINSEQ = 10;
 
-class RPCAccountObjectsHandlerTest : public HandlerBaseTest {};
+struct RPCAccountObjectsHandlerTest : HandlerBaseTest {
+    RPCAccountObjectsHandlerTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 struct AccountObjectsParamTestCaseBundle {
     std::string testName;
@@ -196,7 +201,6 @@ TEST_P(AccountObjectsParameterTest, InvalidParams)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerHeader
     EXPECT_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::optional<ripple::LedgerHeader>{}));
 
@@ -219,7 +223,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerHeader
     EXPECT_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillOnce(Return(std::nullopt));
 
@@ -242,7 +245,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     // return empty ledgerHeader
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
         .WillOnce(Return(std::optional<ripple::LedgerHeader>{}));
@@ -267,7 +269,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LedgerNonExistViaHash)
 
 TEST_F(RPCAccountObjectsHandlerTest, AccountNotExist)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
 
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
@@ -323,7 +324,6 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
                                             ]
                                         })";
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -362,7 +362,6 @@ TEST_F(RPCAccountObjectsHandlerTest, DefaultParameterNoNFTFound)
 
 TEST_F(RPCAccountObjectsHandlerTest, Limit)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -408,7 +407,6 @@ TEST_F(RPCAccountObjectsHandlerTest, Limit)
 
 TEST_F(RPCAccountObjectsHandlerTest, Marker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -453,7 +451,6 @@ TEST_F(RPCAccountObjectsHandlerTest, Marker)
 
 TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -505,7 +502,6 @@ TEST_F(RPCAccountObjectsHandlerTest, MultipleDirNoNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -557,7 +553,6 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -603,7 +598,6 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterAmmType)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -654,8 +648,6 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterReturnEmpty)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -710,8 +702,6 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -755,8 +745,6 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithTypeFilter)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -817,8 +805,6 @@ TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterEmptyResult)
 
 TEST_F(RPCAccountObjectsHandlerTest, DeletionBlockersOnlyFilterWithIncompatibleTypeYieldsEmptyResult)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -942,7 +928,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
                                             ]
                                         })";
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -989,7 +974,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMixOtherObjects)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1033,7 +1017,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitReturnMarker)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1081,7 +1064,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTReachLimitNoMarker)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1153,7 +1135,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarker)
 // when limit reached, happen to be the end of NFT page list
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1207,7 +1188,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNoMoreNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1237,7 +1217,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotInRange)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1271,7 +1250,6 @@ TEST_F(RPCAccountObjectsHandlerTest, NFTMarkerNotExist)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTLimitAdjust)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1384,7 +1362,6 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
                                             ]
                                         })";
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1432,7 +1409,6 @@ TEST_F(RPCAccountObjectsHandlerTest, FilterNFT)
 
 TEST_F(RPCAccountObjectsHandlerTest, NFTZeroMarkerNotAffectOtherMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1512,7 +1488,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitLessThanMin)
         AccountObjectsHandler::LIMIT_MIN
     );
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1588,7 +1563,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitMoreThanMax)
         AccountObjectsHandler::LIMIT_MAX
     );
 
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
 
@@ -1629,7 +1603,6 @@ TEST_F(RPCAccountObjectsHandlerTest, LimitMoreThanMax)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterMPTIssuanceType)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 
@@ -1678,7 +1651,6 @@ TEST_F(RPCAccountObjectsHandlerTest, TypeFilterMPTIssuanceType)
 
 TEST_F(RPCAccountObjectsHandlerTest, TypeFilterMPTokenType)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerinfo));
 

--- a/tests/unit/rpc/handlers/AccountOffersTests.cpp
+++ b/tests/unit/rpc/handlers/AccountOffersTests.cpp
@@ -52,7 +52,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCAccountOffersHandlerTest : public HandlerBaseTest {};
+struct RPCAccountOffersHandlerTest : HandlerBaseTest {
+    RPCAccountOffersHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 struct AccountOfferParamTestCaseBundle {
     std::string testName;
@@ -161,7 +166,6 @@ TEST_P(AccountOfferParameterTest, InvalidParams)
 
 TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaHash)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -189,7 +193,6 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaStringIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -216,7 +219,6 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaIntIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -241,7 +243,6 @@ TEST_F(RPCAccountOffersHandlerTest, LedgerNotFoundViaIntIndex)
 
 TEST_F(RPCAccountOffersHandlerTest, AccountNotFound)
 {
-    backend->setRange(10, 30);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -296,7 +297,6 @@ TEST_F(RPCAccountOffersHandlerTest, DefaultParams)
     );
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -345,7 +345,6 @@ TEST_F(RPCAccountOffersHandlerTest, Limit)
 {
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -396,7 +395,6 @@ TEST_F(RPCAccountOffersHandlerTest, Marker)
 {
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -452,7 +450,6 @@ TEST_F(RPCAccountOffersHandlerTest, MarkerNotExists)
 {
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -490,7 +487,6 @@ TEST_F(RPCAccountOffersHandlerTest, LimitLessThanMin)
 {
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -545,7 +541,6 @@ TEST_F(RPCAccountOffersHandlerTest, LimitMoreThanMax)
 {
     auto constexpr ledgerSeq = 30;
 
-    backend->setRange(10, ledgerSeq);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, ledgerSeq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 

--- a/tests/unit/rpc/handlers/AccountTxTests.cpp
+++ b/tests/unit/rpc/handlers/AccountTxTests.cpp
@@ -51,7 +51,12 @@ constexpr static auto NFTID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C9
 constexpr static auto NFTID2 = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DA";
 constexpr static auto NFTID3 = "15FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DF";
 
-class RPCAccountTxHandlerTest : public HandlerBaseTest {};
+struct RPCAccountTxHandlerTest : HandlerBaseTest {
+    RPCAccountTxHandlerTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 struct AccountTxParamTestCaseBundle {
     std::string testName;
@@ -398,7 +403,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(AccountTxParameterTest, CheckParams)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const& testBundle = GetParam();
 
     auto const req = json::parse(testBundle.testJson);
@@ -480,8 +484,6 @@ genNFTTransactions(uint32_t seq)
 
 TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -523,8 +525,6 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardTrue)
 
 TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -566,8 +566,6 @@ TEST_F(RPCAccountTxHandlerTest, IndexSpecificForwardFalse)
 
 TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -609,8 +607,6 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardTrue)
 
 TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -652,8 +648,6 @@ TEST_F(RPCAccountTxHandlerTest, IndexNotSpecificForwardFalse)
 
 TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -709,8 +703,6 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrue)
 
 TEST_F(RPCAccountTxHandlerTest, BinaryTrueV2)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     EXPECT_CALL(
@@ -765,8 +757,6 @@ TEST_F(RPCAccountTxHandlerTest, BinaryTrueV2)
 
 TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -806,8 +796,6 @@ TEST_F(RPCAccountTxHandlerTest, LimitAndMarker)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -851,8 +839,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
@@ -876,8 +862,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerIntIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
@@ -901,8 +885,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificNonexistLedgerStringIndex)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -946,8 +928,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerHash)
 
 TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -990,8 +970,6 @@ TEST_F(RPCAccountTxHandlerTest, SpecificLedgerIndexValidated)
 
 TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -1033,8 +1011,6 @@ TEST_F(RPCAccountTxHandlerTest, TxLessThanMinSeq)
 
 TEST_F(RPCAccountTxHandlerTest, TxLargerThanMaxSeq)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));
@@ -1272,7 +1248,6 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v1)
                 "seq": 34
             }
         })";
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const transactions = genNFTTransactions(MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -1511,7 +1486,6 @@ TEST_F(RPCAccountTxHandlerTest, NFTTxs_API_v2)
                 "seq": 34
             }
         })";
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const transactions = genNFTTransactions(MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -2036,8 +2010,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(AccountTxTransactionTypeTest, SpecificTransactionType)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MAXSEQ, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchAccountTransactions).WillByDefault(Return(transCursor));

--- a/tests/unit/rpc/handlers/BookChangesTests.cpp
+++ b/tests/unit/rpc/handlers/BookChangesTests.cpp
@@ -50,7 +50,12 @@ constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A
 constexpr static auto MAXSEQ = 30;
 constexpr static auto MINSEQ = 10;
 
-class RPCBookChangesHandlerTest : public HandlerBaseTest {};
+struct RPCBookChangesHandlerTest : HandlerBaseTest {
+    RPCBookChangesHandlerTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 struct BookChangesParamTestCaseBundle {
     std::string testName;
@@ -102,7 +107,6 @@ TEST_P(BookChangesParameterTest, InvalidParams)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaIntSequence)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -120,7 +124,6 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaStringSequence)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(std::nullopt));
@@ -138,7 +141,6 @@ TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaStringSequence)
 
 TEST_F(RPCBookChangesHandlerTest, LedgerNonExistViaHash)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -183,7 +185,6 @@ TEST_F(RPCBookChangesHandlerTest, NormalPath)
             ]
         })";
 
-    backend->setRange(MINSEQ, MAXSEQ);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ, _)).WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, MAXSEQ)));
 

--- a/tests/unit/rpc/handlers/BookOffersTests.cpp
+++ b/tests/unit/rpc/handlers/BookOffersTests.cpp
@@ -67,7 +67,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCBookOffersHandlerTest : public HandlerBaseTest {};
+struct RPCBookOffersHandlerTest : HandlerBaseTest {
+    RPCBookOffersHandlerTest()
+    {
+        backend->setRange(10, 300);
+    }
+};
 
 struct ParameterTestBundle {
     std::string testName;
@@ -76,7 +81,7 @@ struct ParameterTestBundle {
     std::string expectedErrorMessage;
 };
 
-struct RPCBookOffersParameterTest : public RPCBookOffersHandlerTest, public WithParamInterface<ParameterTestBundle> {};
+struct RPCBookOffersParameterTest : RPCBookOffersHandlerTest, WithParamInterface<ParameterTestBundle> {};
 
 TEST_P(RPCBookOffersParameterTest, CheckError)
 {
@@ -509,7 +514,6 @@ TEST_P(RPCBookOffersNormalPathTest, CheckOutput)
     auto const& bundle = GetParam();
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
@@ -1159,7 +1163,6 @@ INSTANTIATE_TEST_SUITE_P(
 // ledger not exist
 TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaIntSequence)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -1191,7 +1194,6 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaIntSequence)
 
 TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaSequence)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(30, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -1223,7 +1225,6 @@ TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaSequence)
 
 TEST_F(RPCBookOffersHandlerTest, LedgerNonExistViaHash)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -1259,7 +1260,6 @@ TEST_F(RPCBookOffersHandlerTest, Limit)
 {
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
@@ -1333,7 +1333,6 @@ TEST_F(RPCBookOffersHandlerTest, LimitMoreThanMax)
 {
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);

--- a/tests/unit/rpc/handlers/DepositAuthorizedTests.cpp
+++ b/tests/unit/rpc/handlers/DepositAuthorizedTests.cpp
@@ -60,7 +60,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCDepositAuthorizedTest : public HandlerBaseTest {};
+struct RPCDepositAuthorizedTest : HandlerBaseTest {
+    RPCDepositAuthorizedTest()
+    {
+        backend->setRange(RangeMin, RangeMax);
+    }
+};
 
 struct DepositAuthorizedTestCaseBundle {
     std::string testName;
@@ -70,8 +75,8 @@ struct DepositAuthorizedTestCaseBundle {
 };
 
 // parameterized test cases for parameters check
-struct DepositAuthorizedParameterTest : public RPCDepositAuthorizedTest,
-                                        public WithParamInterface<DepositAuthorizedTestCaseBundle> {};
+struct DepositAuthorizedParameterTest : RPCDepositAuthorizedTest,
+                                        WithParamInterface<DepositAuthorizedTestCaseBundle> {};
 
 static auto
 generateTestValuesForParametersTest()
@@ -225,8 +230,6 @@ TEST_P(DepositAuthorizedParameterTest, InvalidParams)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaIntSequence)
 {
-    backend->setRange(RangeMin, RangeMax);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RangeMax, _)).WillByDefault(Return(std::nullopt));
 
@@ -254,8 +257,6 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaStringSequence)
 {
-    backend->setRange(RangeMin, RangeMax);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RangeMax, _)).WillByDefault(Return(std::nullopt));
 
@@ -283,8 +284,6 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaHash)
 {
-    backend->setRange(RangeMin, RangeMax);
-
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillByDefault(Return(std::nullopt));
 
@@ -312,8 +311,6 @@ TEST_F(RPCDepositAuthorizedTest, LedgerNotExistViaHash)
 
 TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillByDefault(Return(ledgerHeader));
@@ -347,8 +344,6 @@ TEST_F(RPCDepositAuthorizedTest, SourceAccountDoesNotExist)
 
 TEST_F(RPCDepositAuthorizedTest, DestinationAccountDoesNotExist)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillByDefault(Return(ledgerHeader));
@@ -396,8 +391,6 @@ TEST_F(RPCDepositAuthorizedTest, AccountsAreEqual)
             "destination_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
         })";
 
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillByDefault(Return(ledgerHeader));
@@ -438,8 +431,6 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsNoDepositAuthFlag)
             "source_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
-
-    backend->setRange(10, 30);
 
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
@@ -487,8 +478,6 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsFals
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
 
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillByDefault(Return(ledgerHeader));
@@ -535,8 +524,6 @@ TEST_F(RPCDepositAuthorizedTest, DifferentAccountsWithDepositAuthFlagReturnsTrue
             "source_account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
             "destination_account": "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun"
         })";
-
-    backend->setRange(10, 30);
 
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
@@ -588,8 +575,6 @@ TEST_F(RPCDepositAuthorizedTest, CredentialAcceptedAndNotExpiredReturnsTrue)
         CredentialHash  // CREDENTIALHASH should match credentialIndex
     );
 
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));
@@ -637,8 +622,6 @@ TEST_F(RPCDepositAuthorizedTest, CredentialAcceptedAndNotExpiredReturnsTrue)
 
 TEST_F(RPCDepositAuthorizedTest, CredentialNotAuthorizedReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));
@@ -689,8 +672,6 @@ TEST_F(RPCDepositAuthorizedTest, CredentialNotAuthorizedReturnsFalse)
 
 TEST_F(RPCDepositAuthorizedTest, CredentialExpiredReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30, 100);
 
     // set parent close time to 500 seconds
@@ -747,8 +728,6 @@ TEST_F(RPCDepositAuthorizedTest, CredentialExpiredReturnsFalse)
 
 TEST_F(RPCDepositAuthorizedTest, DuplicateCredentialsReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30, 34);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));
@@ -800,8 +779,6 @@ TEST_F(RPCDepositAuthorizedTest, DuplicateCredentialsReturnsFalse)
 
 TEST_F(RPCDepositAuthorizedTest, NoElementsInCredentialsReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30, 34);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));
@@ -842,8 +819,6 @@ TEST_F(RPCDepositAuthorizedTest, NoElementsInCredentialsReturnsFalse)
 
 TEST_F(RPCDepositAuthorizedTest, MoreThanMaxNumberOfCredentialsReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30, 34);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));
@@ -899,8 +874,6 @@ TEST_F(RPCDepositAuthorizedTest, MoreThanMaxNumberOfCredentialsReturnsFalse)
 
 TEST_F(RPCDepositAuthorizedTest, DifferenSubjectAccountForCredentialReturnsFalse)
 {
-    backend->setRange(10, 30);
-
     auto ledgerHeader = CreateLedgerHeader(LedgerHash, 30);
 
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LedgerHash}, _)).WillOnce(Return(ledgerHeader));

--- a/tests/unit/rpc/handlers/FeatureTests.cpp
+++ b/tests/unit/rpc/handlers/FeatureTests.cpp
@@ -45,7 +45,12 @@ constexpr static auto RANGEMAX = 30;
 constexpr static auto SEQ = 30;
 constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652";
 
-class RPCFeatureHandlerTest : public HandlerBaseTest {
+struct RPCFeatureHandlerTest : HandlerBaseTest {
+    RPCFeatureHandlerTest()
+    {
+        backend->setRange(RANGEMIN, RANGEMAX);
+    }
+
 protected:
     StrictMockAmendmentCenterSharedPtr mockAmendmentCenterPtr;
 };
@@ -58,8 +63,8 @@ struct RPCFeatureHandlerParamTestCaseBundle {
 };
 
 // parameterized test cases for parameters check
-struct RPCFeatureHandlerParamTest : public RPCFeatureHandlerTest,
-                                    public testing::WithParamInterface<RPCFeatureHandlerParamTestCaseBundle> {};
+struct RPCFeatureHandlerParamTest : RPCFeatureHandlerTest,
+                                    testing::WithParamInterface<RPCFeatureHandlerParamTestCaseBundle> {};
 
 static auto
 generateTestValuesForParametersTest()
@@ -149,7 +154,6 @@ TEST_P(RPCFeatureHandlerParamTest, InvalidParams)
 
 TEST_F(RPCFeatureHandlerTest, LedgerNotExistViaIntSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, testing::_)).WillOnce(testing::Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
@@ -170,7 +174,6 @@ TEST_F(RPCFeatureHandlerTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCFeatureHandlerTest, LedgerNotExistViaStringSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, testing::_)).WillOnce(testing::Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
@@ -191,7 +194,6 @@ TEST_F(RPCFeatureHandlerTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCFeatureHandlerTest, LedgerNotExistViaHash)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, testing::_))
         .WillOnce(testing::Return(std::nullopt));
 
@@ -230,8 +232,6 @@ TEST_F(RPCFeatureHandlerTest, AlwaysNoPermissionForVetoed)
 
 TEST_F(RPCFeatureHandlerTest, SuccessPathViaNameWithSingleSupportedAndEnabledResult)
 {
-    backend->setRange(10, 30);
-
     auto const all = std::vector<data::Amendment>{
         {
             .name = Amendments::fixUniversalNumber,
@@ -282,8 +282,6 @@ TEST_F(RPCFeatureHandlerTest, SuccessPathViaNameWithSingleSupportedAndEnabledRes
 
 TEST_F(RPCFeatureHandlerTest, SuccessPathViaHashWithSingleResult)
 {
-    backend->setRange(10, 30);
-
     auto const all = std::vector<data::Amendment>{
         {
             .name = Amendments::fixUniversalNumber,
@@ -337,8 +335,6 @@ TEST_F(RPCFeatureHandlerTest, SuccessPathViaHashWithSingleResult)
 
 TEST_F(RPCFeatureHandlerTest, BadFeaturePath)
 {
-    backend->setRange(10, 30);
-
     auto const all = std::vector<data::Amendment>{{
         .name = Amendments::fixUniversalNumber,
         .feature = data::Amendment::GetAmendmentId(Amendments::fixUniversalNumber),
@@ -365,8 +361,6 @@ TEST_F(RPCFeatureHandlerTest, BadFeaturePath)
 
 TEST_F(RPCFeatureHandlerTest, SuccessPathWithMultipleResults)
 {
-    backend->setRange(10, 30);
-
     auto const all = std::vector<data::Amendment>{
         {
             .name = Amendments::fixUniversalNumber,

--- a/tests/unit/rpc/handlers/GatewayBalancesTests.cpp
+++ b/tests/unit/rpc/handlers/GatewayBalancesTests.cpp
@@ -58,7 +58,12 @@ constexpr static auto INDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B2501
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
 constexpr static auto TXNID = "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879";
 
-class RPCGatewayBalancesHandlerTest : public HandlerBaseTest {};
+struct RPCGatewayBalancesHandlerTest : HandlerBaseTest {
+    RPCGatewayBalancesHandlerTest()
+    {
+        backend->setRange(10, 300);
+    }
+};
 
 struct ParameterTestBundle {
     std::string testName;
@@ -207,7 +212,6 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaStringIndex)
 {
     auto const seq = 123;
 
-    backend->setRange(10, 300);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -236,7 +240,6 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaIntIndex)
 {
     auto const seq = 123;
 
-    backend->setRange(10, 300);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
@@ -263,7 +266,6 @@ TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaIntIndex)
 
 TEST_F(RPCGatewayBalancesHandlerTest, LedgerNotFoundViaHash)
 {
-    backend->setRange(10, 300);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _))
@@ -293,7 +295,6 @@ TEST_F(RPCGatewayBalancesHandlerTest, AccountNotFound)
 {
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
@@ -326,7 +327,6 @@ TEST_F(RPCGatewayBalancesHandlerTest, InvalidHotWallet)
 {
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
@@ -385,7 +385,6 @@ TEST_P(NormalPathTest, CheckOutput)
     auto const& bundle = GetParam();
     auto const seq = 300;
 
-    backend->setRange(10, seq);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);

--- a/tests/unit/rpc/handlers/LedgerDataTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerDataTests.cpp
@@ -53,7 +53,12 @@ constexpr static auto INDEX1 = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 constexpr static auto TXNID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F0DD";
 
-class RPCLedgerDataHandlerTest : public HandlerBaseTest {};
+struct RPCLedgerDataHandlerTest : HandlerBaseTest {
+    RPCLedgerDataHandlerTest()
+    {
+        backend->setRange(RANGEMIN, RANGEMAX);
+    }
+};
 
 struct LedgerDataParamTestCaseBundle {
     std::string testName;
@@ -110,7 +115,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(LedgerDataParameterTest, InvalidParams)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{LedgerDataHandler{backend}};
@@ -125,8 +129,6 @@ TEST_P(LedgerDataParameterTest, InvalidParams)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaIntSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
@@ -148,8 +150,6 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaStringSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
@@ -171,8 +171,6 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaHash)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
 
@@ -194,8 +192,6 @@ TEST_F(RPCLedgerDataHandlerTest, LedgerNotExistViaHash)
 
 TEST_F(RPCLedgerDataHandlerTest, MarkerNotExist)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -235,8 +231,6 @@ TEST_F(RPCLedgerDataHandlerTest, NoMarker)
       "transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000",
       "closed":true
    })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
 
@@ -295,8 +289,6 @@ TEST_F(RPCLedgerDataHandlerTest, Version2)
       "closed": true
    })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
 
     // When 'type' not specified, default to all the types
@@ -349,8 +341,6 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilter)
       "transaction_hash":"0000000000000000000000000000000000000000000000000000000000000000",
       "closed":true
    })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
@@ -415,8 +405,6 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilterAMM)
       "closed":true
    })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -477,8 +465,6 @@ TEST_F(RPCLedgerDataHandlerTest, OutOfOrder)
       "closed":true
    })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -513,8 +499,6 @@ TEST_F(RPCLedgerDataHandlerTest, OutOfOrder)
 
 TEST_F(RPCLedgerDataHandlerTest, Marker)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -564,8 +548,6 @@ TEST_F(RPCLedgerDataHandlerTest, Marker)
 
 TEST_F(RPCLedgerDataHandlerTest, DiffMarker)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -608,8 +590,6 @@ TEST_F(RPCLedgerDataHandlerTest, DiffMarker)
 
 TEST_F(RPCLedgerDataHandlerTest, Binary)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -649,8 +629,6 @@ TEST_F(RPCLedgerDataHandlerTest, Binary)
 
 TEST_F(RPCLedgerDataHandlerTest, BinaryLimitMoreThanMax)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -691,8 +669,6 @@ TEST_F(RPCLedgerDataHandlerTest, BinaryLimitMoreThanMax)
 
 TEST_F(RPCLedgerDataHandlerTest, JsonLimitMoreThanMax)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -732,8 +708,6 @@ TEST_F(RPCLedgerDataHandlerTest, JsonLimitMoreThanMax)
 
 TEST_F(RPCLedgerDataHandlerTest, TypeFilterMPTIssuance)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));
@@ -776,8 +750,6 @@ TEST_F(RPCLedgerDataHandlerTest, TypeFilterMPTIssuance)
 
 TEST_F(RPCLedgerDataHandlerTest, TypeFilterMPToken)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _))
         .WillByDefault(Return(CreateLedgerHeader(LEDGERHASH, RANGEMAX)));

--- a/tests/unit/rpc/handlers/LedgerEntryTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerEntryTests.cpp
@@ -74,7 +74,12 @@ constexpr static auto NFTID = "00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875
 constexpr static auto TXNID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD";
 constexpr static auto CREDENTIALTYPE = "4B5943";
 
-class RPCLedgerEntryTest : public HandlerBaseTest {};
+struct RPCLedgerEntryTest : HandlerBaseTest {
+    RPCLedgerEntryTest()
+    {
+        backend->setRange(RANGEMIN, RANGEMAX);
+    }
+};
 
 struct ParamTestCaseBundle {
     std::string testName;
@@ -2213,7 +2218,6 @@ TEST_P(IndexTest, InvalidIndexNotString)
 
 TEST_F(RPCLedgerEntryTest, LedgerEntryNotFound)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
@@ -2871,7 +2875,6 @@ TEST_P(RPCLedgerEntryNormalPathTest, NormalPath)
 {
     auto const testBundle = GetParam();
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
@@ -2921,7 +2924,6 @@ TEST_F(RPCLedgerEntryTest, BinaryFalse)
         }
     })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
@@ -2947,7 +2949,6 @@ TEST_F(RPCLedgerEntryTest, BinaryFalse)
 
 TEST_F(RPCLedgerEntryTest, UnexpectedLedgerType)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
@@ -2974,8 +2975,6 @@ TEST_F(RPCLedgerEntryTest, UnexpectedLedgerType)
 
 TEST_F(RPCLedgerEntryTest, LedgerNotExistViaIntSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
@@ -2998,8 +2997,6 @@ TEST_F(RPCLedgerEntryTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCLedgerEntryTest, LedgerNotExistViaStringSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
@@ -3022,8 +3019,6 @@ TEST_F(RPCLedgerEntryTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCLedgerEntryTest, LedgerNotExistViaHash)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillRepeatedly(Return(std::nullopt));
 
     runSpawn([&, this](auto yield) {
@@ -3109,7 +3104,6 @@ TEST_F(RPCLedgerEntryTest, BinaryFalseIncludeDeleted)
         }
     })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
@@ -3157,7 +3151,6 @@ TEST_F(RPCLedgerEntryTest, LedgerEntryDeleted)
             "index": "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD"
             }
         })";
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
     // return valid ledger entry which can be deserialized
@@ -3187,7 +3180,6 @@ TEST_F(RPCLedgerEntryTest, LedgerEntryDeleted)
 // Expected Result: return entryNotFound error
 TEST_F(RPCLedgerEntryTest, LedgerEntryNotExist)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
     EXPECT_CALL(*backend, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _))
@@ -3239,7 +3231,6 @@ TEST_F(RPCLedgerEntryTest, BinaryFalseIncludeDeleteFalse)
         }
     })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
@@ -3297,7 +3288,6 @@ TEST_F(RPCLedgerEntryTest, ObjectUpdateIncludeDelete)
             }
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerinfo
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
@@ -3348,7 +3338,6 @@ TEST_F(RPCLedgerEntryTest, ObjectDeletedPreviously)
             "index": "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DD"
             }
         })";
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
     // return valid ledger entry which can be deserialized
@@ -3378,7 +3367,6 @@ TEST_F(RPCLedgerEntryTest, ObjectDeletedPreviously)
 // Expected Result: return entryNotFound error
 TEST_F(RPCLedgerEntryTest, ObjectSeqNotExist)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const ledgerinfo = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerinfo));
     EXPECT_CALL(*backend, doFetchLedgerObject(ripple::uint256{INDEX1}, RANGEMAX, _))
@@ -3428,7 +3416,6 @@ TEST_F(RPCLedgerEntryTest, SyntheticMPTIssuanceID)
 
     auto const mptId = ripple::makeMptID(2, GetAccountIDWithString(ACCOUNT));
 
-    backend->setRange(RANGEMIN, RANGEMAX);
     // return valid ledgerHeader
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
@@ -3450,28 +3437,4 @@ TEST_F(RPCLedgerEntryTest, SyntheticMPTIssuanceID)
         ASSERT_TRUE(output);
         EXPECT_EQ(*output.result, json::parse(OUT));
     });
-}
-
-using RPCLedgerEntryDeathTest = RPCLedgerEntryTest;
-
-TEST_F(RPCLedgerEntryDeathTest, RangeNotAvailable)
-{
-    boost::asio::io_context ctx;
-    bool checkCalled = false;
-    spawn(ctx, [&, _unused = make_work_guard(ctx)](boost::asio::yield_context yield) {
-        auto const handler = AnyHandler{LedgerEntryHandler{backend}};
-        auto const req = json::parse(fmt::format(
-            R"({{
-                "index": "{}"
-            }})",
-            INDEX1
-        ));
-        checkCalled = true;
-        EXPECT_DEATH(
-            { [[maybe_unused]] auto _unused2 = handler.process(req, Context{yield}); }, "Ledger range must be available"
-        );
-    });
-
-    ctx.run();
-    ASSERT_TRUE(checkCalled);
 }

--- a/tests/unit/rpc/handlers/LedgerIndexTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerIndexTests.cpp
@@ -43,7 +43,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCLedgerIndexTest : public HandlerBaseTestStrict {};
+struct RPCLedgerIndexTest : HandlerBaseTestStrict {
+    RPCLedgerIndexTest()
+    {
+        backend->setRange(RANGEMIN, RANGEMAX);
+    }
+};
 
 TEST_F(RPCLedgerIndexTest, DateStrNotValid)
 {
@@ -60,7 +65,6 @@ TEST_F(RPCLedgerIndexTest, DateStrNotValid)
 
 TEST_F(RPCLedgerIndexTest, NoDateGiven)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX, 5);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerHeader));
 
@@ -77,7 +81,6 @@ TEST_F(RPCLedgerIndexTest, NoDateGiven)
 
 TEST_F(RPCLedgerIndexTest, EarlierThanMinLedger)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const handler = AnyHandler{LedgerIndexHandler{backend}};
     auto const req = json::parse(R"({"date": "2024-06-25T12:23:05Z"})");
     auto const ledgerHeader =
@@ -94,7 +97,6 @@ TEST_F(RPCLedgerIndexTest, EarlierThanMinLedger)
 TEST_F(RPCLedgerIndexTest, ChangeTimeZone)
 {
     setenv("TZ", "EST+5", 1);
-    backend->setRange(RANGEMIN, RANGEMAX);
     auto const handler = AnyHandler{LedgerIndexHandler{backend}};
     auto const req = json::parse(R"({"date": "2024-06-25T12:23:05Z"})");
     auto const ledgerHeader =
@@ -144,7 +146,6 @@ TEST_P(LedgerIndexTests, SearchFromLedgerRange)
 {
     auto const testBundle = GetParam();
     auto const jv = json::parse(testBundle.json).as_object();
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     // start from 1719318190 , which is the unix time for 2024-06-25T12:23:10Z to 2024-06-25T12:23:50Z with
     // step 2

--- a/tests/unit/rpc/handlers/LedgerTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerTests.cpp
@@ -59,7 +59,12 @@ using namespace rpc;
 namespace json = boost::json;
 using namespace testing;
 
-class RPCLedgerHandlerTest : public HandlerBaseTest {};
+struct RPCLedgerHandlerTest : HandlerBaseTest {
+    RPCLedgerHandlerTest()
+    {
+        backend->setRange(RANGEMIN, RANGEMAX);
+    }
+};
 
 struct LedgerParamTestCaseBundle {
     std::string testName;
@@ -185,8 +190,6 @@ TEST_P(LedgerParameterTest, InvalidParams)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaIntSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
@@ -208,8 +211,6 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaIntSequence)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaStringSequence)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(std::nullopt));
 
@@ -231,8 +232,6 @@ TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaStringSequence)
 
 TEST_F(RPCLedgerHandlerTest, LedgerNotExistViaHash)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
 
@@ -275,8 +274,6 @@ TEST_F(RPCLedgerHandlerTest, Default)
             }
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -295,8 +292,6 @@ TEST_F(RPCLedgerHandlerTest, Default)
 // fields not supported for specific value can be set to its default value
 TEST_F(RPCLedgerHandlerTest, ConditionallyNotSupportedFieldsDefaultValue)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillRepeatedly(Return(ledgerHeader));
 
@@ -316,8 +311,6 @@ TEST_F(RPCLedgerHandlerTest, ConditionallyNotSupportedFieldsDefaultValue)
 
 TEST_F(RPCLedgerHandlerTest, QueryViaLedgerIndex)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(15, _)).WillByDefault(Return(ledgerHeader));
@@ -333,8 +326,6 @@ TEST_F(RPCLedgerHandlerTest, QueryViaLedgerIndex)
 
 TEST_F(RPCLedgerHandlerTest, QueryViaLedgerHash)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{INDEX1}, _)).WillByDefault(Return(ledgerHeader));
@@ -360,8 +351,6 @@ TEST_F(RPCLedgerHandlerTest, BinaryTrue)
                 "closed":true
             }
         })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -402,8 +391,6 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandBinary)
                 ]
             }
         })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -456,8 +443,6 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandBinaryV2)
                 ]
             }
         })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerHeader));
@@ -544,8 +529,6 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinary)
                 ]
             }
         })";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -647,8 +630,6 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinaryV2)
             }
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerHeader));
 
@@ -678,8 +659,6 @@ TEST_F(RPCLedgerHandlerTest, TransactionsExpandNotBinaryV2)
 
 TEST_F(RPCLedgerHandlerTest, TwoRequestInARowTransactionsExpandNotBinaryV2)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillOnce(Return(ledgerHeader));
 
@@ -726,8 +705,6 @@ TEST_F(RPCLedgerHandlerTest, TwoRequestInARowTransactionsExpandNotBinaryV2)
 
 TEST_F(RPCLedgerHandlerTest, TransactionsNotExpand)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -777,8 +754,6 @@ TEST_F(RPCLedgerHandlerTest, DiffNotBinary)
             }
         ])";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -821,8 +796,6 @@ TEST_F(RPCLedgerHandlerTest, DiffBinary)
                 "object":"1100612200400000240000000125000000032B000000002D00000002551B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1BC983515BC62400000000000000A81144B4E9C06F24296074F7BC48F92A97916C6DC5EA9"
             }
         ])";
-
-    backend->setRange(RANGEMIN, RANGEMAX);
 
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -915,8 +888,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsEmtpy)
             }
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1006,8 +977,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryFalse)
             "validated": true
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1075,8 +1044,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
             "validated": true
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1124,8 +1091,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsTrueBinaryTrue)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsIssuerIsSelf)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1181,8 +1146,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
             "validated": true
         })";
 
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1230,8 +1193,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotEnoughForReserve)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));
@@ -1284,8 +1245,6 @@ TEST_F(RPCLedgerHandlerTest, OwnerFundsNotXRP)
 
 TEST_F(RPCLedgerHandlerTest, OwnerFundsIgnoreFreezeLine)
 {
-    backend->setRange(RANGEMIN, RANGEMAX);
-
     auto const ledgerHeader = CreateLedgerHeader(LEDGERHASH, RANGEMAX);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(RANGEMAX, _)).WillByDefault(Return(ledgerHeader));

--- a/tests/unit/rpc/handlers/MPTHoldersTests.cpp
+++ b/tests/unit/rpc/handlers/MPTHoldersTests.cpp
@@ -66,7 +66,12 @@ static std::string MPTOUT2 =
         "mptoken_index": "36D91DEE5EFE4A93119A8B84C944A528F2B444329F3846E49FE921040DE17E65"
     })";
 
-class RPCMPTHoldersHandlerTest : public HandlerBaseTest {};
+struct RPCMPTHoldersHandlerTest : HandlerBaseTest {
+    RPCMPTHoldersHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCMPTHoldersHandlerTest, NonHexLedgerHash)
 {
@@ -245,7 +250,6 @@ TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
     auto const input = json::parse(fmt::format(
@@ -267,7 +271,6 @@ TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerInfo>{}));
     auto const input = json::parse(fmt::format(
@@ -291,7 +294,6 @@ TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerinfo = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
@@ -317,7 +319,6 @@ TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -341,7 +342,6 @@ TEST_F(RPCMPTHoldersHandlerTest, NonExistLedgerViaLedgerIndex2)
 // normal case when MPT does not exist
 TEST_F(RPCMPTHoldersHandlerTest, MPTNotFound)
 {
-    backend->setRange(10, 30);
     auto ledgerinfo = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerinfo));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -381,7 +381,6 @@ TEST_F(RPCMPTHoldersHandlerTest, DefaultParameters)
         MPTOUT1
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const issuanceKk = ripple::keylet::mptIssuance(ripple::uint192(MPTID)).key;
@@ -429,7 +428,6 @@ TEST_F(RPCMPTHoldersHandlerTest, CustomAmounts)
         MPTID
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const issuanceKk = ripple::keylet::mptIssuance(ripple::uint192(MPTID)).key;
@@ -473,7 +471,6 @@ TEST_F(RPCMPTHoldersHandlerTest, SpecificLedgerIndex)
         MPTOUT1
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, specificLedger);
     ON_CALL(*backend, fetchLedgerBySequence(specificLedger, _)).WillByDefault(Return(ledgerInfo));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -524,7 +521,6 @@ TEST_F(RPCMPTHoldersHandlerTest, MarkerParameter)
         ripple::strHex(GetAccountIDWithString(HOLDER1_ACCOUNT))
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const issuanceKk = ripple::keylet::mptIssuance(ripple::uint192(MPTID)).key;
@@ -571,7 +567,6 @@ TEST_F(RPCMPTHoldersHandlerTest, MultipleMPTs)
         MPTOUT2
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const issuanceKk = ripple::keylet::mptIssuance(ripple::uint192(MPTID)).key;
@@ -614,7 +609,6 @@ TEST_F(RPCMPTHoldersHandlerTest, LimitMoreThanMAx)
         MPTOUT1
     );
 
-    backend->setRange(10, 30);
     auto ledgerInfo = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerInfo));
     auto const issuanceKk = ripple::keylet::mptIssuance(ripple::uint192(MPTID)).key;

--- a/tests/unit/rpc/handlers/NFTBuyOffersTests.cpp
+++ b/tests/unit/rpc/handlers/NFTBuyOffersTests.cpp
@@ -50,7 +50,12 @@ constexpr static auto NFTID = "00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875
 constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 
-class RPCNFTBuyOffersHandlerTest : public HandlerBaseTest {};
+struct RPCNFTBuyOffersHandlerTest : HandlerBaseTest {
+    RPCNFTBuyOffersHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCNFTBuyOffersHandlerTest, NonHexLedgerHash)
 {
@@ -232,7 +237,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -257,7 +261,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -283,7 +286,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db, call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -307,7 +309,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case when nft is not found
 TEST_F(RPCNFTBuyOffersHandlerTest, NoNFT)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -410,7 +411,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, DefaultParameters)
         ]
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -449,7 +449,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, DefaultParameters)
 // normal case when provided with nft_id and limit
 TEST_F(RPCNFTBuyOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -496,7 +495,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 // normal case when provided with nft_id, limit and marker
 TEST_F(RPCNFTBuyOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -558,7 +556,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 // nothing left after reading remaining 50 entries
 TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
@@ -641,7 +638,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimi
 
 TEST_F(RPCNFTBuyOffersHandlerTest, LimitLessThanMin)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -684,7 +680,6 @@ TEST_F(RPCNFTBuyOffersHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCNFTBuyOffersHandlerTest, LimitMoreThanMax)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);

--- a/tests/unit/rpc/handlers/NFTHistoryTests.cpp
+++ b/tests/unit/rpc/handlers/NFTHistoryTests.cpp
@@ -49,7 +49,12 @@ constexpr static auto ACCOUNT2 = "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun";
 constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652";
 constexpr static auto NFTID = "00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004";
 
-class RPCNFTHistoryHandlerTest : public HandlerBaseTest {};
+struct RPCNFTHistoryHandlerTest : HandlerBaseTest {
+    RPCNFTHistoryHandlerTest()
+    {
+        backend->setRange(MINSEQ, MAXSEQ);
+    }
+};
 
 struct NFTHistoryParamTestCaseBundle {
     std::string testName;
@@ -228,7 +233,6 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(NFTHistoryParameterTest, InvalidParams)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
     auto const testBundle = GetParam();
     runSpawn([&, this](auto yield) {
         auto const handler = AnyHandler{NFTHistoryHandler{backend}};
@@ -268,8 +272,6 @@ genTransactions(uint32_t seq1, uint32_t seq2)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardTrue)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -409,7 +411,6 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV1)
                                     "seq": 34
                                 }
                                 })";
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -561,7 +562,6 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV2)
                                     "seq": 34
                                 }
                                 })";
-    backend->setRange(MINSEQ, MAXSEQ);
 
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -602,8 +602,6 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexSpecificForwardFalseV2)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -641,8 +639,6 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardTrue)
 
 TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -684,8 +680,6 @@ TEST_F(RPCNFTHistoryHandlerTest, IndexNotSpecificForwardFalse)
 
 TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV1)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -741,8 +735,6 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV1)
 
 TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV2)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     EXPECT_CALL(
@@ -797,8 +789,6 @@ TEST_F(RPCNFTHistoryHandlerTest, BinaryTrueV2)
 
 TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -838,8 +828,6 @@ TEST_F(RPCNFTHistoryHandlerTest, LimitAndMarker)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -883,8 +871,6 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerIntIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
@@ -908,8 +894,6 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerIntIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerStringIndex)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchLedgerBySequence(MAXSEQ - 1, _)).WillByDefault(Return(std::nullopt));
 
@@ -933,8 +917,6 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificNonexistLedgerStringIndex)
 
 TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     // adjust the order for forward->false
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
@@ -978,8 +960,6 @@ TEST_F(RPCNFTHistoryHandlerTest, SpecificLedgerHash)
 
 TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -1021,8 +1001,6 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLessThanMinSeq)
 
 TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MAXSEQ - 1, MINSEQ + 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));
@@ -1064,8 +1042,6 @@ TEST_F(RPCNFTHistoryHandlerTest, TxLargerThanMaxSeq)
 
 TEST_F(RPCNFTHistoryHandlerTest, LimitMoreThanMax)
 {
-    backend->setRange(MINSEQ, MAXSEQ);
-
     auto const transactions = genTransactions(MINSEQ + 1, MAXSEQ - 1);
     auto const transCursor = TransactionsAndCursor{transactions, TransactionsCursor{12, 34}};
     ON_CALL(*backend, fetchNFTTransactions).WillByDefault(Return(transCursor));

--- a/tests/unit/rpc/handlers/NFTInfoTests.cpp
+++ b/tests/unit/rpc/handlers/NFTInfoTests.cpp
@@ -45,7 +45,12 @@ constexpr static auto LEDGERHASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A
 constexpr static auto NFTID = "00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875B974D9F00000004";
 constexpr static auto NFTID2 = "00081388319F12E15BCA13E1B933BF4C99C8E1BBC36BD4910A85D52F00000022";
 
-class RPCNFTInfoHandlerTest : public HandlerBaseTest {};
+struct RPCNFTInfoHandlerTest : HandlerBaseTest {
+    RPCNFTInfoHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCNFTInfoHandlerTest, NonHexLedgerHash)
 {
@@ -170,7 +175,6 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -193,7 +197,6 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -218,7 +221,6 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -244,7 +246,6 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -268,7 +269,6 @@ TEST_F(RPCNFTInfoHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case nft does not exist
 TEST_F(RPCNFTInfoHandlerTest, NonExistNFT)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -310,7 +310,6 @@ TEST_F(RPCNFTInfoHandlerTest, DefaultParameters)
         "validated": true
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -351,7 +350,6 @@ TEST_F(RPCNFTInfoHandlerTest, BurnedNFT)
         "validated": true
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -393,7 +391,6 @@ TEST_F(RPCNFTInfoHandlerTest, NotBurnedNFTWithoutURI)
         "validated": true
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -434,7 +431,6 @@ TEST_F(RPCNFTInfoHandlerTest, NFTWithExtraFieldsSet)
         "validated": true
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);

--- a/tests/unit/rpc/handlers/NFTSellOffersTests.cpp
+++ b/tests/unit/rpc/handlers/NFTSellOffersTests.cpp
@@ -50,7 +50,12 @@ constexpr static auto NFTID = "00010000A7CAD27B688D14BA1A9FA5366554D6ADCF9CE0875
 constexpr static auto INDEX1 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC321";
 constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
 
-class RPCNFTSellOffersHandlerTest : public HandlerBaseTest {};
+struct RPCNFTSellOffersHandlerTest : HandlerBaseTest {
+    RPCNFTSellOffersHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCNFTSellOffersHandlerTest, LimitNotInt)
 {
@@ -232,7 +237,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -257,7 +261,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -283,7 +286,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db, call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -307,7 +309,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, NonExistLedgerViaLedgerIndex2)
 // error case when nft is not found
 TEST_F(RPCNFTSellOffersHandlerTest, NoNFT)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -410,7 +411,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
         ]
     })";
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -449,7 +449,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, DefaultParameters)
 // normal case when provided with nft_id and limit
 TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -496,7 +495,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, MultipleResultsWithMarkerAndLimitOutput)
 // normal case when provided with nft_id, limit and marker
 TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -558,7 +556,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsForInputWithMarkerAndLimit)
 // nothing left after reading remaining 50 entries
 TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLimit)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(3);
@@ -641,7 +638,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, ResultsWithoutMarkerForInputWithMarkerAndLim
 
 TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -684,7 +680,6 @@ TEST_F(RPCNFTSellOffersHandlerTest, LimitLessThanMin)
 
 TEST_F(RPCNFTSellOffersHandlerTest, LimitMoreThanMax)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);

--- a/tests/unit/rpc/handlers/NFTsByIssuerTest.cpp
+++ b/tests/unit/rpc/handlers/NFTsByIssuerTest.cpp
@@ -89,7 +89,12 @@ static std::string NFT3OUT =
         "nft_serial": 4
     })";
 
-class RPCNFTsByIssuerHandlerTest : public HandlerBaseTest {};
+struct RPCNFTsByIssuerHandlerTest : HandlerBaseTest {
+    RPCNFTsByIssuerHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCNFTsByIssuerHandlerTest, NonHexLedgerHash)
 {
@@ -228,7 +233,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerStringIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerHeader>{}));
     auto const input = json::parse(fmt::format(
@@ -250,7 +254,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerStringIndex)
 
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIntIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(std::optional<ripple::LedgerHeader>{}));
     auto const input = json::parse(fmt::format(
@@ -274,7 +277,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIntIndex)
 // idk why this case will happen in reality
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash2)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerByHash return ledger but seq is 31 > 30
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 31);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
@@ -300,7 +302,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerHash2)
 // error case ledger > max seq via index
 TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIndex2)
 {
-    backend->setRange(10, 30);
     // no need to check from db,call fetchLedgerBySequence 0 time
     // differ from previous logic
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(0);
@@ -324,7 +325,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, NonExistLedgerViaLedgerIndex2)
 // normal case when issuer does not exist or has no NFTs
 TEST_F(RPCNFTsByIssuerHandlerTest, AccountNotFound)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -364,7 +364,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, DefaultParameters)
         NFT1OUT
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -421,7 +420,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, SpecificLedgerIndex)
         specificLedger
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, specificLedger);
     ON_CALL(*backend, fetchLedgerBySequence(specificLedger, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -471,7 +469,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, TaxonParameter)
         NFT1OUT
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -516,7 +513,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MarkerParameter)
         NFT3OUT
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -563,7 +559,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, MultipleNFTs)
         NFT3OUT
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;
@@ -610,7 +605,6 @@ TEST_F(RPCNFTsByIssuerHandlerTest, LimitMoreThanMAx)
         NFT1OUT
     );
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
     auto const accountKk = ripple::keylet::account(GetAccountIDWithString(ACCOUNT)).key;

--- a/tests/unit/rpc/handlers/NoRippleCheckTests.cpp
+++ b/tests/unit/rpc/handlers/NoRippleCheckTests.cpp
@@ -50,7 +50,12 @@ constexpr static auto INDEX2 = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B25
 constexpr static auto ISSUER = "rK9DrarGKnVEo2nYp5MfVRXRYf5yRX3mwD";
 constexpr static auto TXNID = "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879";
 
-class RPCNoRippleCheckTest : public HandlerBaseTest {};
+struct RPCNoRippleCheckTest : HandlerBaseTest {
+    RPCNoRippleCheckTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 struct NoRippleParamTestCaseBundle {
     std::string testName;
@@ -60,8 +65,7 @@ struct NoRippleParamTestCaseBundle {
 };
 
 // parameterized test cases for parameters check
-struct NoRippleCheckParameterTest : public RPCNoRippleCheckTest,
-                                    public WithParamInterface<NoRippleParamTestCaseBundle> {};
+struct NoRippleCheckParameterTest : RPCNoRippleCheckTest, WithParamInterface<NoRippleParamTestCaseBundle> {};
 
 static auto
 generateTestValuesForParametersTest()
@@ -200,7 +204,6 @@ TEST_F(NoRippleCheckParameterTest, V1ApiTransactionsIsNotBool)
 
 TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaHash)
 {
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(std::nullopt));
@@ -228,7 +231,6 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaIntIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::nullopt));
@@ -256,7 +258,6 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaStringIndex)
 {
     auto constexpr seq = 12;
 
-    backend->setRange(10, 30);
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     // return empty ledgerHeader
     ON_CALL(*backend, fetchLedgerBySequence(seq, _)).WillByDefault(Return(std::nullopt));
@@ -282,7 +283,6 @@ TEST_F(RPCNoRippleCheckTest, LedgerNotExistViaStringIndex)
 
 TEST_F(RPCNoRippleCheckTest, AccountNotExist)
 {
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, 30);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -322,7 +322,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleUserDefaultRippleSetTrustLineNoRipple
             "validated":true
         })";
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -384,7 +383,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleUserDefaultRippleUnsetTrustLineNoRipp
             "validated":true
         })";
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -441,7 +439,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleSetTrustLineNoRip
             "validated":true
         })";
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -503,7 +500,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleUnsetTrustLineNoR
             "validated":true
         })";
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -549,7 +545,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathRoleGatewayDefaultRippleUnsetTrustLineNoR
 {
     static auto constexpr seq = 30;
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -599,7 +594,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathLimit)
 {
     constexpr auto seq = 30;
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -703,7 +697,6 @@ TEST_F(RPCNoRippleCheckTest, NormalPathTransactions)
         ripple::tfClearNoRipple
     );
 
-    backend->setRange(10, seq);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);
@@ -758,7 +751,6 @@ TEST_F(RPCNoRippleCheckTest, LimitMoreThanMax)
 {
     constexpr auto seq = 30;
 
-    backend->setRange(10, 30);
     auto ledgerHeader = CreateLedgerHeader(LEDGERHASH, seq);
     ON_CALL(*backend, fetchLedgerByHash(ripple::uint256{LEDGERHASH}, _)).WillByDefault(Return(ledgerHeader));
     EXPECT_CALL(*backend, fetchLedgerByHash).Times(1);

--- a/tests/unit/rpc/handlers/TransactionEntryTests.cpp
+++ b/tests/unit/rpc/handlers/TransactionEntryTests.cpp
@@ -44,7 +44,12 @@ constexpr static auto ACCOUNT = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn";
 constexpr static auto ACCOUNT2 = "rLEsXccBGNR3UPuPu2hUXPjziKC3qKSBun";
 constexpr static auto CURRENCY = "0158415500000000C1F76FF6ECB0BAC600000000";
 
-class RPCTransactionEntryHandlerTest : public HandlerBaseTest {};
+struct RPCTransactionEntryHandlerTest : HandlerBaseTest {
+    RPCTransactionEntryHandlerTest()
+    {
+        backend->setRange(10, 30);
+    }
+};
 
 TEST_F(RPCTransactionEntryHandlerTest, TxHashNotProvide)
 {
@@ -98,7 +103,6 @@ TEST_F(RPCTransactionEntryHandlerTest, NonExistLedgerViaLedgerHash)
 // error case ledger non exist via index
 TEST_F(RPCTransactionEntryHandlerTest, NonExistLedgerViaLedgerIndex)
 {
-    backend->setRange(10, 30);
     // mock fetchLedgerBySequence return empty
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(std::optional<ripple::LedgerHeader>{}));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
@@ -121,7 +125,6 @@ TEST_F(RPCTransactionEntryHandlerTest, NonExistLedgerViaLedgerIndex)
 
 TEST_F(RPCTransactionEntryHandlerTest, TXNotFound)
 {
-    backend->setRange(10, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(CreateLedgerHeader(INDEX, 30)));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
     ON_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _))
@@ -154,7 +157,6 @@ TEST_F(RPCTransactionEntryHandlerTest, LedgerSeqNotMatch)
     ON_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillByDefault(Return(tx));
     EXPECT_CALL(*backend, fetchTransaction).Times(1);
 
-    backend->setRange(10, 30);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(CreateLedgerHeader(INDEX, 30)));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -232,7 +234,6 @@ TEST_F(RPCTransactionEntryHandlerTest, NormalPath)
     ON_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillByDefault(Return(tx));
     EXPECT_CALL(*backend, fetchTransaction).Times(1);
 
-    backend->setRange(10, tx.ledgerSequence);
     ON_CALL(*backend, fetchLedgerBySequence).WillByDefault(Return(CreateLedgerHeader(INDEX, tx.ledgerSequence)));
     EXPECT_CALL(*backend, fetchLedgerBySequence).Times(1);
 
@@ -308,8 +309,6 @@ TEST_F(RPCTransactionEntryHandlerTest, NormalPathV2)
     tx.date = 123456;
     tx.ledgerSequence = 30;
     EXPECT_CALL(*backend, fetchTransaction(ripple::uint256{TXNID}, _)).WillOnce(Return(tx));
-
-    backend->setRange(10, tx.ledgerSequence);
     EXPECT_CALL(*backend, fetchLedgerBySequence).WillOnce(Return(CreateLedgerHeader(INDEX, tx.ledgerSequence)));
 
     runSpawn([&, this](auto yield) {


### PR DESCRIPTION
There are a few files that cannot move the setRange into constructor of the test because either the place that calls setRange matters or tests checks range doesn't exist