### PR TITLE
test: Remove SetUp and TearDown methods in tests

### DIFF
--- a/tests/integration/data/BackendFactoryTests.cpp
+++ b/tests/integration/data/BackendFactoryTests.cpp
@@ -85,8 +85,7 @@ protected:
 
 class BackendCassandraFactoryTestWithDB : public BackendCassandraFactoryTest {
 protected:
-    void
-    TearDown() override
+    ~BackendCassandraFactoryTestWithDB()
     {
         // drop the keyspace for next test
         data::cassandra::Handle const handle{TestGlobals::instance().backendHost};

--- a/tests/integration/data/cassandra/BackendTests.cpp
+++ b/tests/integration/data/cassandra/BackendTests.cpp
@@ -111,26 +111,17 @@ protected:
 
     // recreated for each test
     data::LedgerCache cache_;
-    std::unique_ptr<BackendInterface> backend_;
+    std::unique_ptr<BackendInterface> backend_{std::make_unique<CassandraBackend>(settingsProvider_, cache_, false)};
 
-    void
-    SetUp() override
-    {
-        SyncAsioContextTest::SetUp();
-        backend_ = std::make_unique<CassandraBackend>(settingsProvider_, cache_, false);
-    }
-    void
-    TearDown() override
-    {
-        backend_.reset();
+    std::default_random_engine randomEngine_{0};
 
+    ~BackendCassandraTest()
+    {
         // drop the keyspace for next test
         Handle const handle{TestGlobals::instance().backendHost};
         EXPECT_TRUE(handle.connect());
         handle.execute("DROP KEYSPACE " + TestGlobals::instance().backendKeyspace);
     }
-
-    std::default_random_engine randomEngine_{0};
 };
 
 TEST_F(BackendCassandraTest, Basic)

--- a/tests/integration/migration/cassandra/CassandraMigrationManagerTests.cpp
+++ b/tests/integration/migration/cassandra/CassandraMigrationManagerTests.cpp
@@ -155,8 +155,7 @@ protected:
         setupDatabase();
     }
 
-    void
-    TearDown() override
+    ~MigrationCassandraSimpleTest()
     {
         // drop the keyspace
         Handle const handle{TestGlobals::instance().backendHost};

--- a/tests/unit/etl/LedgerPublisherTests.cpp
+++ b/tests/unit/etl/LedgerPublisherTests.cpp
@@ -55,17 +55,6 @@ constexpr auto kAGE = 800;
 }  // namespace
 
 struct ETLLedgerPublisherTest : util::prometheus::WithPrometheus, MockBackendTestStrict, SyncAsioContextTest {
-    void
-    SetUp() override
-    {
-        SyncAsioContextTest::SetUp();
-    }
-
-    void
-    TearDown() override
-    {
-        SyncAsioContextTest::TearDown();
-    }
     util::config::ClioConfigDefinition cfg{{}};
     MockLedgerCache mockCache;
     StrictMockSubscriptionManagerSharedPtr mockSubscriptionManagerPtr;

--- a/tests/unit/etl/TransformerTests.cpp
+++ b/tests/unit/etl/TransformerTests.cpp
@@ -60,19 +60,12 @@ struct ETLTransformerTest : util::prometheus::WithPrometheus, MockBackendTest {
     using TransformerType = etl::impl::
         Transformer<ExtractionDataPipeType, LedgerLoaderType, LedgerPublisherType, AmendmentBlockHandlerType>;
 
-    void
-    SetUp() override
+    ETLTransformerTest()
     {
         state_.isStopping = false;
         state_.writeConflict = false;
         state_.isReadOnly = false;
         state_.isWriting = false;
-    }
-
-    void
-    TearDown() override
-    {
-        transformer_.reset();
     }
 
 protected:

--- a/tests/unit/rpc/RPCHelpersTests.cpp
+++ b/tests/unit/rpc/RPCHelpersTests.cpp
@@ -86,16 +86,10 @@ constexpr auto kAMM_ID = 54321;
 }  // namespace
 
 class RPCHelpersTest : public util::prometheus::WithPrometheus, public MockBackendTest, public SyncAsioContextTest {
-    void
-    SetUp() override
+public:
+    RPCHelpersTest()
     {
         backend_->setRange(10, 300);
-        SyncAsioContextTest::SetUp();
-    }
-    void
-    TearDown() override
-    {
-        SyncAsioContextTest::TearDown();
     }
 
 protected:

--- a/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
+++ b/tests/unit/rpc/handlers/GetAggregatePriceTests.cpp
@@ -89,10 +89,8 @@ mockLedgerObject(
 
 class RPCGetAggregatePriceHandlerTest : public HandlerBaseTest {
 protected:
-    void
-    SetUp() override
+    RPCGetAggregatePriceHandlerTest()
     {
-        HandlerBaseTest::SetUp();
         backend_->setRange(kRANGE_MIN, kRANGE_MAX);
     }
 };

--- a/tests/unit/rpc/handlers/ServerInfoTests.cpp
+++ b/tests/unit/rpc/handlers/ServerInfoTests.cpp
@@ -56,22 +56,9 @@ constexpr auto kCLIENT_IP = "1.1.1.1";
 }  // namespace
 
 struct RPCServerInfoHandlerTest : HandlerBaseTest, MockLoadBalancerTest, MockCountersTest {
-    void
-    SetUp() override
+    RPCServerInfoHandlerTest()
     {
-        HandlerBaseTest::SetUp();
-        MockLoadBalancerTest::SetUp();
-        MockCountersTest::SetUp();
-
         backend_->setRange(10, 30);
-    }
-
-    void
-    TearDown() override
-    {
-        MockCountersTest::TearDown();
-        MockLoadBalancerTest::TearDown();
-        HandlerBaseTest::TearDown();
     }
 
     static void


### PR DESCRIPTION
Fix: https://github.com/XRPLF/clio/issues/910