### PR TITLE
fix: Add Delegate to Ledger types

### DIFF
--- a/src/util/LedgerUtils.hpp
+++ b/src/util/LedgerUtils.hpp
@@ -118,6 +118,7 @@ class LedgerTypes {
         LedgerTypeAttribute::deletionBlockerLedgerType(JS(mpt_issuance), ripple::ltMPTOKEN_ISSUANCE),
         LedgerTypeAttribute::deletionBlockerLedgerType(JS(mptoken), ripple::ltMPTOKEN),
         LedgerTypeAttribute::deletionBlockerLedgerType(JS(permissioned_domain), ripple::ltPERMISSIONED_DOMAIN),
+        LedgerTypeAttribute::accountOwnedLedgerType(JS(delegate), ripple::ltDELEGATE),
     };
 
 public:

--- a/tests/unit/util/LedgerUtilsTests.cpp
+++ b/tests/unit/util/LedgerUtilsTests.cpp
@@ -57,7 +57,8 @@ TEST(LedgerUtilsTests, LedgerObjectTypeList)
         JS(permissioned_domain),
         JS(oracle),
         JS(credential),
-        JS(nunl)
+        JS(nunl),
+        JS(delegate)
     };
 
     static_assert(std::size(kTYPES_LIST) == kTYPES.size());
@@ -91,6 +92,7 @@ TEST(LedgerUtilsTests, AccountOwnedTypeList)
         JS(mpt_issuance),
         JS(mptoken),
         JS(permissioned_domain),
+        JS(delegate)
     };
 
     static_assert(std::size(kCORRECT_TYPES) == kACCOUNT_OWNED.size());


### PR DESCRIPTION
Fix discrepancy with rippled for `account_objects` API.