### PR TITLE
feat: Implement and use LedgerCacheInterface

### DIFF
--- a/src/app/ClioApplication.cpp
+++ b/src/app/ClioApplication.cpp
@@ -23,6 +23,7 @@
 #include "app/WebHandlers.hpp"
 #include "data/AmendmentCenter.hpp"
 #include "data/BackendFactory.hpp"
+#include "data/LedgerCache.hpp"
 #include "etl/ETLService.hpp"
 #include "etl/LoadBalancer.hpp"
 #include "etl/NetworkValidatedLedgers.hpp"
@@ -102,9 +103,10 @@ ClioApplication::run(bool const useNgWebServer)
     auto whitelistHandler = web::dosguard::WhitelistHandler{config_};
     auto dosGuard = web::dosguard::DOSGuard{config_, whitelistHandler};
     auto sweepHandler = web::dosguard::IntervalSweepHandler{config_, ioc, dosGuard};
+    auto cache = data::LedgerCache{};
 
     // Interface to the database
-    auto backend = data::makeBackend(config_);
+    auto backend = data::makeBackend(config_, cache);
 
     auto const amendmentCenter = std::make_shared<data::AmendmentCenter const>(backend);
 

--- a/src/data/BackendFactory.hpp
+++ b/src/data/BackendFactory.hpp
@@ -21,6 +21,7 @@
 
 #include "data/BackendInterface.hpp"
 #include "data/CassandraBackend.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
 #include "util/log/Logger.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
