### PR TITLE
refactor: Compare error_code with enum values, not hardcoded ints

### DIFF
--- a/tests/unit/app/WebHandlersTests.cpp
+++ b/tests/unit/app/WebHandlersTests.cpp
@@ -181,7 +181,7 @@ TEST_F(RequestHandlerTest, DosguardRateLimited_Http)
 
         auto const body = boost::json::parse(httpResponse.body()).as_object();
         EXPECT_EQ(body.at("error").as_string(), "slowDown");
-        EXPECT_EQ(body.at("error_code").as_int64(), 10);
+        EXPECT_EQ(body.at("error_code").as_int64(), rpc::RippledError::rpcSLOW_DOWN);
         EXPECT_EQ(body.at("status").as_string(), "error");
         EXPECT_FALSE(body.contains("id"));
         EXPECT_FALSE(body.contains("request"));
@@ -201,7 +201,7 @@ TEST_F(RequestHandlerTest, DosguardRateLimited_Ws)
         auto const message = boost::json::parse(response.message()).as_object();
 
         EXPECT_EQ(message.at("error").as_string(), "slowDown");
-        EXPECT_EQ(message.at("error_code").as_int64(), 10);
+        EXPECT_EQ(message.at("error_code").as_int64(), rpc::RippledError::rpcSLOW_DOWN);
         EXPECT_EQ(message.at("status").as_string(), "error");
         EXPECT_EQ(message.at("id").as_string(), "some id");
         EXPECT_EQ(message.at("request").as_string(), requestMessage);
@@ -221,7 +221,7 @@ TEST_F(RequestHandlerTest, DosguardRateLimited_Ws_ErrorParsing)
         auto const message = boost::json::parse(response.message()).as_object();
 
         EXPECT_EQ(message.at("error").as_string(), "slowDown");
-        EXPECT_EQ(message.at("error_code").as_int64(), 10);
+        EXPECT_EQ(message.at("error_code").as_int64(), rpc::RippledError::rpcSLOW_DOWN);
         EXPECT_EQ(message.at("status").as_string(), "error");
         EXPECT_FALSE(message.contains("id"));
         EXPECT_EQ(message.at("request").as_string(), requestMessage);
@@ -245,7 +245,7 @@ TEST_F(RequestHandlerTest, RpcHandlerThrows)
 
         auto const body = boost::json::parse(httpResponse.body()).as_object();
         EXPECT_EQ(body.at("error").as_string(), "internal");
-        EXPECT_EQ(body.at("error_code").as_int64(), 73);
+        EXPECT_EQ(body.at("error_code").as_int64(), rpc::RippledError::rpcINTERNAL);
         EXPECT_EQ(body.at("status").as_string(), "error");
     });
 }

