### PR TITLE
fix: Guarantee async behaviour of WsBase::send

### DIFF
--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -173,7 +173,8 @@ public:
     void
     send(std::shared_ptr<std::string> msg) override
     {
-        boost::asio::dispatch(
+        // Note: post used instead of dispatch to guarantee async behavior of wsFail and maybeSendNext
+        boost::asio::post(
             derived().ws().get_executor(),
             [this, self = derived().shared_from_this(), msg = std::move(msg)]() {
                 if (messages_.size() > maxSendingQueueSize_) {


### PR DESCRIPTION
`dispatch` can (and sometimes will) execute the otherwise async code on the thread of the caller if it's already on the same `io_context`. `wsFail` closes the socket if an error happened which can happen while the Subscription subsystem is publishing something into the same socket and hence holding the lock that is also required to unsubscribe once the connection is no longer needed. This can lead to double locking and things hang indefinitely.