### PR TITLE
ci: Fix time field to be string in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -37,7 +37,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -53,7 +53,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -69,7 +69,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -85,7 +85,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -101,7 +101,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -117,7 +117,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -133,7 +133,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -149,7 +149,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -165,7 +165,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -181,7 +181,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft
@@ -197,7 +197,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 04:00
+      time: "04:00"
       timezone: Etc/GMT
     reviewers:
       - godexsoft


### PR DESCRIPTION
Sorry, it seems to have been the wrong change.
I pushed this to `develop` in my fork, enabled Dependabot there and PRs were created in my fork.

Close: https://github.com/XRPLF/clio/issues/2022