### PR TITLE
fix: Use ytanikin/pr-conventional-commits action for conventional com…

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -1,4 +1,5 @@
 name: Check PR title
+
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -7,12 +8,9 @@ on:
 jobs:
   check_title:
     runs-on: ubuntu-latest
-    # permissions:
-    #   pull-requests: write
     steps:
-      - uses: ytanikin/PRConventionalCommits@b628c5a234cc32513014b7bfdd1e47b532124d98 #v1.3.0
+      - uses: ytanikin/pr-conventional-commits@8267db1bacc237419f9ed0228bb9d94e94271a1d #v1.4.1
         with:
           task_types: '["build","feat","fix","docs","test","ci","style","refactor","perf","chore"]'
-          add_label: false
-          # Turned off labelling because it leads to an error, see https://github.com/ytanikin/PRConventionalCommits/issues/19
-          # custom_labels: '{"build":"build", "feat":"enhancement", "fix":"bug", "docs":"documentation", "test":"testability", "ci":"ci", "style":"refactoring", "refactor":"refactoring", "perf":"performance", "chore":"tooling"}'
+          add_label: true
+          custom_labels: '{"build":"build", "feat":"enhancement", "fix":"bug", "docs":"documentation", "test":"testability", "ci":"ci", "style":"refactoring", "refactor":"refactoring", "perf":"performance", "chore":"tooling"}'


### PR DESCRIPTION
…mits check

There are 2 actions with almost the same name from the same author:
- https://github.com/ytanikin/PRConventionalCommits: the one we use, not updated for 7 months
- https://github.com/ytanikin/pr-conventional-commits: seems to be more recent, has more stars and releases

I've merged this change to my develop branch in my fork and created a PR on to test it works: https://github.com/mathbunnyru/clio/pull/3

I will update the upstream issue and suggest author to archive the old action: https://github.com/ytanikin/pr-conventional-commits/issues/19