@@ -38,10 +39,11 @@ namespace data {
  * @brief A factory function that creates the backend based on a config.
  *
  * @param config The clio config to use
+ * @param cache The ledger cache to use
  * @return A shared_ptr<BackendInterface> with the selected implementation
  */
 inline std::shared_ptr<BackendInterface>
-makeBackend(util::config::ClioConfigDefinition const& config)
+makeBackend(util::config::ClioConfigDefinition const& config, data::LedgerCacheInterface& cache)
 {
     static util::Logger const log{"Backend"};  // NOLINT(readability-identifier-naming)
     LOG(log.info()) << "Constructing BackendInterface";
@@ -53,7 +55,9 @@ makeBackend(util::config::ClioConfigDefinition const& config)
 
     if (boost::iequals(type, "cassandra")) {
         auto const cfg = config.getObject("database." + type);
-        backend = std::make_shared<data::cassandra::CassandraBackend>(data::cassandra::SettingsProvider{cfg}, readOnly);
+        backend = std::make_shared<data::cassandra::CassandraBackend>(
+            data::cassandra::SettingsProvider{cfg}, cache, readOnly
+        );
     }
 
     if (!backend)

--- a/src/data/BackendInterface.cpp
+++ b/src/data/BackendInterface.cpp
@@ -87,7 +87,7 @@ BackendInterface::fetchLedgerObject(
     boost::asio::yield_context yield
 ) const
 {
-    auto obj = cache_.get(key, sequence);
+    auto obj = cache_.get().get(key, sequence);
     if (obj) {
         LOG(gLog.trace()) << "Cache hit - " << ripple::strHex(key);
         return obj;
@@ -126,7 +126,7 @@ BackendInterface::fetchLedgerObjects(
     results.resize(keys.size());
     std::vector<ripple::uint256> misses;
     for (size_t i = 0; i < keys.size(); ++i) {
-        auto obj = cache_.get(keys[i], sequence);
+        auto obj = cache_.get().get(keys[i], sequence);
         if (obj) {
             results[i] = *obj;
         } else {
@@ -156,7 +156,7 @@ BackendInterface::fetchSuccessorKey(
     boost::asio::yield_context yield
 ) const
 {
-    auto succ = cache_.getSuccessor(key, ledgerSequence);
+    auto succ = cache_.get().getSuccessor(key, ledgerSequence);
     if (succ) {
         LOG(gLog.trace()) << "Cache hit - " << ripple::strHex(key);
     } else {

--- a/src/data/BackendInterface.hpp
+++ b/src/data/BackendInterface.hpp
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "data/DBHelpers.hpp"
-#include "data/LedgerCache.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "data/Types.hpp"
 #include "etl/CorruptionDetector.hpp"
 #include "util/log/Logger.hpp"
@@ -40,6 +40,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -139,18 +140,27 @@ class BackendInterface {
 protected:
     mutable std::shared_mutex rngMtx_;
     std::optional<LedgerRange> range_;
-    LedgerCache cache_;
-    std::optional<etl::CorruptionDetector<LedgerCache>> corruptionDetector_;
+    std::reference_wrapper<LedgerCacheInterface> cache_;
+    std::optional<etl::CorruptionDetector> corruptionDetector_;
 
 public:
-    BackendInterface() = default;
+    /**
+     * @brief Construct a new backend interface instance.
+     *
+     * @param cache The ledger cache to use
+     */
+    BackendInterface(LedgerCacheInterface& cache) : cache_{cache}
+    {
+    }
     virtual ~BackendInterface() = default;
 
-    // TODO: Remove this hack. Cache should not be exposed thru BackendInterface
+    // TODO: Remove this hack once old ETL is removed.
+    // Cache should not be exposed thru BackendInterface
+
     /**
      * @return Immutable cache
      */
-    LedgerCache const&
+    LedgerCacheInterface const&
     cache() const
     {
         return cache_;
@@ -159,7 +169,7 @@ public:
     /**
      * @return Mutable cache
      */
-    LedgerCache&
+    LedgerCacheInterface&
     cache()
     {
         return cache_;
@@ -171,7 +181,7 @@ public:
      * @param detector The corruption detector to set
      */
     void
-    setCorruptionDetector(etl::CorruptionDetector<LedgerCache> detector)
+    setCorruptionDetector(etl::CorruptionDetector detector)
     {
         corruptionDetector_ = std::move(detector);
     }

--- a/src/data/CassandraBackend.hpp
+++ b/src/data/CassandraBackend.hpp
@@ -21,6 +21,7 @@
 
 #include "data/BackendInterface.hpp"
 #include "data/DBHelpers.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "data/Types.hpp"
 #include "data/cassandra/Concepts.hpp"
 #include "data/cassandra/Handle.hpp"
@@ -88,10 +89,12 @@ public:
      * @brief Create a new cassandra/scylla backend instance.
      *
      * @param settingsProvider The settings provider to use
+     * @param cache The ledger cache to use
      * @param readOnly Whether the database should be in readonly mode
      */
-    BasicCassandraBackend(SettingsProviderType settingsProvider, bool readOnly)
-        : settingsProvider_{std::move(settingsProvider)}
+    BasicCassandraBackend(SettingsProviderType settingsProvider, data::LedgerCacheInterface& cache, bool readOnly)
+        : BackendInterface(cache)
+        , settingsProvider_{std::move(settingsProvider)}
         , schema_{settingsProvider_}
         , handle_{settingsProvider_.getSettings()}
         , executor_{settingsProvider_.getSettings(), handle_}

--- a/src/data/LedgerCache.cpp
+++ b/src/data/LedgerCache.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
-    Copyright (c) 2025, the clio developers.
+    Copyright (c) 2022, the clio developers.
 
     Permission to use, copy, modify, and distribute this software for any
     purpose with or without fee is hereby granted, provided that the above

--- a/src/data/LedgerCache.cpp
+++ b/src/data/LedgerCache.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
-    Copyright (c) 2022, the clio developers.
+    Copyright (c) 2025, the clio developers.
 
     Permission to use, copy, modify, and distribute this software for any
     purpose with or without fee is hereby granted, provided that the above

--- a/src/data/LedgerCache.hpp
+++ b/src/data/LedgerCache.hpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
-    Copyright (c) 2025, the clio developers.
+    Copyright (c) 2022, the clio developers.
 
     Permission to use, copy, modify, and distribute this software for any
     purpose with or without fee is hereby granted, provided that the above

--- a/src/data/LedgerCache.hpp
+++ b/src/data/LedgerCache.hpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
-    Copyright (c) 2022, the clio developers.
+    Copyright (c) 2025, the clio developers.
 
     Permission to use, copy, modify, and distribute this software for any
     purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCacheInterface.hpp"
 #include "data/Types.hpp"
 #include "util/prometheus/Counter.hpp"
 #include "util/prometheus/Label.hpp"
@@ -43,7 +44,7 @@ namespace data {
 /**
  * @brief Cache for an entire ledger.
  */
-class LedgerCache {
+class LedgerCache : public LedgerCacheInterface {
     struct CacheEntry {
         uint32_t seq = 0;
         Blob blob;
@@ -83,109 +84,44 @@ class LedgerCache {
     std::unordered_set<ripple::uint256, ripple::hardened_hash<>> deletes_;
 
 public:
-    /**
-     * @brief Update the cache with new ledger objects.
-     *
-     * @param objs The ledger objects to update cache with
-     * @param seq The sequence to update cache for
-     * @param isBackground Should be set to true when writing old data from a background thread
-     */
     void
-    update(std::vector<LedgerObject> const& objs, uint32_t seq, bool isBackground = false);
+    update(std::vector<LedgerObject> const& objs, uint32_t seq, bool isBackground = false) override;
 
-    /**
-     * @brief Fetch a cached object by its key and sequence number.
-     *
-     * @param key The key to fetch for
-     * @param seq The sequence to fetch for
-     * @return If found in cache, will return the cached Blob; otherwise nullopt is returned
-     */
     std::optional<Blob>
-    get(ripple::uint256 const& key, uint32_t seq) const;
+    get(ripple::uint256 const& key, uint32_t seq) const override;
 
-    /**
-     * @brief Gets a cached successor.
-     *
-     * Note: This function always returns std::nullopt when @ref isFull() returns false.
-     *
-     * @param key The key to fetch for
-     * @param seq The sequence to fetch for
-     * @return If found in cache, will return the cached successor; otherwise nullopt is returned
-     */
     std::optional<LedgerObject>
-    getSuccessor(ripple::uint256 const& key, uint32_t seq) const;
+    getSuccessor(ripple::uint256 const& key, uint32_t seq) const override;
 
-    /**
-     * @brief Gets a cached predcessor.
-     *
-     * Note: This function always returns std::nullopt when @ref isFull() returns false.
-     *
-     * @param key The key to fetch for
-     * @param seq The sequence to fetch for
-     * @return If found in cache, will return the cached predcessor; otherwise nullopt is returned
-     */
     std::optional<LedgerObject>
-    getPredecessor(ripple::uint256 const& key, uint32_t seq) const;
+    getPredecessor(ripple::uint256 const& key, uint32_t seq) const override;
 
-    /**
-     * @brief Disables the cache.
-     */
     void
-    setDisabled();
+    setDisabled() override;
 
-    /**
-     * @return true if the cache is disabled; false otherwise
-     */
     bool
-    isDisabled() const;
+    isDisabled() const override;
 
-    /**
-     * @brief Sets the full flag to true.
-     *
-     * This is used when cache loaded in its entirety at startup of the application. This can be either loaded from DB,
-     * populated together with initial ledger download (on first run) or downloaded from a peer node (specified in
-     * config).
-     */
     void
-    setFull();
+    setFull() override;
 
-    /**
-     * @return The latest ledger sequence for which cache is available.
-     */
     uint32_t
-    latestLedgerSequence() const;
+    latestLedgerSequence() const override;
 
-    /**
-     * @return true if the cache has all data for the most recent ledger; false otherwise
-     */
     bool
-    isFull() const;
+    isFull() const override;
 
-    /**
-     * @return The total size of the cache.
-     */
     size_t
-    size() const;
+    size() const override;
 
-    /**
-     * @return A number representing the success rate of hitting an object in the cache versus missing it.
-     */
     float
-    getObjectHitRate() const;
+    getObjectHitRate() const override;
 
-    /**
-     * @return A number representing the success rate of hitting a successor in the cache versus missing it.
-     */
     float
-    getSuccessorHitRate() const;
+    getSuccessorHitRate() const override;
 
-    /**
-     * @brief Waits until the cache contains a specific sequence.
-     *
-     * @param seq The sequence to wait for
-     */
     void
-    waitUntilCacheContainsSeq(uint32_t seq);
+    waitUntilCacheContainsSeq(uint32_t seq) override;
 };
 
 }  // namespace data

--- a/src/data/LedgerCacheInterface.hpp
+++ b/src/data/LedgerCacheInterface.hpp
@@ -1,0 +1,146 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2025, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+
+#include "data/Types.hpp"
+
+#include <xrpl/basics/base_uint.h>
+#include <xrpl/basics/hardened_hash.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace data {
+
+/**
+ * @brief Cache for an entire ledger.
+ */
+class LedgerCacheInterface {
+public:
+    virtual ~LedgerCacheInterface() = default;
+
+    /**
+     * @brief Update the cache with new ledger objects.
+     *
+     * @param objs The ledger objects to update cache with
+     * @param seq The sequence to update cache for
+     * @param isBackground Should be set to true when writing old data from a background thread
+     */
+    virtual void
+    update(std::vector<LedgerObject> const& objs, uint32_t seq, bool isBackground = false) = 0;
+
+    /**
+     * @brief Fetch a cached object by its key and sequence number.
+     *
+     * @param key The key to fetch for
+     * @param seq The sequence to fetch for
+     * @return If found in cache, will return the cached Blob; otherwise nullopt is returned
+     */
+    virtual std::optional<Blob>
+    get(ripple::uint256 const& key, uint32_t seq) const = 0;
+
+    /**
+     * @brief Gets a cached successor.
+     *
+     * Note: This function always returns std::nullopt when @ref isFull() returns false.
+     *
+     * @param key The key to fetch for
+     * @param seq The sequence to fetch for
+     * @return If found in cache, will return the cached successor; otherwise nullopt is returned
+     */
+    virtual std::optional<LedgerObject>
+    getSuccessor(ripple::uint256 const& key, uint32_t seq) const = 0;
+
+    /**
+     * @brief Gets a cached predcessor.
+     *
+     * Note: This function always returns std::nullopt when @ref isFull() returns false.
+     *
+     * @param key The key to fetch for
+     * @param seq The sequence to fetch for
+     * @return If found in cache, will return the cached predcessor; otherwise nullopt is returned
+     */
+    virtual std::optional<LedgerObject>
+    getPredecessor(ripple::uint256 const& key, uint32_t seq) const = 0;
+
+    /**
+     * @brief Disables the cache.
+     */
+    virtual void
+    setDisabled() = 0;
+
+    /**
+     * @return true if the cache is disabled; false otherwise
+     */
+    virtual bool
+    isDisabled() const = 0;
+
+    /**
+     * @brief Sets the full flag to true.
+     *
+     * This is used when cache loaded in its entirety at startup of the application. This can be either loaded from DB,
+     * populated together with initial ledger download (on first run) or downloaded from a peer node (specified in
+     * config).
+     */
+    virtual void
+    setFull() = 0;
+
+    /**
+     * @return The latest ledger sequence for which cache is available.
+     */
+    virtual uint32_t
+    latestLedgerSequence() const = 0;
+
+    /**
+     * @return true if the cache has all data for the most recent ledger; false otherwise
+     */
+    virtual bool
+    isFull() const = 0;
+
+    /**
+     * @return The total size of the cache.
+     */
+    virtual size_t
+    size() const = 0;
+
+    /**
+     * @return A number representing the success rate of hitting an object in the cache versus missing it.
+     */
+    virtual float
+    getObjectHitRate() const = 0;
+
+    /**
+     * @return A number representing the success rate of hitting a successor in the cache versus missing it.
+     */
+    virtual float
+    getSuccessorHitRate() const = 0;
+
+    /**
+     * @brief Waits until the cache contains a specific sequence.
+     *
+     * @param seq The sequence to wait for
+     */
+    virtual void
+    waitUntilCacheContainsSeq(uint32_t seq) = 0;
+};
+
+}  // namespace data

--- a/src/data/LedgerCacheInterface.hpp
+++ b/src/data/LedgerCacheInterface.hpp
@@ -37,6 +37,8 @@ namespace data {
 class LedgerCacheInterface {
 public:
     virtual ~LedgerCacheInterface() = default;
+    LedgerCacheInterface() = default;
+    LedgerCacheInterface(LedgerCacheInterface&&) = delete;
 
     /**
      * @brief Update the cache with new ledger objects.

--- a/src/data/LedgerCacheInterface.hpp
+++ b/src/data/LedgerCacheInterface.hpp
@@ -39,6 +39,11 @@ public:
     virtual ~LedgerCacheInterface() = default;
     LedgerCacheInterface() = default;
     LedgerCacheInterface(LedgerCacheInterface&&) = delete;
+    LedgerCacheInterface(LedgerCacheInterface const&) = delete;
+    LedgerCacheInterface&
+    operator=(LedgerCacheInterface&&) = delete;
+    LedgerCacheInterface&
+    operator=(LedgerCacheInterface const&) = delete;
 
     /**
      * @brief Update the cache with new ledger objects.

--- a/src/etl/CacheLoader.hpp
+++ b/src/etl/CacheLoader.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "data/BackendInterface.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "etl/CacheLoaderSettings.hpp"
 #include "etl/impl/CacheLoader.hpp"
 #include "etl/impl/CursorFromAccountProvider.hpp"
@@ -44,13 +45,13 @@ namespace etl {
  * @tparam CursorProviderType The type of the cursor provider to use
  * @tparam ExecutionContextType The type of the execution context to use
  */
-template <typename CacheType, typename ExecutionContextType = util::async::CoroExecutionContext>
+template <typename ExecutionContextType = util::async::CoroExecutionContext>
 class CacheLoader {
-    using CacheLoaderType = impl::CacheLoaderImpl<CacheType>;
+    using CacheLoaderType = impl::CacheLoaderImpl<data::LedgerCacheInterface>;
 
     util::Logger log_{"ETL"};
     std::shared_ptr<BackendInterface> backend_;
-    std::reference_wrapper<CacheType> cache_;
+    std::reference_wrapper<data::LedgerCacheInterface> cache_;
 
     CacheLoaderSettings settings_;
     ExecutionContextType ctx_;
@@ -67,7 +68,7 @@ public:
     CacheLoader(
         util::config::ClioConfigDefinition const& config,
         std::shared_ptr<BackendInterface> const& backend,
-        CacheType& cache
+        data::LedgerCacheInterface& cache
     )
         : backend_{backend}, cache_{cache}, settings_{makeCacheLoaderSettings(config)}, ctx_{settings_.numThreads}
     {

--- a/src/etl/CorruptionDetector.hpp
+++ b/src/etl/CorruptionDetector.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCacheInterface.hpp"
 #include "etl/SystemState.hpp"
 #include "util/log/Logger.hpp"
 
@@ -31,10 +32,9 @@ namespace etl {
  *
  * @tparam CacheType The type of the cache to disable on corruption
  */
-template <typename CacheType>
 class CorruptionDetector {
     std::reference_wrapper<SystemState> state_;
-    std::reference_wrapper<CacheType> cache_;
+    std::reference_wrapper<data::LedgerCacheInterface> cache_;
 
     util::Logger log_{"ETL"};
 
@@ -45,7 +45,8 @@ public:
      * @param state The system state
      * @param cache The cache to disable on corruption
      */
-    CorruptionDetector(SystemState& state, CacheType& cache) : state_{std::ref(state)}, cache_{std::ref(cache)}
+    CorruptionDetector(SystemState& state, data::LedgerCacheInterface& cache)
+        : state_{std::ref(state)}, cache_{std::ref(cache)}
     {
     }
 

--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -285,6 +285,6 @@ ETLService::ETLService(
     txnThreshold_ = config.get<std::size_t>("txn_threshold");
 
     // This should probably be done in the backend factory but we don't have state available until here
-    backend_->setCorruptionDetector(CorruptionDetector<data::LedgerCache>{state_, backend->cache()});
+    backend_->setCorruptionDetector(CorruptionDetector{state_, backend->cache()});
 }
 }  // namespace etl

--- a/src/etl/ETLService.hpp
+++ b/src/etl/ETLService.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "data/BackendInterface.hpp"
-#include "data/LedgerCache.hpp"
 #include "etl/CacheLoader.hpp"
 #include "etl/ETLState.hpp"
 #include "etl/LoadBalancer.hpp"
@@ -86,12 +85,11 @@ class ETLService : public ETLServiceTag {
     // TODO: make these template parameters in ETLService
     using LoadBalancerType = LoadBalancer;
     using DataPipeType = etl::impl::ExtractionDataPipe<org::xrpl::rpc::v1::GetLedgerResponse>;
-    using CacheType = data::LedgerCache;
-    using CacheLoaderType = etl::CacheLoader<CacheType>;
+    using CacheLoaderType = etl::CacheLoader<>;
     using LedgerFetcherType = etl::impl::LedgerFetcher<LoadBalancerType>;
     using ExtractorType = etl::impl::Extractor<DataPipeType, LedgerFetcherType>;
     using LedgerLoaderType = etl::impl::LedgerLoader<LoadBalancerType, LedgerFetcherType>;
-    using LedgerPublisherType = etl::impl::LedgerPublisher<CacheType>;
+    using LedgerPublisherType = etl::impl::LedgerPublisher;
     using AmendmentBlockHandlerType = etl::impl::AmendmentBlockHandler;
     using TransformerType =
         etl::impl::Transformer<DataPipeType, LedgerLoaderType, LedgerPublisherType, AmendmentBlockHandlerType>;

--- a/src/etl/impl/LedgerPublisher.hpp
+++ b/src/etl/impl/LedgerPublisher.hpp
@@ -21,6 +21,7 @@
 
 #include "data/BackendInterface.hpp"
 #include "data/DBHelpers.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "data/Types.hpp"
 #include "etl/SystemState.hpp"
 #include "feed/SubscriptionManagerInterface.hpp"
@@ -38,6 +39,7 @@
 #include <xrpl/protocol/STObject.h>
 #include <xrpl/protocol/Serializer.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -64,14 +66,13 @@ namespace etl::impl {
  * includes reading all of the transactions from the database) is done from the application wide asio io_service, and a
  * strand is used to ensure ledgers are published in order.
  */
-template <typename CacheType>
 class LedgerPublisher {
     util::Logger log_{"ETL"};
 
     boost::asio::strand<boost::asio::io_context::executor_type> publishStrand_;
 
     std::shared_ptr<BackendInterface> backend_;
-    std::reference_wrapper<CacheType> cache_;
+    std::reference_wrapper<data::LedgerCacheInterface> cache_;
     std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions_;
     std::reference_wrapper<SystemState const> state_;  // shared state for ETL
 
@@ -94,7 +95,7 @@ public:
     LedgerPublisher(
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
-        CacheType& cache,
+        data::LedgerCacheInterface& cache,
         std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
         SystemState const& state
     )
@@ -205,7 +206,7 @@ public:
                 subscriptions_->pubLedger(lgrInfo, *fees, range, transactions.size());
 
                 // order with transaction index
-                std::sort(transactions.begin(), transactions.end(), [](auto const& t1, auto const& t2) {
+                std::ranges::sort(transactions, [](auto const& t1, auto const& t2) {
                     ripple::SerialIter iter1{t1.metadata.data(), t1.metadata.size()};
                     ripple::STObject const object1(iter1, ripple::sfMetadata);
                     ripple::SerialIter iter2{t2.metadata.data(), t2.metadata.size()};

--- a/src/migration/MigrationApplication.cpp
+++ b/src/migration/MigrationApplication.cpp
@@ -41,7 +41,7 @@ MigratorApplication::MigratorApplication(util::config::ClioConfigDefinition cons
 {
     PrometheusService::init(config);
 
-    auto expectedMigrationManager = migration::impl::makeMigrationManager(config);
+    auto expectedMigrationManager = migration::impl::makeMigrationManager(config, cache_);
 
     if (not expectedMigrationManager) {
         throw std::runtime_error("Failed to create migration manager: " + expectedMigrationManager.error());

--- a/src/migration/MigrationApplication.hpp
+++ b/src/migration/MigrationApplication.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCache.hpp"
 #include "migration/MigrationManagerInterface.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
 
@@ -76,6 +77,7 @@ class MigratorApplication {
     std::string option_;
     std::shared_ptr<migration::MigrationManagerInterface> migrationManager_;
     MigrateSubCmd cmd_;
+    data::LedgerCache cache_;
 
 public:
     /**

--- a/src/migration/cassandra/CassandraMigrationBackend.hpp
+++ b/src/migration/cassandra/CassandraMigrationBackend.hpp
@@ -20,9 +20,8 @@
 #pragma once
 
 #include "data/CassandraBackend.hpp"
+#include "data/LedgerCacheInterface.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
-#include "data/cassandra/Types.hpp"
-#include "migration/MigratiorStatus.hpp"
 #include "migration/cassandra/impl/CassandraMigrationSchema.hpp"
 #include "migration/cassandra/impl/Spec.hpp"
 #include "util/log/Logger.hpp"
@@ -49,9 +48,13 @@ public:
      * @brief Construct a new Cassandra Migration Backend object. The backend is not readonly.
      *
      * @param settingsProvider The settings provider
+     * @param cache The ledger cache to use
      */
-    explicit CassandraMigrationBackend(data::cassandra::SettingsProvider settingsProvider)
-        : data::cassandra::CassandraBackend{auto{settingsProvider}, false /* not readonly */}
+    explicit CassandraMigrationBackend(
+        data::cassandra::SettingsProvider settingsProvider,
+        data::LedgerCacheInterface& cache
+    )
+        : data::cassandra::CassandraBackend{auto{settingsProvider}, cache, false /* not readonly */}
         , settingsProvider_(std::move(settingsProvider))
         , migrationSchema_{settingsProvider_}
     {

--- a/src/migration/impl/MigrationManagerFactory.cpp
+++ b/src/migration/impl/MigrationManagerFactory.cpp
@@ -19,6 +19,7 @@
 
 #include "migration/impl/MigrationManagerFactory.hpp"
 
+#include "data/LedgerCacheInterface.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
 #include "migration/MigrationManagerInterface.hpp"
 #include "migration/cassandra/CassandraMigrationBackend.hpp"
@@ -35,7 +36,7 @@
 namespace migration::impl {
 
 std::expected<std::shared_ptr<MigrationManagerInterface>, std::string>
-makeMigrationManager(util::config::ClioConfigDefinition const& config)
+makeMigrationManager(util::config::ClioConfigDefinition const& config, data::LedgerCacheInterface& cache)
 {
     static util::Logger const log{"Migration"};  // NOLINT(readability-identifier-naming)
     LOG(log.info()) << "Constructing MigrationManager";
@@ -48,11 +49,10 @@ makeMigrationManager(util::config::ClioConfigDefinition const& config)
     }
 
     auto const cfg = config.getObject("database." + type);
-
     auto migrationCfg = config.getObject("migration");
 
     return std::make_shared<cassandra::CassandraMigrationManager>(
-        std::make_shared<cassandra::CassandraMigrationBackend>(data::cassandra::SettingsProvider{cfg}),
+        std::make_shared<cassandra::CassandraMigrationBackend>(data::cassandra::SettingsProvider{cfg}, cache),
         std::move(migrationCfg)
     );
 }

--- a/src/migration/impl/MigrationManagerFactory.hpp
+++ b/src/migration/impl/MigrationManagerFactory.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCacheInterface.hpp"
 #include "migration/MigrationManagerInterface.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
 
@@ -33,9 +34,10 @@ namespace migration::impl {
  *
  * @param config The configuration of the migration application, it contains the database connection configuration and
  * other migration specific configurations
+ * @param cache The ledger cache to use
  * @return A shared pointer to the MigrationManagerInterface if the creation was successful, otherwise an error message
  */
 std::expected<std::shared_ptr<MigrationManagerInterface>, std::string>
-makeMigrationManager(util::config::ClioConfigDefinition const& config);
+makeMigrationManager(util::config::ClioConfigDefinition const& config, data::LedgerCacheInterface& cache);
 
 }  // namespace migration::impl

--- a/src/util/Assert.cpp
+++ b/src/util/Assert.cpp
@@ -21,7 +21,6 @@
 
 #include "util/log/Logger.hpp"
 
-
 #include <cstdlib>
 #include <iostream>
 #include <string_view>

--- a/tests/common/util/MockBackend.hpp
+++ b/tests/common/util/MockBackend.hpp
@@ -21,6 +21,7 @@
 
 #include "data/BackendInterface.hpp"
 #include "data/DBHelpers.hpp"
+#include "data/LedgerCache.hpp"
 #include "data/Types.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
 
@@ -36,10 +37,8 @@
 #include <string>
 #include <vector>
 
-using namespace data;
-
 struct MockBackend : public BackendInterface {
-    MockBackend(util::config::ClioConfigDefinition)
+    MockBackend(util::config::ClioConfigDefinition) : BackendInterface(cache_)
     {
     }
 
@@ -65,32 +64,32 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(
-        std::optional<TransactionAndMetadata>,
+        std::optional<data::TransactionAndMetadata>,
         fetchTransaction,
         (ripple::uint256 const&, boost::asio::yield_context),
         (const, override)
     );
 
     MOCK_METHOD(
-        std::vector<TransactionAndMetadata>,
+        std::vector<data::TransactionAndMetadata>,
         fetchTransactions,
         (std::vector<ripple::uint256> const&, boost::asio::yield_context),
         (const, override)
     );
 
     MOCK_METHOD(
-        TransactionsAndCursor,
+        data::TransactionsAndCursor,
         fetchAccountTransactions,
         (ripple::AccountID const&,
          std::uint32_t const,
          bool,
-         std::optional<TransactionsCursor> const&,
+         std::optional<data::TransactionsCursor> const&,
          boost::asio::yield_context),
         (const, override)
     );
 
     MOCK_METHOD(
-        std::vector<TransactionAndMetadata>,
+        std::vector<data::TransactionAndMetadata>,
         fetchAllTransactionsInLedger,
         (std::uint32_t const, boost::asio::yield_context),
         (const, override)
@@ -104,25 +103,25 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(
-        std::optional<NFT>,
+        std::optional<data::NFT>,
         fetchNFT,
         (ripple::uint256 const&, std::uint32_t const, boost::asio::yield_context),
         (const, override)
     );
 
     MOCK_METHOD(
-        TransactionsAndCursor,
+        data::TransactionsAndCursor,
         fetchNFTTransactions,
         (ripple::uint256 const&,
          std::uint32_t const,
          bool const,
-         std::optional<TransactionsCursor> const&,
+         std::optional<data::TransactionsCursor> const&,
          boost::asio::yield_context),
         (const, override)
     );
 
     MOCK_METHOD(
-        NFTsAndCursor,
+        data::NFTsAndCursor,
         fetchNFTsByIssuer,
         (ripple::AccountID const& issuer,
          std::optional<std::uint32_t> const& taxon,
@@ -134,7 +133,7 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(
-        std::vector<Blob>,
+        std::vector<data::Blob>,
         doFetchLedgerObjects,
         (std::vector<ripple::uint256> const&, std::uint32_t const, boost::asio::yield_context),
         (const, override)
@@ -148,7 +147,7 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(
-        std::optional<Blob>,
+        std::optional<data::Blob>,
         doFetchLedgerObject,
         (ripple::uint256 const&, std::uint32_t const, boost::asio::yield_context),
         (const, override)
@@ -162,7 +161,7 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(
-        std::vector<LedgerObject>,
+        std::vector<data::LedgerObject>,
         fetchLedgerDiff,
         (std::uint32_t const, boost::asio::yield_context),
         (const, override)
@@ -182,7 +181,12 @@ struct MockBackend : public BackendInterface {
         (const, override)
     );
 
-    MOCK_METHOD(std::optional<LedgerRange>, hardFetchLedgerRange, (boost::asio::yield_context), (const, override));
+    MOCK_METHOD(
+        std::optional<data::LedgerRange>,
+        hardFetchLedgerRange,
+        (boost::asio::yield_context),
+        (const, override)
+    );
 
     MOCK_METHOD(void, writeLedger, (ripple::LedgerHeader const&, std::string&&), (override));
 
@@ -218,7 +222,7 @@ struct MockBackend : public BackendInterface {
     MOCK_METHOD(void, writeMPTHolders, (std::vector<MPTHolderData> const&), (override));
 
     MOCK_METHOD(
-        MPTHoldersAndCursor,
+        data::MPTHoldersAndCursor,
         fetchMPTHolders,
         (ripple::uint192 const& mptID,
          std::uint32_t const,
@@ -229,4 +233,7 @@ struct MockBackend : public BackendInterface {
     );
 
     MOCK_METHOD(void, writeMigratorStatus, (std::string const&, std::string const&), (override));
+
+protected:
+    data::LedgerCache cache_;  // TODO: this should probably be injected and MockLedgerCache instead
 };

--- a/tests/common/util/MockLedgerCache.hpp
+++ b/tests/common/util/MockLedgerCache.hpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
-    Copyright (c) 2023, the clio developers.
+    Copyright (c) 2025, the clio developers.
 
     Permission to use, copy, modify, and distribute this software for any
     purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCacheInterface.hpp"
 #include "data/Types.hpp"
 
 #include <gmock/gmock.h>
@@ -29,36 +30,46 @@
 #include <optional>
 #include <vector>
 
-struct MockCache {
-    virtual ~MockCache() = default;
-
+struct MockLedgerCache : data::LedgerCacheInterface {
     MOCK_METHOD(void, updateImp, (std::vector<data::LedgerObject> const& a, uint32_t b, bool c), ());
 
-    virtual void
-    update(std::vector<data::LedgerObject> const& a, uint32_t b, bool c = false)
+    void
+    update(std::vector<data::LedgerObject> const& a, uint32_t b, bool c = false) override
     {
         updateImp(a, b, c);
     }
 
-    MOCK_METHOD(std::optional<data::Blob>, get, (ripple::uint256 const& a, uint32_t b), (const));
+    MOCK_METHOD(std::optional<data::Blob>, get, (ripple::uint256 const& a, uint32_t b), (const, override));
 
-    MOCK_METHOD(std::optional<data::LedgerObject>, getSuccessor, (ripple::uint256 const& a, uint32_t b), (const));
+    MOCK_METHOD(
+        std::optional<data::LedgerObject>,
+        getSuccessor,
+        (ripple::uint256 const& a, uint32_t b),
+        (const, override)
+    );
 
-    MOCK_METHOD(std::optional<data::LedgerObject>, getPredecessor, (ripple::uint256 const& a, uint32_t b), (const));
+    MOCK_METHOD(
+        std::optional<data::LedgerObject>,
+        getPredecessor,
+        (ripple::uint256 const& a, uint32_t b),
+        (const, override)
+    );
 
-    MOCK_METHOD(void, setDisabled, (), ());
+    MOCK_METHOD(void, setDisabled, (), (override));
 
-    MOCK_METHOD(bool, isDisabled, (), (const));
+    MOCK_METHOD(bool, isDisabled, (), (const, override));
 
-    MOCK_METHOD(void, setFull, (), ());
+    MOCK_METHOD(void, setFull, (), (override));
 
-    MOCK_METHOD(bool, isFull, (), (const));
+    MOCK_METHOD(bool, isFull, (), (const, override));
 
-    MOCK_METHOD(uint32_t, latestLedgerSequence, (), (const));
+    MOCK_METHOD(uint32_t, latestLedgerSequence, (), (const, override));
 
-    MOCK_METHOD(size_t, size, (), (const));
+    MOCK_METHOD(size_t, size, (), (const, override));
 
-    MOCK_METHOD(float, getObjectHitRate, (), (const));
+    MOCK_METHOD(float, getObjectHitRate, (), (const, override));
 
-    MOCK_METHOD(float, getSuccessorHitRate, (), (const));
+    MOCK_METHOD(float, getSuccessorHitRate, (), (const, override));
+
+    MOCK_METHOD(void, waitUntilCacheContainsSeq, (uint32_t), (override));
 };

--- a/tests/integration/data/BackendFactoryTests.cpp
+++ b/tests/integration/data/BackendFactoryTests.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include "data/BackendFactory.hpp"
+#include "data/LedgerCache.hpp"
 #include "data/cassandra/Handle.hpp"
 #include "util/AsioContextTestFixture.hpp"
 #include "util/MockPrometheus.hpp"
@@ -97,7 +98,8 @@ protected:
 TEST_F(BackendCassandraFactoryTest, NoSuchBackend)
 {
     useConfig(R"json( {"database": {"type": "unknown"}} )json");
-    EXPECT_THROW(data::makeBackend(cfg_), std::runtime_error);
+    auto cache = data::LedgerCache{};
+    EXPECT_THROW(data::makeBackend(cfg_, cache), std::runtime_error);
 }
 
 TEST_F(BackendCassandraFactoryTest, CreateCassandraBackendDBDisconnect)
@@ -111,13 +113,15 @@ TEST_F(BackendCassandraFactoryTest, CreateCassandraBackendDBDisconnect)
         }}
     )json");
 
-    EXPECT_THROW(data::makeBackend(cfg_), std::runtime_error);
+    auto cache = data::LedgerCache{};
+    EXPECT_THROW(data::makeBackend(cfg_, cache), std::runtime_error);
 }
 
 TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackend)
 {
     {
-        auto backend = data::makeBackend(cfg_);
+        auto cache = data::LedgerCache{};
+        auto backend = data::makeBackend(cfg_, cache);
         EXPECT_TRUE(backend);
 
         // empty db does not have ledger range
@@ -131,7 +135,8 @@ TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackend)
     }
 
     {
-        auto backend = data::makeBackend(cfg_);
+        auto cache = data::LedgerCache{};
+        auto backend = data::makeBackend(cfg_, cache);
         EXPECT_TRUE(backend);
 
         auto const range = backend->fetchLedgerRange();
@@ -143,7 +148,8 @@ TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackend)
 TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackendReadOnlyWithEmptyDB)
 {
     useConfig(R"json( {"read_only": true} )json");
-    EXPECT_THROW(data::makeBackend(cfg_), std::runtime_error);
+    auto cache = data::LedgerCache{};
+    EXPECT_THROW(data::makeBackend(cfg_, cache), std::runtime_error);
 }
 
 TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackendReadOnlyWithDBReady)
@@ -151,6 +157,7 @@ TEST_F(BackendCassandraFactoryTestWithDB, CreateCassandraBackendReadOnlyWithDBRe
     auto cfgReadOnly = cfg_;
     ASSERT_FALSE(cfgReadOnly.parse(ConfigFileJson{boost::json::parse(R"json( {"read_only": true} )json").as_object()}));
 
-    EXPECT_TRUE(data::makeBackend(cfg_));
-    EXPECT_TRUE(data::makeBackend(cfgReadOnly));
+    auto cache = data::LedgerCache{};
+    EXPECT_TRUE(data::makeBackend(cfg_, cache));
+    EXPECT_TRUE(data::makeBackend(cfgReadOnly, cache));
 }

--- a/tests/integration/data/cassandra/BackendTests.cpp
+++ b/tests/integration/data/cassandra/BackendTests.cpp
@@ -20,6 +20,7 @@
 #include "data/BackendInterface.hpp"
 #include "data/CassandraBackend.hpp"
 #include "data/DBHelpers.hpp"
+#include "data/LedgerCache.hpp"
 #include "data/Types.hpp"
 #include "data/cassandra/Handle.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
@@ -104,13 +105,14 @@ protected:
     SettingsProvider settingsProvider_{obj_};
 
     // recreated for each test
+    data::LedgerCache cache_;
     std::unique_ptr<BackendInterface> backend_;
 
     void
     SetUp() override
     {
         SyncAsioContextTest::SetUp();
-        backend_ = std::make_unique<CassandraBackend>(settingsProvider_, false);
+        backend_ = std::make_unique<CassandraBackend>(settingsProvider_, cache_, false);
     }
     void
     TearDown() override

--- a/tests/integration/migration/cassandra/CassandraMigrationManagerTests.cpp
+++ b/tests/integration/migration/cassandra/CassandraMigrationManagerTests.cpp
@@ -19,6 +19,7 @@
 
 #include "data/BackendInterface.hpp"
 #include "data/DBHelpers.hpp"
+#include "data/LedgerCache.hpp"
 #include "data/cassandra/Handle.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
 #include "migration/MigrationManagerInterface.hpp"
@@ -75,7 +76,9 @@ makeMigrationTestManagerAndBackend(ClioConfigDefinition const& config)
 {
     auto const cfg = config.getObject("database.cassandra");
 
-    auto const backendPtr = std::make_shared<CassandraMigrationTestBackend>(data::cassandra::SettingsProvider{cfg});
+    auto cache = data::LedgerCache{};
+    auto const backendPtr =
+        std::make_shared<CassandraMigrationTestBackend>(data::cassandra::SettingsProvider{cfg}, cache);
 
     return std::make_pair(
         std::make_shared<CassandraMigrationTestManager>(backendPtr, config.getObject("migration")), backendPtr

--- a/tests/integration/migration/cassandra/CassandraMigrationTestBackend.hpp
+++ b/tests/integration/migration/cassandra/CassandraMigrationTestBackend.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "data/LedgerCacheInterface.hpp"
 #include "data/cassandra/Handle.hpp"
 #include "data/cassandra/Schema.hpp"
 #include "data/cassandra/SettingsProvider.hpp"
@@ -50,9 +51,10 @@ public:
      * @brief Construct a new Cassandra Migration Test Backend object
      *
      * @param settingsProvider The settings provider for the Cassandra backend
+     * @param cache The ledger cache to use
      */
-    CassandraMigrationTestBackend(data::cassandra::SettingsProvider settingsProvider)
-        : migration::cassandra::CassandraMigrationBackend(settingsProvider)
+    CassandraMigrationTestBackend(data::cassandra::SettingsProvider settingsProvider, data::LedgerCacheInterface& cache)
+        : migration::cassandra::CassandraMigrationBackend(settingsProvider, cache)
         , settingsProvider_(std::move(settingsProvider))
 
     {

--- a/tests/unit/etl/CacheLoaderTests.cpp
+++ b/tests/unit/etl/CacheLoaderTests.cpp
@@ -23,7 +23,7 @@
 #include "etl/FakeDiffProvider.hpp"
 #include "etl/impl/CacheLoader.hpp"
 #include "util/MockBackendTestFixture.hpp"
-#include "util/MockCache.hpp"
+#include "util/MockLedgerCache.hpp"
 #include "util/MockPrometheus.hpp"
 #include "util/async/context/BasicExecutionContext.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
@@ -75,7 +75,7 @@ constexpr auto kSEQ = 30;
 
 struct CacheLoaderTest : util::prometheus::WithPrometheus, MockBackendTest {
     DiffProvider diffProvider;
-    MockCache cache;
+    MockLedgerCache cache;
 };
 
 using Settings = etl::CacheLoaderSettings;
@@ -137,7 +137,7 @@ TEST_P(ParametrizedCacheLoaderTest, LoadCacheWithDifferentSettings)
     async::CoroExecutionContext ctx{settings.numThreads};
     etl::impl::CursorFromFixDiffNumProvider const provider{backend_, settings.numCacheDiffs};
 
-    etl::impl::CacheLoaderImpl<MockCache> loader{
+    etl::impl::CacheLoaderImpl<MockLedgerCache> loader{
         ctx, backend_, cache, kSEQ, settings.numCacheMarkers, settings.cachePageFetchSize, provider.getCursors(kSEQ)
     };
 
@@ -166,7 +166,7 @@ TEST_P(ParametrizedCacheLoaderTest, AutomaticallyCancelledAndAwaitedInDestructor
     async::CoroExecutionContext ctx{settings.numThreads};
     etl::impl::CursorFromFixDiffNumProvider const provider{backend_, settings.numCacheDiffs};
 
-    etl::impl::CacheLoaderImpl<MockCache> const loader{
+    etl::impl::CacheLoaderImpl<MockLedgerCache> const loader{
         ctx, backend_, cache, kSEQ, settings.numCacheMarkers, settings.cachePageFetchSize, provider.getCursors(kSEQ)
     };
 
@@ -195,7 +195,7 @@ TEST_P(ParametrizedCacheLoaderTest, CacheDisabledLeadsToCancellation)
     async::CoroExecutionContext ctx{settings.numThreads};
     etl::impl::CursorFromFixDiffNumProvider const provider{backend_, settings.numCacheDiffs};
 
-    etl::impl::CacheLoaderImpl<MockCache> loader{
+    etl::impl::CacheLoaderImpl<MockLedgerCache> loader{
         ctx, backend_, cache, kSEQ, settings.numCacheMarkers, settings.cachePageFetchSize, provider.getCursors(kSEQ)
     };
 
@@ -208,7 +208,7 @@ TEST_P(ParametrizedCacheLoaderTest, CacheDisabledLeadsToCancellation)
 TEST_F(CacheLoaderTest, SyncCacheLoaderWaitsTillFullyLoaded)
 {
     auto const cfg = getParseCacheConfig(json::parse(R"({"cache": {"load": "sync"}})"));
-    CacheLoader loader{cfg, backend_, cache};
+    CacheLoader<> loader{cfg, backend_, cache};
 
     auto const diffs = diffProvider.getLatestDiff();
     auto const loops = diffs.size() + 1;

--- a/tests/unit/etl/CorruptionDetectorTests.cpp
+++ b/tests/unit/etl/CorruptionDetectorTests.cpp
@@ -20,7 +20,7 @@
 #include "etl/CorruptionDetector.hpp"
 #include "etl/SystemState.hpp"
 #include "util/LoggerFixtures.hpp"
-#include "util/MockCache.hpp"
+#include "util/MockLedgerCache.hpp"
 #include "util/MockPrometheus.hpp"
 
 #include <gmock/gmock.h>
@@ -36,7 +36,7 @@ TEST_F(CorruptionDetectorTest, DisableCacheOnCorruption)
 {
     using namespace ripple;
     auto state = etl::SystemState{};
-    auto cache = MockCache{};
+    auto cache = MockLedgerCache{};
     auto detector = etl::CorruptionDetector{state, cache};
 
     EXPECT_CALL(cache, setDisabled()).Times(1);

--- a/tests/unit/etl/LedgerPublisherTests.cpp
+++ b/tests/unit/etl/LedgerPublisherTests.cpp
@@ -23,7 +23,7 @@
 #include "etl/impl/LedgerPublisher.hpp"
 #include "util/AsioContextTestFixture.hpp"
 #include "util/MockBackendTestFixture.hpp"
-#include "util/MockCache.hpp"
+#include "util/MockLedgerCache.hpp"
 #include "util/MockPrometheus.hpp"
 #include "util/MockSubscriptionManager.hpp"
 #include "util/TestObject.hpp"
@@ -41,6 +41,7 @@
 
 using namespace testing;
 using namespace etl;
+using namespace data;
 using namespace std::chrono;
 
 namespace {
@@ -66,7 +67,7 @@ struct ETLLedgerPublisherTest : util::prometheus::WithPrometheus, MockBackendTes
         SyncAsioContextTest::TearDown();
     }
     util::config::ClioConfigDefinition cfg{{}};
-    MockCache mockCache;
+    MockLedgerCache mockCache;
     StrictMockSubscriptionManagerSharedPtr mockSubscriptionManagerPtr;
 };
 

--- a/tests/unit/etlng/LoadingTests.cpp
+++ b/tests/unit/etlng/LoadingTests.cpp
@@ -42,6 +42,7 @@
 
 using namespace etlng::model;
 using namespace etlng::impl;
+using namespace data;
 
 namespace {
 

--- a/tests/unit/etlng/MonitorTests.cpp
+++ b/tests/unit/etlng/MonitorTests.cpp
@@ -36,6 +36,7 @@
 #include <semaphore>
 
 using namespace etlng::impl;
+using namespace data;
 
 namespace {
 constexpr auto kSTART_SEQ = 123u;

--- a/tests/unit/feed/BookChangesFeedTests.cpp
+++ b/tests/unit/feed/BookChangesFeedTests.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 using namespace feed::impl;
+using namespace data;
 
 namespace {
 

--- a/tests/unit/feed/SubscriptionManagerTests.cpp
+++ b/tests/unit/feed/SubscriptionManagerTests.cpp
@@ -58,6 +58,7 @@ constexpr auto kLEDGER_HASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF2
 namespace json = boost::json;
 using namespace feed;
 using namespace feed::impl;
+using namespace data;
 
 template <class Execution>
 class SubscriptionManagerBaseTest : public util::prometheus::WithPrometheus, public MockBackendTest {

--- a/tests/unit/feed/TransactionFeedTests.cpp
+++ b/tests/unit/feed/TransactionFeedTests.cpp
@@ -45,6 +45,8 @@
 #include <memory>
 #include <vector>
 
+using namespace data;
+
 namespace {
 
 constexpr auto kACCOUNT1 = "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn";

--- a/tests/unit/migration/MigrationInspectorFactoryTests.cpp
+++ b/tests/unit/migration/MigrationInspectorFactoryTests.cpp
@@ -32,6 +32,7 @@
 #include <optional>
 
 using namespace testing;
+using namespace data;
 
 struct MigrationInspectorFactoryTests : util::prometheus::WithPrometheus,
                                         common::util::WithMockAssert,

--- a/tests/unit/migration/MigrationManagerFactoryTests.cpp
+++ b/tests/unit/migration/MigrationManagerFactoryTests.cpp
@@ -19,6 +19,7 @@
 
 #include "migration/impl/MigrationManagerFactory.hpp"
 #include "util/LoggerFixtures.hpp"
+#include "util/MockLedgerCache.hpp"
 #include "util/newconfig/ConfigDefinition.hpp"
 #include "util/newconfig/ConfigValue.hpp"
 #include "util/newconfig/Types.hpp"
@@ -29,10 +30,11 @@ struct MigrationManagerFactoryTests : public NoLoggerFixture {};
 
 TEST_F(MigrationManagerFactoryTests, InvalidDBType)
 {
+    MockLedgerCache cache{};
     util::config::ClioConfigDefinition const configDef{
         {"database.type", util::config::ConfigValue{util::config::ConfigType::String}.defaultValue("invalid")}
     };
-    auto const ret = migration::impl::makeMigrationManager(configDef);
+    auto const ret = migration::impl::makeMigrationManager(configDef, cache);
     EXPECT_FALSE(ret);
     EXPECT_EQ(ret.error(), "Invalid database type");
 }

--- a/tests/unit/rpc/RPCEngineTests.cpp
+++ b/tests/unit/rpc/RPCEngineTests.cpp
@@ -56,6 +56,7 @@
 #include <variant>
 #include <vector>
 
+using namespace data;
 using namespace rpc;
 using namespace util;
 namespace json = boost::json;

--- a/tests/unit/rpc/RPCHelpersTests.cpp
+++ b/tests/unit/rpc/RPCHelpersTests.cpp
@@ -58,6 +58,7 @@
 #include <variant>
 #include <vector>
 
+using namespace data;
 using namespace rpc;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AMMInfoTests.cpp
+++ b/tests/unit/rpc/handlers/AMMInfoTests.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountChannelsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountChannelsTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountCurrenciesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountCurrenciesTests.cpp
@@ -40,6 +40,8 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
+
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountInfoTests.cpp
+++ b/tests/unit/rpc/handlers/AccountInfoTests.cpp
@@ -44,6 +44,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountLinesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountLinesTests.cpp
@@ -44,6 +44,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountNFTsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountNFTsTests.cpp
@@ -58,6 +58,7 @@ constexpr auto kMIN_SEQ = 10;
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountObjectsTests.cpp
+++ b/tests/unit/rpc/handlers/AccountObjectsTests.cpp
@@ -48,6 +48,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountOffersTests.cpp
+++ b/tests/unit/rpc/handlers/AccountOffersTests.cpp
@@ -53,6 +53,7 @@ constexpr auto kINDEX1 = "1B8590C01B0006EDFA9ED60296DD052DC5E90F99659B25014D08E1
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/AccountTxTests.cpp
+++ b/tests/unit/rpc/handlers/AccountTxTests.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/BookChangesTests.cpp
+++ b/tests/unit/rpc/handlers/BookChangesTests.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/BookOffersTests.cpp
+++ b/tests/unit/rpc/handlers/BookOffersTests.cpp
@@ -80,6 +80,7 @@ struct ParameterTestBundle {
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/DepositAuthorizedTests.cpp
+++ b/tests/unit/rpc/handlers/DepositAuthorizedTests.cpp
@@ -61,6 +61,7 @@ constexpr auto kRANGE_MAX = 30;
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/FeatureTests.cpp
+++ b/tests/unit/rpc/handlers/FeatureTests.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 
 namespace {
 

--- a/tests/unit/rpc/handlers/GatewayBalancesTests.cpp
+++ b/tests/unit/rpc/handlers/GatewayBalancesTests.cpp
@@ -46,6 +46,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
+++ b/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
@@ -42,6 +42,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/LedgerDataTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerDataTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/LedgerEntryTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerEntryTests.cpp
@@ -56,6 +56,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/LedgerIndexTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerIndexTests.cpp
@@ -44,6 +44,7 @@ constexpr auto kLEDGER_HASH = "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF2
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/LedgerRangeTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerRangeTests.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/LedgerTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerTests.cpp
@@ -61,6 +61,7 @@ constexpr auto kRANGE_MAX = 30;
 }  // namespace
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/MPTHoldersTests.cpp
+++ b/tests/unit/rpc/handlers/MPTHoldersTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NFTBuyOffersTests.cpp
+++ b/tests/unit/rpc/handlers/NFTBuyOffersTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NFTHistoryTests.cpp
+++ b/tests/unit/rpc/handlers/NFTHistoryTests.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NFTInfoTests.cpp
+++ b/tests/unit/rpc/handlers/NFTInfoTests.cpp
@@ -37,6 +37,7 @@
 #include <optional>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NFTSellOffersTests.cpp
+++ b/tests/unit/rpc/handlers/NFTSellOffersTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NFTsByIssuerTest.cpp
+++ b/tests/unit/rpc/handlers/NFTsByIssuerTest.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/NoRippleCheckTests.cpp
+++ b/tests/unit/rpc/handlers/NoRippleCheckTests.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/ServerInfoTests.cpp
+++ b/tests/unit/rpc/handlers/ServerInfoTests.cpp
@@ -42,6 +42,7 @@
 #include <string>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/SubscribeTests.cpp
+++ b/tests/unit/rpc/handlers/SubscribeTests.cpp
@@ -51,6 +51,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 using std::chrono::milliseconds;

--- a/tests/unit/rpc/handlers/TransactionEntryTests.cpp
+++ b/tests/unit/rpc/handlers/TransactionEntryTests.cpp
@@ -35,6 +35,7 @@
 #include <optional>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/TxTests.cpp
+++ b/tests/unit/rpc/handlers/TxTests.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 

--- a/tests/unit/rpc/handlers/UnsubscribeTests.cpp
+++ b/tests/unit/rpc/handlers/UnsubscribeTests.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 using namespace rpc;
+using namespace data;
 namespace json = boost::json;
 using namespace testing;
 using namespace feed;


### PR DESCRIPTION
For #1200 

This PR introduces `LedgerCacheInterface` and modifies the rest of the codebase to use cache (mostly) through this interface.
Removal of `cache()` getters in `BackendInterface` will be done after old ETL code is removed.