### PR TITLE
chore: Fix clang-tidy 'fixes'

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -185,7 +185,7 @@ CheckOptions:
   readability-identifier-naming.FunctionIgnoredRegexp: '.*tag_invoke.*'
   bugprone-unsafe-functions.ReportMoreUnsafeFunctions: true
   bugprone-unused-return-value.CheckedReturnTypes: ::std::error_code;::std::error_condition;::std::errc
-  misc-include-cleaner.IgnoreHeaders: '.*/(detail|impl)/.*;.*(expected|unexpected).*;.*ranges_lower_bound\.h;time.h;stdlib.h'
+  misc-include-cleaner.IgnoreHeaders: '.*/(detail|impl)/.*;.*(expected|unexpected).*;.*ranges_lower_bound\.h;time.h;stdlib.h;__chrono/.*;fmt/chrono.h;boost/uuid/uuid_hash.hpp'
 
 HeaderFilterRegex: '^.*/(src|tests)/.*\.(h|hpp)$'
 WarningsAsErrors: '*'

--- a/src/util/TimeUtils.cpp
+++ b/src/util/TimeUtils.cpp
@@ -19,7 +19,7 @@
 
 #include "util/TimeUtils.hpp"
 
-#include <__chrono/time_point.h>
+#include <fmt/chrono.h>
 #include <fmt/core.h>
 #include <xrpl/basics/chrono.h>
 

--- a/tests/integration/data/cassandra/BackendTests.cpp
+++ b/tests/integration/data/cassandra/BackendTests.cpp
@@ -41,6 +41,7 @@
 #include <boost/asio/spawn.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_hash.hpp>
 #include <gtest/gtest.h>
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/base_uint.h>


### PR DESCRIPTION
Undo some of #1994