### PR TITLE
refactor: Add str() method to BaseTagDecorator

### DIFF
--- a/src/util/Taggable.hpp
+++ b/src/util/Taggable.hpp
@@ -96,6 +96,18 @@ public:
         decorator.decorate(os);
         return os;
     }
+
+    /**
+     * @brief Gets the string representation of the tag.
+     *
+     * @return The string representation of the tag
+     */
+    std::string str() const
+    {
+        std::ostringstream oss;
+        decorate(oss);
+        return std::move(oss).str();
+    }
 };
 
 /**

--- a/src/util/Taggable.hpp
+++ b/src/util/Taggable.hpp
@@ -102,7 +102,8 @@ public:
      *
      * @return The string representation of the tag
      */
-    std::string str() const
+    std::string
+    toString() const
     {
         std::ostringstream oss;
         decorate(oss);

--- a/tests/unit/rpc/RPCHelpersTests.cpp
+++ b/tests/unit/rpc/RPCHelpersTests.cpp
@@ -1210,7 +1210,7 @@ TEST_P(RPCHelpersLogDurationTest, LogDuration)
     std::string const output = getLoggerString();
 
     EXPECT_NE(output.find(GetParam().expectedLogLevel), std::string::npos) << output;
-    EXPECT_NE(output.find(tag.str()), std::string::npos);
+    EXPECT_NE(output.find(tag.toString()), std::string::npos);
 
     if (GetParam().expectDuration) {
         std::string const durationStr = std::to_string(GetParam().duration.count()) + " milliseconds";

--- a/tests/unit/rpc/RPCHelpersTests.cpp
+++ b/tests/unit/rpc/RPCHelpersTests.cpp
@@ -1204,19 +1204,13 @@ struct RPCHelpersLogDurationTest : LoggerFixture, testing::WithParamInterface<RP
 TEST_P(RPCHelpersLogDurationTest, LogDuration)
 {
     auto const& tag = taggable.tag();
-    // TOOD: Update in https://github.com/XRPLF/clio/issues/2008
-    auto const tagStr = [&tag]() {
-        std::stringstream ss;
-        ss << tag;
-        return ss.str();
-    }();
 
     logDuration(request, tag, GetParam().duration);
 
     std::string const output = getLoggerString();
 
     EXPECT_NE(output.find(GetParam().expectedLogLevel), std::string::npos) << output;
-    EXPECT_NE(output.find(tagStr), std::string::npos);
+    EXPECT_NE(output.find(tag.str()), std::string::npos);
 
     if (GetParam().expectDuration) {
         std::string const durationStr = std::to_string(GetParam().duration.count()) + " milliseconds";


### PR DESCRIPTION
Fix: https://github.com/XRPLF/clio/issues/2008