--- a/tests/unit/rpc/ErrorTests.cpp
+++ b/tests/unit/rpc/ErrorTests.cpp
@@ -32,8 +32,10 @@ using namespace rpc;
 using namespace std;
 
 namespace {
+
+template <typename ErrorCodeType>
 void
-check(boost::json::object const& j, std::string_view error, uint32_t errorCode, std::string_view errorMessage)
+check(boost::json::object const& j, std::string_view error, ErrorCodeType errorCode, std::string_view errorMessage)
 {
     EXPECT_TRUE(j.contains("error"));
     EXPECT_TRUE(j.contains("error_code"));
@@ -51,7 +53,7 @@ check(boost::json::object const& j, std::string_view error, uint32_t errorCode, 
     EXPECT_EQ(boost::json::value_to<std::string>(j.at("type")), "response");
 
     EXPECT_EQ(boost::json::value_to<std::string>(j.at("error")), error.data());
-    EXPECT_EQ(j.at("error_code").as_uint64(), errorCode);
+    EXPECT_EQ(j.at("error_code").as_uint64(), static_cast<uint64_t>(errorCode));
     EXPECT_EQ(boost::json::value_to<std::string>(j.at("error_message")), errorMessage.data());
 }
 }  // namespace
@@ -86,13 +88,13 @@ TEST(RPCErrorsTest, StatusEquals)
 TEST(RPCErrorsTest, SuccessToJSON)
 {
     auto const status = Status{RippledError::rpcSUCCESS};
-    check(makeError(status), "unknown", 0, "An unknown error code.");
+    check(makeError(status), "unknown", RippledError::rpcSUCCESS, "An unknown error code.");
 }
 
 TEST(RPCErrorsTest, RippledErrorToJSON)
 {
     auto const status = Status{RippledError::rpcINVALID_PARAMS};
-    check(makeError(status), "invalidParams", 31, "Invalid parameters.");
+    check(makeError(status), "invalidParams", RippledError::rpcINVALID_PARAMS, "Invalid parameters.");
 }
 
 TEST(RPCErrorsTest, RippledErrorFromStringToJSON)
@@ -104,31 +106,31 @@ TEST(RPCErrorsTest, RippledErrorFromStringToJSON)
 TEST(RPCErrorsTest, RippledErrorToJSONCustomMessage)
 {
     auto const status = Status{RippledError::rpcINVALID_PARAMS, "custom"};
-    check(makeError(status), "invalidParams", 31, "custom");
+    check(makeError(status), "invalidParams", RippledError::rpcINVALID_PARAMS, "custom");
 }
 
 TEST(RPCErrorsTest, RippledErrorToJSONCustomStrCodeAndMessage)
 {
     auto const status = Status{RippledError::rpcINVALID_PARAMS, "customCode", "customMessage"};
-    check(makeError(status), "customCode", 31, "customMessage");
+    check(makeError(status), "customCode", RippledError::rpcINVALID_PARAMS, "customMessage");
 }
 
 TEST(RPCErrorsTest, ClioErrorToJSON)
 {
     auto const status = Status{ClioError::RpcMalformedCurrency};
-    check(makeError(status), "malformedCurrency", 5000, "Malformed currency.");
+    check(makeError(status), "malformedCurrency", ClioError::RpcMalformedCurrency, "Malformed currency.");
 }
 
 TEST(RPCErrorsTest, ClioErrorToJSONCustomMessage)
 {
     auto const status = Status{ClioError::RpcMalformedCurrency, "custom"};
-    check(makeError(status), "malformedCurrency", 5000, "custom");
+    check(makeError(status), "malformedCurrency", ClioError::RpcMalformedCurrency, "custom");
 }
 
 TEST(RPCErrorsTest, ClioErrorToJSONCustomStrCodeAndMessage)
 {
     auto const status = Status{ClioError::RpcMalformedCurrency, "customCode", "customMessage"};
-    check(makeError(status), "customCode", 5000, "customMessage");
+    check(makeError(status), "customCode", ClioError::RpcMalformedCurrency, "customMessage");
 }
 
 TEST(RPCErrorsTest, InvalidClioErrorToJSON)

--- a/tests/unit/rpc/handlers/TestHandlerTests.cpp
+++ b/tests/unit/rpc/handlers/TestHandlerTests.cpp
@@ -79,8 +79,8 @@ TEST_F(RPCTestHandlerTest, HandlerErrorHandling)
 
         auto const err = rpc::makeError(output.result.error());
         EXPECT_EQ(err.at("error").as_string(), "invalidParams");
+        EXPECT_EQ(err.at("error_code").as_uint64(), rpc::RippledError::rpcINVALID_PARAMS);
         EXPECT_EQ(err.at("error_message").as_string(), "Invalid parameters.");
-        EXPECT_EQ(err.at("error_code").as_uint64(), 31);
     });
 }
 

--- a/tests/unit/rpc/handlers/TxTests.cpp
+++ b/tests/unit/rpc/handlers/TxTests.cpp
@@ -834,8 +834,8 @@ TEST_F(RPCTxTest, CTIDNotMatch)
         ASSERT_FALSE(output);
 
         auto const err = rpc::makeError(output.result.error());
-        // TODO: https://github.com/XRPLF/clio/issues/2002
-        EXPECT_EQ(err.at("error_code").as_uint64(), 4);
+        EXPECT_EQ(err.at("error").as_string(), "unknown");
+        EXPECT_EQ(err.at("error_code").as_uint64(), rpc::RippledError::rpcWRONG_NETWORK);
         EXPECT_EQ(
             err.at("error_message").as_string(),
             "Wrong network. You should submit this request to a node running on NetworkID: 2"

--- a/tests/unit/web/RPCServerHandlerTests.cpp
+++ b/tests/unit/web/RPCServerHandlerTests.cpp
@@ -914,10 +914,13 @@ TEST_P(WebRPCServerHandlerInvalidAPIVersionParamTest, WSInvalidAPIVersion)
 
     auto response = boost::json::parse(session->message);
     EXPECT_TRUE(response.is_object());
+
     EXPECT_TRUE(response.as_object().contains("error"));
     EXPECT_EQ(response.at("error").as_string(), "invalid_API_version");
-    EXPECT_TRUE(response.as_object().contains("error_message"));
-    EXPECT_EQ(response.at("error_message").as_string(), GetParam().wsMessage);
+
     EXPECT_TRUE(response.as_object().contains("error_code"));
     EXPECT_EQ(response.at("error_code").as_int64(), static_cast<int64_t>(rpc::ClioError::RpcInvalidApiVersion));
+
+    EXPECT_TRUE(response.as_object().contains("error_message"));
+    EXPECT_EQ(response.at("error_message").as_string(), GetParam().wsMessage);
 }


### PR DESCRIPTION
Fix: https://github.com/XRPLF/clio/issues/2002