### PR TITLE
fix: Remove InvalidHotWallet Error from gateway_balances RPC handler

### DIFF
--- a/src/rpc/Errors.cpp
+++ b/src/rpc/Errors.cpp
@@ -79,7 +79,6 @@ getErrorInfo(ClioError code)
         {.code = ClioError::RpcMalformedRequest, .error = "malformedRequest", .message = "Malformed request."},
         {.code = ClioError::RpcMalformedOwner, .error = "malformedOwner", .message = "Malformed owner."},
         {.code = ClioError::RpcMalformedAddress, .error = "malformedAddress", .message = "Malformed address."},
-        {.code = ClioError::RpcInvalidHotWallet, .error = "invalidHotWallet", .message = "Invalid hot wallet."},
         {.code = ClioError::RpcUnknownOption, .error = "unknownOption", .message = "Unknown option."},
         {.code = ClioError::RpcFieldNotFoundTransaction,
          .error = "fieldNotFoundTransaction",

--- a/src/rpc/Errors.hpp
+++ b/src/rpc/Errors.hpp
@@ -39,7 +39,6 @@ enum class ClioError {
     RpcMalformedRequest = 5001,
     RpcMalformedOwner = 5002,
     RpcMalformedAddress = 5003,
-    RpcInvalidHotWallet = 5004,
     RpcUnknownOption = 5005,
     RpcFieldNotFoundTransaction = 5006,
     RpcMalformedOracleDocumentId = 5007,

--- a/src/rpc/handlers/GatewayBalances.cpp
+++ b/src/rpc/handlers/GatewayBalances.cpp
@@ -145,10 +145,6 @@ GatewayBalancesHandler::process(GatewayBalancesHandler::Input input, Context con
     if (auto status = std::get_if<Status>(&ret))
         return Error{*status};
 
-    auto inHotbalances = [&](auto const& hw) { return output.hotBalances.contains(hw); };
-    if (not std::ranges::all_of(input.hotWallets, inHotbalances))
-        return Error{Status{ClioError::RpcInvalidHotWallet}};
-
     output.accountID = input.account;
     output.ledgerHash = ripple::strHex(lgrInfo.hash);
     output.ledgerIndex = lgrInfo.seq;

--- a/src/web/impl/ErrorHandling.hpp
+++ b/src/web/impl/ErrorHandling.hpp
@@ -88,7 +88,6 @@ public:
                     case rpc::ClioError::RpcMalformedRequest:
                     case rpc::ClioError::RpcMalformedOwner:
                     case rpc::ClioError::RpcMalformedAddress:
-                    case rpc::ClioError::RpcInvalidHotWallet:
                     case rpc::ClioError::RpcFieldNotFoundTransaction:
                     case rpc::ClioError::RpcMalformedOracleDocumentId:
                     case rpc::ClioError::RpcMalformedAuthorizedCredentials:

--- a/src/web/ng/impl/ErrorHandling.cpp
+++ b/src/web/ng/impl/ErrorHandling.cpp
@@ -102,7 +102,6 @@ ErrorHelper::makeError(rpc::Status const& err) const
             case rpc::ClioError::RpcMalformedRequest:
             case rpc::ClioError::RpcMalformedOwner:
             case rpc::ClioError::RpcMalformedAddress:
-            case rpc::ClioError::RpcInvalidHotWallet:
             case rpc::ClioError::RpcFieldNotFoundTransaction:
             case rpc::ClioError::RpcMalformedOracleDocumentId:
             case rpc::ClioError::RpcMalformedAuthorizedCredentials:


### PR DESCRIPTION
Fixes #1825 by removing the check in the gateway_balances RPC handler that returns the RpcInvalidHotWallet error code if one of the addresses supplied in the request's `hotwallet` array does not have a trustline with the `account` from the request.

As stated in the original ticket, this change fixes a discrepancy in behavior between Clio and rippled, as rippled does not check for trustline existence when handling gateway_balances RPCs