### PR TITLE
fix: CacheLoader causes crash when no cache is used

### DIFF
--- a/src/etl/CacheLoader.hpp
+++ b/src/etl/CacheLoader.hpp
@@ -130,7 +130,8 @@ public:
     void
     stop() noexcept
     {
-        loader_->stop();
+        if (loader_ != nullptr)
+            loader_->stop();
     }
 
     /**
@@ -139,7 +140,8 @@ public:
     void
     wait() noexcept
     {
-        loader_->wait();
+        if (loader_ != nullptr)
+            loader_->wait();
     }
 };
 

--- a/tests/unit/etl/CacheLoaderTests.cpp
+++ b/tests/unit/etl/CacheLoaderTests.cpp
@@ -270,3 +270,18 @@ TEST_F(CacheLoaderTest, DisabledCacheLoaderDoesNotLoadCache)
 
     loader.load(kSEQ);
 }
+
+TEST_F(CacheLoaderTest, DisabledCacheLoaderCanCallStopAndWait)
+{
+    auto const cfg = getParseCacheConfig(json::parse(R"({"cache": {"load": "none"}})"));
+    CacheLoader loader{cfg, backend_, cache};
+
+    EXPECT_CALL(cache, updateImp).Times(0);
+    EXPECT_CALL(cache, isFull).WillRepeatedly(Return(false));
+    EXPECT_CALL(cache, setDisabled).Times(1);
+
+    loader.load(kSEQ);
+
+    EXPECT_NO_THROW(loader.stop());
+    EXPECT_NO_THROW(loader.wait());
+}


### PR DESCRIPTION
If cache is disabled or Clio starts with and empty DB, `loader_` inside cache is not created. So calling `CacheLoader::stop()` or `CacheLoader::wait()` was causing crash.