### PR TITLE
ci: Attempt to remove whitespace to fix sanitizer build

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -83,6 +83,6 @@ runs:
         cmake \
           -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \
           -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-          "$(echo '${SANITIZER_OPTION}' | xargs echo -n)" \
+          "$(echo \"${SANITIZER_OPTION}\" | xargs echo -n)" \
           .. \
           -G Ninja

--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -83,6 +83,6 @@ runs:
         cmake \
           -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \
           -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-          "${SANITIZER_OPTION}" \
+          "$(echo '${SANITIZER_OPTION}' | xargs echo -n)" \
           .. \
           -G Ninja

--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       env:
         BUILD_TYPE: "${{ inputs.build_type }}"
-        SANITIZER_OPTION: |
+        SANITIZER_OPTION: |-
           ${{ inputs.sanitizer == 'tsan' && '-Dsan=thread' ||
               inputs.sanitizer == 'ubsan' && '-Dsan=undefined' ||
               inputs.sanitizer == 'asan' && '-Dsan=address' ||
@@ -83,6 +83,6 @@ runs:
         cmake \
           -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \
           -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-          "$(echo \"${SANITIZER_OPTION}\" | xargs echo -n)" \
+          "${SANITIZER_OPTION}" \
           .. \
           -G Ninja

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,5 +1,5 @@
 name: Run tests with sanitizers
-# remove me
+
 on:
   schedule:
     - cron: "0 4 * * 1-5"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,5 +1,5 @@
 name: Run tests with sanitizers
-
+# remove me
 on:
   schedule:
     - cron: "0 4 * * 1-5"


### PR DESCRIPTION
Let's see if this does the trick. 
Alternatives are
- more complicated cleanup using sed or similar
- don't multiline the expression (e.g. "${{ multiline expression becomes single line }}")
- don't wrap `SANITIZER_OPTION` in double quotes (like it was before)
- something else that i did not find - let me know if you know