### PR TITLE
fix: Use UniformRandomGenerator class to prevent threading issue

### DIFF
--- a/benchmarks/util/async/ExecutionContextBenchmarks.cpp
+++ b/benchmarks/util/async/ExecutionContextBenchmarks.cpp
@@ -191,9 +191,9 @@ generateData()
     constexpr auto kTOTAL = 10'000;
     std::vector<uint64_t> data;
     data.reserve(kTOTAL);
-    util::UniformRandomGenerator urng;
+    util::MTRandomGenerator randomGenerator;
     for (auto i = 0; i < kTOTAL; ++i)
-        data.push_back(urng.uniform(1, 100'000'000));
+        data.push_back(randomGenerator.uniform(1, 100'000'000));
 
     return data;
 }

--- a/benchmarks/util/async/ExecutionContextBenchmarks.cpp
+++ b/benchmarks/util/async/ExecutionContextBenchmarks.cpp
@@ -191,8 +191,9 @@ generateData()
     constexpr auto kTOTAL = 10'000;
     std::vector<uint64_t> data;
     data.reserve(kTOTAL);
+    util::UniformRandomGenerator urng;
     for (auto i = 0; i < kTOTAL; ++i)
-        data.push_back(util::Random::uniform(1, 100'000'000));
+        data.push_back(urng.uniform(1, 100'000'000));
 
     return data;
 }

--- a/src/app/ClioApplication.cpp
+++ b/src/app/ClioApplication.cpp
@@ -139,8 +139,6 @@ ClioApplication::run(bool const useNgWebServer)
     // Tracks which ledgers have been validated by the network
     auto ledgers = etl::NetworkValidatedLedgers::makeValidatedLedgers();
 
-    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
-
     // Handles the connection to one or more rippled nodes.
     // ETL uses the balancer to extract data.
     // The server uses the balancer to forward RPCs to a rippled node.
@@ -148,11 +146,11 @@ ClioApplication::run(bool const useNgWebServer)
     auto balancer = [&] -> std::shared_ptr<etlng::LoadBalancerInterface> {
         if (config_.get<bool>("__ng_etl"))
             return etlng::LoadBalancer::makeLoadBalancer(
-                config_, ioc, backend, subscriptions, std::move(randomGenerator), ledgers
+                config_, ioc, backend, subscriptions, std::make_unique<util::MTRandomGenerator>(), ledgers
             );
 
         return etl::LoadBalancer::makeLoadBalancer(
-            config_, ioc, backend, subscriptions, std::move(randomGenerator), ledgers
+            config_, ioc, backend, subscriptions, std::make_unique<util::MTRandomGenerator>(), ledgers
         );
     }();
 

--- a/src/app/ClioApplication.cpp
+++ b/src/app/ClioApplication.cpp
@@ -139,15 +139,21 @@ ClioApplication::run(bool const useNgWebServer)
     // Tracks which ledgers have been validated by the network
     auto ledgers = etl::NetworkValidatedLedgers::makeValidatedLedgers();
 
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
+
     // Handles the connection to one or more rippled nodes.
     // ETL uses the balancer to extract data.
     // The server uses the balancer to forward RPCs to a rippled node.
     // The balancer itself publishes to streams (transactions_proposed and accounts_proposed)
     auto balancer = [&] -> std::shared_ptr<etlng::LoadBalancerInterface> {
         if (config_.get<bool>("__ng_etl"))
-            return etlng::LoadBalancer::makeLoadBalancer(config_, ioc, backend, subscriptions, ledgers);
+            return etlng::LoadBalancer::makeLoadBalancer(
+                config_, ioc, backend, subscriptions, std::move(randomGenerator), ledgers
+            );
 
-        return etl::LoadBalancer::makeLoadBalancer(config_, ioc, backend, subscriptions, ledgers);
+        return etl::LoadBalancer::makeLoadBalancer(
+            config_, ioc, backend, subscriptions, std::move(randomGenerator), ledgers
+        );
     }();
 
     // ETL is responsible for writing and publishing to streams. In read-only mode, ETL only publishes

--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -314,12 +314,18 @@ LoadBalancer::toJson() const
     return ret;
 }
 
+void
+LoadBalancer::setSeed(size_t seed)
+{
+    urng_.setSeed(seed);
+}
+
 template <typename Func>
 void
 LoadBalancer::execute(Func f, uint32_t ledgerSequence, std::chrono::steady_clock::duration retryAfter)
 {
     ASSERT(not sources_.empty(), "ETL sources must be configured to execute functions.");
-    size_t sourceIdx = util::Random::uniform(0ul, sources_.size() - 1);
+    size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
 
     size_t numAttempts = 0;
 
@@ -403,7 +409,7 @@ LoadBalancer::forwardToRippledImpl(
     ++forwardingCounters_.cacheMiss.get();
 
     ASSERT(not sources_.empty(), "ETL sources must be configured to forward requests.");
-    std::size_t sourceIdx = util::Random::uniform(0ul, sources_.size() - 1);
+    std::size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
 
     auto numAttempts = 0u;
 

--- a/src/etl/LoadBalancer.cpp
+++ b/src/etl/LoadBalancer.cpp
@@ -71,12 +71,19 @@ LoadBalancer::makeLoadBalancer(
     boost::asio::io_context& ioc,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
     std::shared_ptr<NetworkValidatedLedgersInterface> validatedLedgers,
     SourceFactory sourceFactory
 )
 {
     return std::make_shared<LoadBalancer>(
-        config, ioc, std::move(backend), std::move(subscriptions), std::move(validatedLedgers), std::move(sourceFactory)
+        config,
+        ioc,
+        std::move(backend),
+        std::move(subscriptions),
+        std::move(randomGenerator),
+        std::move(validatedLedgers),
+        std::move(sourceFactory)
     );
 }
 
@@ -85,10 +92,12 @@ LoadBalancer::LoadBalancer(
     boost::asio::io_context& ioc,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
     std::shared_ptr<NetworkValidatedLedgersInterface> validatedLedgers,
     SourceFactory sourceFactory
 )
-    : forwardingCounters_{
+    : randomGenerator_(std::move(randomGenerator))
+    , forwardingCounters_{
           .successDuration = PrometheusService::counterInt(
               "forwarding_duration_milliseconds_counter",
               Labels({util::prometheus::Label{"status", "success"}}),
@@ -314,18 +323,12 @@ LoadBalancer::toJson() const
     return ret;
 }
 
-void
-LoadBalancer::setSeed(size_t seed)
-{
-    urng_.setSeed(seed);
-}
-
 template <typename Func>
 void
 LoadBalancer::execute(Func f, uint32_t ledgerSequence, std::chrono::steady_clock::duration retryAfter)
 {
     ASSERT(not sources_.empty(), "ETL sources must be configured to execute functions.");
-    size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
+    size_t sourceIdx = randomGenerator_->uniform(0ul, sources_.size() - 1);
 
     size_t numAttempts = 0;
 
@@ -409,7 +412,7 @@ LoadBalancer::forwardToRippledImpl(
     ++forwardingCounters_.cacheMiss.get();
 
     ASSERT(not sources_.empty(), "ETL sources must be configured to forward requests.");
-    std::size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
+    std::size_t sourceIdx = randomGenerator_->uniform(0ul, sources_.size() - 1);
 
     auto numAttempts = 0u;
 

--- a/src/etl/LoadBalancer.hpp
+++ b/src/etl/LoadBalancer.hpp
@@ -29,6 +29,7 @@
 #include "rpc/Errors.hpp"
 #include "util/Assert.hpp"
 #include "util/Mutex.hpp"
+#include "util/Random.hpp"
 #include "util/ResponseExpirationCache.hpp"
 #include "util/config/ConfigDefinition.hpp"
 #include "util/log/Logger.hpp"
@@ -87,6 +88,8 @@ private:
     // Forwarding cache must be destroyed after sources because sources have a callback to invalidate cache
     std::optional<util::ResponseExpirationCache> forwardingCache_;
     std::optional<std::string> forwardingXUserValue_;
+
+    util::UniformRandomGenerator urng_ = {};
 
     std::vector<SourcePtr> sources_;
     std::optional<ETLState> etlState_;
@@ -249,6 +252,14 @@ public:
      */
     void
     stop(boost::asio::yield_context yield) override;
+
+    /**
+     * @brief Set the seed for the random number generator.
+     * @param seed Seed to set
+     * @note This function is only used in tests.
+     */
+    void
+    setSeed(size_t seed);
 
 private:
     /**

--- a/src/etl/LoadBalancer.hpp
+++ b/src/etl/LoadBalancer.hpp
@@ -89,7 +89,7 @@ private:
     std::optional<util::ResponseExpirationCache> forwardingCache_;
     std::optional<std::string> forwardingXUserValue_;
 
-    util::UniformRandomGenerator urng_ = {};
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator_;
 
     std::vector<SourcePtr> sources_;
     std::optional<ETLState> etlState_;
@@ -126,6 +126,7 @@ public:
      * @param ioc The io_context to run on
      * @param backend BackendInterface implementation
      * @param subscriptions Subscription manager
+     * @param randomGenerator A random generator to use for selecting sources
      * @param validatedLedgers The network validated ledgers datastructure
      * @param sourceFactory A factory function to create a source
      */
@@ -134,6 +135,7 @@ public:
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
         std::shared_ptr<NetworkValidatedLedgersInterface> validatedLedgers,
         SourceFactory sourceFactory = makeSource
     );
@@ -145,6 +147,7 @@ public:
      * @param ioc The io_context to run on
      * @param backend BackendInterface implementation
      * @param subscriptions Subscription manager
+     * @param randomGenerator A random generator to use for selecting sources
      * @param validatedLedgers The network validated ledgers data structure
      * @param sourceFactory A factory function to create a source
      * @return A shared pointer to a new instance of LoadBalancer
@@ -155,6 +158,7 @@ public:
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
         std::shared_ptr<NetworkValidatedLedgersInterface> validatedLedgers,
         SourceFactory sourceFactory = makeSource
     );
@@ -252,14 +256,6 @@ public:
      */
     void
     stop(boost::asio::yield_context yield) override;
-
-    /**
-     * @brief Set the seed for the random number generator.
-     * @param seed Seed to set
-     * @note This function is only used in tests.
-     */
-    void
-    setSeed(size_t seed);
 
 private:
     /**

--- a/src/etlng/LoadBalancer.cpp
+++ b/src/etlng/LoadBalancer.cpp
@@ -72,12 +72,19 @@ LoadBalancer::makeLoadBalancer(
     boost::asio::io_context& ioc,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
     std::shared_ptr<etl::NetworkValidatedLedgersInterface> validatedLedgers,
     SourceFactory sourceFactory
 )
 {
     return std::make_shared<LoadBalancer>(
-        config, ioc, std::move(backend), std::move(subscriptions), std::move(validatedLedgers), std::move(sourceFactory)
+        config,
+        ioc,
+        std::move(backend),
+        std::move(subscriptions),
+        std::move(randomGenerator),
+        std::move(validatedLedgers),
+        std::move(sourceFactory)
     );
 }
 
@@ -86,10 +93,12 @@ LoadBalancer::LoadBalancer(
     boost::asio::io_context& ioc,
     std::shared_ptr<BackendInterface> backend,
     std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
     std::shared_ptr<etl::NetworkValidatedLedgersInterface> validatedLedgers,
     SourceFactory sourceFactory
 )
-    : forwardingCounters_{
+    : randomGenerator_(std::move(randomGenerator))
+    , forwardingCounters_{
           .successDuration = PrometheusService::counterInt(
               "forwarding_duration_milliseconds_counter",
               Labels({util::prometheus::Label{"status", "success"}}),
@@ -318,18 +327,12 @@ LoadBalancer::toJson() const
     return ret;
 }
 
-void
-LoadBalancer::setSeed(size_t seed)
-{
-    urng_.setSeed(seed);
-}
-
 template <typename Func>
 void
 LoadBalancer::execute(Func f, uint32_t ledgerSequence, std::chrono::steady_clock::duration retryAfter)
 {
     ASSERT(not sources_.empty(), "ETL sources must be configured to execute functions.");
-    size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
+    size_t sourceIdx = randomGenerator_->uniform(0ul, sources_.size() - 1);
 
     size_t numAttempts = 0;
 
@@ -413,7 +416,7 @@ LoadBalancer::forwardToRippledImpl(
     ++forwardingCounters_.cacheMiss.get();
 
     ASSERT(not sources_.empty(), "ETL sources must be configured to forward requests.");
-    std::size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
+    std::size_t sourceIdx = randomGenerator_->uniform(0ul, sources_.size() - 1);
 
     auto numAttempts = 0u;
 

--- a/src/etlng/LoadBalancer.cpp
+++ b/src/etlng/LoadBalancer.cpp
@@ -318,12 +318,18 @@ LoadBalancer::toJson() const
     return ret;
 }
 
+void
+LoadBalancer::setSeed(size_t seed)
+{
+    urng_.setSeed(seed);
+}
+
 template <typename Func>
 void
 LoadBalancer::execute(Func f, uint32_t ledgerSequence, std::chrono::steady_clock::duration retryAfter)
 {
     ASSERT(not sources_.empty(), "ETL sources must be configured to execute functions.");
-    size_t sourceIdx = util::Random::uniform(0ul, sources_.size() - 1);
+    size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
 
     size_t numAttempts = 0;
 
@@ -407,7 +413,7 @@ LoadBalancer::forwardToRippledImpl(
     ++forwardingCounters_.cacheMiss.get();
 
     ASSERT(not sources_.empty(), "ETL sources must be configured to forward requests.");
-    std::size_t sourceIdx = util::Random::uniform(0ul, sources_.size() - 1);
+    std::size_t sourceIdx = urng_.uniform(0ul, sources_.size() - 1);
 
     auto numAttempts = 0u;
 

--- a/src/etlng/LoadBalancer.hpp
+++ b/src/etlng/LoadBalancer.hpp
@@ -29,6 +29,7 @@
 #include "rpc/Errors.hpp"
 #include "util/Assert.hpp"
 #include "util/Mutex.hpp"
+#include "util/Random.hpp"
 #include "util/ResponseExpirationCache.hpp"
 #include "util/config/ConfigDefinition.hpp"
 #include "util/log/Logger.hpp"
@@ -87,6 +88,8 @@ private:
     // Forwarding cache must be destroyed after sources because sources have a callback to invalidate cache
     std::optional<util::ResponseExpirationCache> forwardingCache_;
     std::optional<std::string> forwardingXUserValue_;
+
+    util::UniformRandomGenerator urng_ = {};
 
     std::vector<SourcePtr> sources_;
     std::optional<etl::ETLState> etlState_;
@@ -251,6 +254,14 @@ public:
      */
     void
     stop(boost::asio::yield_context yield) override;
+
+    /**
+     * @brief Set the seed for the random number generator.
+     * @param seed Seed to set
+     * @note This function is only used in tests.
+     */
+    void
+    setSeed(size_t seed);
 
 private:
     /**

--- a/src/etlng/LoadBalancer.hpp
+++ b/src/etlng/LoadBalancer.hpp
@@ -89,7 +89,7 @@ private:
     std::optional<util::ResponseExpirationCache> forwardingCache_;
     std::optional<std::string> forwardingXUserValue_;
 
-    util::UniformRandomGenerator urng_ = {};
+    std::unique_ptr<util::RandomGeneratorInterface> randomGenerator_;
 
     std::vector<SourcePtr> sources_;
     std::optional<etl::ETLState> etlState_;
@@ -126,6 +126,7 @@ public:
      * @param ioc The io_context to run on
      * @param backend BackendInterface implementation
      * @param subscriptions Subscription manager
+     * @param randomGenerator A random generator to use for selecting sources
      * @param validatedLedgers The network validated ledgers datastructure
      * @param sourceFactory A factory function to create a source
      */
@@ -134,6 +135,7 @@ public:
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
         std::shared_ptr<etl::NetworkValidatedLedgersInterface> validatedLedgers,
         SourceFactory sourceFactory = makeSource
     );
@@ -145,6 +147,7 @@ public:
      * @param ioc The io_context to run on
      * @param backend BackendInterface implementation
      * @param subscriptions Subscription manager
+     * @param randomGenerator A random generator to use for selecting sources
      * @param validatedLedgers The network validated ledgers datastructure
      * @param sourceFactory A factory function to create a source
      * @return A shared pointer to a new instance of LoadBalancer
@@ -155,6 +158,7 @@ public:
         boost::asio::io_context& ioc,
         std::shared_ptr<BackendInterface> backend,
         std::shared_ptr<feed::SubscriptionManagerInterface> subscriptions,
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator,
         std::shared_ptr<etl::NetworkValidatedLedgersInterface> validatedLedgers,
         SourceFactory sourceFactory = makeSource
     );
@@ -254,14 +258,6 @@ public:
      */
     void
     stop(boost::asio::yield_context yield) override;
-
-    /**
-     * @brief Set the seed for the random number generator.
-     * @param seed Seed to set
-     * @note This function is only used in tests.
-     */
-    void
-    setSeed(size_t seed);
 
 private:
     /**

--- a/src/util/Random.cpp
+++ b/src/util/Random.cpp
@@ -25,12 +25,15 @@
 
 namespace util {
 
-void
-Random::setSeed(size_t seed)
+UniformRandomGenerator::UniformRandomGenerator()
+    : generator_{std::chrono::system_clock::now().time_since_epoch().count()}
 {
-    generator.seed(seed);
 }
 
-std::mt19937_64 Random::generator{std::chrono::system_clock::now().time_since_epoch().count()};
+void
+UniformRandomGenerator::setSeed(size_t seed)
+{
+    generator_.seed(seed);
+}
 
 }  // namespace util

--- a/src/util/Random.cpp
+++ b/src/util/Random.cpp
@@ -25,13 +25,18 @@
 
 namespace util {
 
-UniformRandomGenerator::UniformRandomGenerator()
-    : generator_{std::chrono::system_clock::now().time_since_epoch().count()}
+MTRandomGenerator::MTRandomGenerator() : generator_{std::chrono::system_clock::now().time_since_epoch().count()}
 {
 }
 
+size_t
+MTRandomGenerator::uniform(size_t min, size_t max)
+{
+    return uniformImpl(min, max);
+}
+
 void
-UniformRandomGenerator::setSeed(size_t seed)
+MTRandomGenerator::setSeed(SeedType seed)
 {
     generator_.seed(seed);
 }

--- a/src/util/Random.hpp
+++ b/src/util/Random.hpp
@@ -26,10 +26,12 @@
 namespace util {
 
 /**
- * @brief Random number generator
+ * @brief Uniform random number generator
  */
-class Random {
+class UniformRandomGenerator {
 public:
+    UniformRandomGenerator();
+
     /**
      * @brief Generate a random number between min and max
      *
@@ -39,16 +41,16 @@ public:
      * @return Random number between min and max
      */
     template <typename T>
-    static T
+    T
     uniform(T min, T max)
     {
         ASSERT(min <= max, "Min cannot be greater than max. min: {}, max: {}", min, max);
         if constexpr (std::is_floating_point_v<T>) {
             std::uniform_real_distribution<T> distribution(min, max);
-            return distribution(generator);
+            return distribution(generator_);
         }
         std::uniform_int_distribution<T> distribution(min, max);
-        return distribution(generator);
+        return distribution(generator_);
     }
 
     /**
@@ -56,11 +58,11 @@ public:
      *
      * @param seed Seed to set
      */
-    static void
+    void
     setSeed(size_t seed);
 
 private:
-    static std::mt19937_64 generator;
+    std::mt19937_64 generator_;
 };
 
 }  // namespace util

--- a/src/util/Random.hpp
+++ b/src/util/Random.hpp
@@ -26,11 +26,49 @@
 namespace util {
 
 /**
- * @brief Uniform random number generator
+ * @brief Random number generator interface
  */
-class UniformRandomGenerator {
+class RandomGeneratorInterface {
 public:
-    UniformRandomGenerator();
+    virtual ~RandomGeneratorInterface() = default;
+
+    using SeedType = typename std::mt19937_64::result_type;
+
+    /**
+     * @brief Generate a random number between min and max
+     *
+     * @param min Minimum value
+     * @param max Maximum value
+     * @return Random number between min and max
+     */
+    virtual size_t
+    uniform(size_t min, size_t max) = 0;
+
+    /**
+     * @brief Set the seed for the random number generator
+     *
+     * @param seed Seed to set
+     */
+    virtual void
+    setSeed(SeedType seed) = 0;
+};
+
+/**
+ * @brief Mersenne Twister random number generator
+ */
+class MTRandomGenerator : public RandomGeneratorInterface {
+public:
+    MTRandomGenerator();
+
+    /**
+     * @brief Generate a random number between min and max
+     *
+     * @param min Minimum value
+     * @param max Maximum value
+     * @return Random number between min and max
+     */
+    size_t
+    uniform(size_t min, size_t max) override;
 
     /**
      * @brief Generate a random number between min and max
@@ -42,7 +80,7 @@ public:
      */
     template <typename T>
     T
-    uniform(T min, T max)
+    uniformImpl(T min, T max)
     {
         ASSERT(min <= max, "Min cannot be greater than max. min: {}, max: {}", min, max);
         if constexpr (std::is_floating_point_v<T>) {
@@ -59,10 +97,10 @@ public:
      * @param seed Seed to set
      */
     void
-    setSeed(size_t seed);
+    setSeed(SeedType seed) override;
 
 private:
-    std::mt19937_64 generator_;
+    std::mt19937_64 generator_ = {};
 };
 
 }  // namespace util

--- a/src/util/Random.hpp
+++ b/src/util/Random.hpp
@@ -100,7 +100,7 @@ public:
     setSeed(SeedType seed) override;
 
 private:
-    std::mt19937_64 generator_ = {};
+    std::mt19937_64 generator_;
 };
 
 }  // namespace util

--- a/src/util/Random.hpp
+++ b/src/util/Random.hpp
@@ -41,6 +41,7 @@ public:
      * @param max Maximum value
      * @return Random number between min and max
      */
+    [[nodiscard]]
     virtual size_t
     uniform(size_t min, size_t max) = 0;
 
@@ -67,6 +68,7 @@ public:
      * @param max Maximum value
      * @return Random number between min and max
      */
+    [[nodiscard]]
     size_t
     uniform(size_t min, size_t max) override;
 
@@ -79,6 +81,7 @@ public:
      * @return Random number between min and max
      */
     template <typename T>
+    [[nodiscard]]
     T
     uniformImpl(T min, T max)
     {

--- a/tests/common/util/MockRandomGenerator.hpp
+++ b/tests/common/util/MockRandomGenerator.hpp
@@ -20,7 +20,12 @@
 #pragma once
 #include "util/Random.hpp"
 
-struct MockRandomGenerator : public util::RandomGeneratorInterface {
+#include <gtest/gtest.h>
+
+struct MockRandomGeneratorImpl : public util::RandomGeneratorInterface {
     MOCK_METHOD(size_t, uniform, (size_t min, size_t max), (override));
     MOCK_METHOD(void, setSeed, (SeedType seed), (override));
 };
+
+using MockRandomGenerator = testing::NiceMock<MockRandomGeneratorImpl>;
+using StrictMockRandomGenerator = testing::StrictMock<MockRandomGeneratorImpl>;

--- a/tests/common/util/MockRandomGenerator.hpp
+++ b/tests/common/util/MockRandomGenerator.hpp
@@ -1,0 +1,26 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of clio: https://github.com/XRPLF/clio
+    Copyright (c) 2025, the clio developers.
+
+    Permission to use, copy, modify, and distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL,  DIRECT,  INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#pragma once
+#include "util/Random.hpp"
+
+struct MockRandomGenerator : public util::RandomGeneratorInterface {
+    MOCK_METHOD(size_t, uniform, (size_t min, size_t max), (override));
+    MOCK_METHOD(void, setSeed, (SeedType seed), (override));
+};

--- a/tests/integration/data/cassandra/BackendTests.cpp
+++ b/tests/integration/data/cassandra/BackendTests.cpp
@@ -624,6 +624,7 @@ TEST_F(BackendCassandraTest, Basic)
         };
         auto generateAccountTx = [&](uint32_t ledgerSequence, auto txns) {
             std::vector<AccountTransactionsData> ret;
+            util::UniformRandomGenerator urng;
             auto accounts = generateAccounts(ledgerSequence, 10);
             uint32_t idx = 0;
             for (auto& [hash, txn, meta] : txns) {
@@ -632,7 +633,7 @@ TEST_F(BackendCassandraTest, Basic)
                 data.transactionIndex = idx;
                 data.txHash = hash;
                 for (size_t i = 0; i < 3; ++i) {
-                    data.accounts.insert(accounts[util::Random::uniform(0ul, accounts.size() - 1)]);
+                    data.accounts.insert(accounts[urng.uniform(0ul, accounts.size() - 1)]);
                 }
                 ++idx;
                 ret.push_back(data);

--- a/tests/integration/data/cassandra/BackendTests.cpp
+++ b/tests/integration/data/cassandra/BackendTests.cpp
@@ -624,7 +624,7 @@ TEST_F(BackendCassandraTest, Basic)
         };
         auto generateAccountTx = [&](uint32_t ledgerSequence, auto txns) {
             std::vector<AccountTransactionsData> ret;
-            util::UniformRandomGenerator urng;
+            util::MTRandomGenerator randomGenerator;
             auto accounts = generateAccounts(ledgerSequence, 10);
             uint32_t idx = 0;
             for (auto& [hash, txn, meta] : txns) {
@@ -633,7 +633,7 @@ TEST_F(BackendCassandraTest, Basic)
                 data.transactionIndex = idx;
                 data.txHash = hash;
                 for (size_t i = 0; i < 3; ++i) {
-                    data.accounts.insert(accounts[urng.uniform(0ul, accounts.size() - 1)]);
+                    data.accounts.insert(accounts[randomGenerator.uniform(0ul, accounts.size() - 1)]);
                 }
                 ++idx;
                 ret.push_back(data);

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -123,7 +123,7 @@ struct LoadBalancerConstructorTests : util::prometheus::WithPrometheus, MockBack
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        return std::make_unique<LoadBalancer>(
+        auto lb = std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
             backend_,
@@ -131,6 +131,8 @@ struct LoadBalancerConstructorTests : util::prometheus::WithPrometheus, MockBack
             networkManager_,
             [this](auto&&... args) -> SourcePtr { return sourceFactory_(std::forward<decltype(args)>(args)...); }
         );
+        lb->setSeed(0);
+        return lb;
     }
 
 protected:
@@ -430,11 +432,6 @@ TEST_F(LoadBalancer3SourcesTests, forwardingUpdate)
 }
 
 struct LoadBalancerLoadInitialLedgerTests : LoadBalancerOnConnectHookTests {
-    LoadBalancerLoadInitialLedgerTests()
-    {
-        util::Random::setSeed(0);
-    }
-
 protected:
     uint32_t const sequence_ = 123;
     uint32_t const numMarkers_ = 16;
@@ -496,7 +493,6 @@ TEST_F(LoadBalancerLoadInitialLedgerCustomNumMarkersTests, loadInitialLedger)
     EXPECT_CALL(sourceFactory_.sourceAt(1), run);
     auto loadBalancer = makeLoadBalancer();
 
-    util::Random::setSeed(0);
     EXPECT_CALL(sourceFactory_.sourceAt(0), hasLedger(sequence_)).WillOnce(Return(true));
     EXPECT_CALL(sourceFactory_.sourceAt(0), loadInitialLedger(sequence_, numMarkers_)).WillOnce(Return(response_));
 
@@ -506,7 +502,6 @@ TEST_F(LoadBalancerLoadInitialLedgerCustomNumMarkersTests, loadInitialLedger)
 struct LoadBalancerFetchLegerTests : LoadBalancerOnConnectHookTests {
     LoadBalancerFetchLegerTests()
     {
-        util::Random::setSeed(0);
         response_.second.set_validated(true);
     }
 
@@ -580,7 +575,6 @@ TEST_F(LoadBalancerFetchLegerTests, fetch_bothSourcesFail)
 struct LoadBalancerForwardToRippledTests : LoadBalancerConstructorTests, SyncAsioContextTest {
     LoadBalancerForwardToRippledTests()
     {
-        util::Random::setSeed(0);
         EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(boost::json::object{}));
         EXPECT_CALL(sourceFactory_.sourceAt(0), run);
         EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(boost::json::object{}));

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -24,6 +24,7 @@
 #include "util/MockBackendTestFixture.hpp"
 #include "util/MockNetworkValidatedLedgers.hpp"
 #include "util/MockPrometheus.hpp"
+#include "util/MockRandomGenerator.hpp"
 #include "util/MockSource.hpp"
 #include "util/MockSubscriptionManager.hpp"
 #include "util/NameGenerator.hpp"
@@ -123,8 +124,10 @@ struct LoadBalancerConstructorTests : util::prometheus::WithPrometheus, MockBack
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
-        randomGenerator->setSeed(0);
+
+        auto randomGenerator = std::make_unique<MockRandomGenerator>();
+        randomGenerator_ = randomGenerator.get();
+
         return std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
@@ -137,6 +140,7 @@ struct LoadBalancerConstructorTests : util::prometheus::WithPrometheus, MockBack
     }
 
 protected:
+    MockRandomGenerator* randomGenerator_ = nullptr;
     StrictMockSubscriptionManagerSharedPtr subscriptionManager_;
     StrictMockNetworkValidatedLedgersPtr networkManager_;
     StrictMockSourceFactory sourceFactory_{2};
@@ -809,6 +813,7 @@ TEST_F(LoadBalancerForwardToRippledTests, onLedgerClosedHookInvalidatesCache)
 
     auto const request = boost::json::object{{"command", "server_info"}};
 
+    EXPECT_CALL(*randomGenerator_, uniform(0, 1)).WillOnce(Return(0)).WillOnce(Return(1));
     EXPECT_CALL(
         sourceFactory_.sourceAt(0),
         forwardToRippled(request, clientIP_, LoadBalancer::kUSER_FORWARDING_X_USER_VALUE, testing::_)

--- a/tests/unit/etl/LoadBalancerTests.cpp
+++ b/tests/unit/etl/LoadBalancerTests.cpp
@@ -123,16 +123,17 @@ struct LoadBalancerConstructorTests : util::prometheus::WithPrometheus, MockBack
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        auto lb = std::make_unique<LoadBalancer>(
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
+        randomGenerator->setSeed(0);
+        return std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
             backend_,
             subscriptionManager_,
+            std::move(randomGenerator),
             networkManager_,
             [this](auto&&... args) -> SourcePtr { return sourceFactory_(std::forward<decltype(args)>(args)...); }
         );
-        lb->setSeed(0);
-        return lb;
     }
 
 protected:

--- a/tests/unit/etlng/LoadBalancerTests.cpp
+++ b/tests/unit/etlng/LoadBalancerTests.cpp
@@ -26,6 +26,7 @@
 #include "util/MockBackendTestFixture.hpp"
 #include "util/MockNetworkValidatedLedgers.hpp"
 #include "util/MockPrometheus.hpp"
+#include "util/MockRandomGenerator.hpp"
 #include "util/MockSourceNg.hpp"
 #include "util/MockSubscriptionManager.hpp"
 #include "util/NameGenerator.hpp"
@@ -144,8 +145,10 @@ struct LoadBalancerConstructorNgTests : util::prometheus::WithPrometheus, MockBa
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
-        randomGenerator->setSeed(0);
+
+        auto randomGenerator = std::make_unique<MockRandomGenerator>();
+        randomGenerator_ = randomGenerator.get();
+
         return std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
@@ -158,6 +161,7 @@ struct LoadBalancerConstructorNgTests : util::prometheus::WithPrometheus, MockBa
     }
 
 protected:
+    MockRandomGenerator* randomGenerator_ = nullptr;
     StrictMockSubscriptionManagerSharedPtr subscriptionManager_;
     StrictMockNetworkValidatedLedgersPtr networkManager_;
     StrictMockSourceNgFactory sourceFactory_{2};
@@ -835,6 +839,8 @@ TEST_F(LoadBalancerForwardToRippledNgTests, onLedgerClosedHookInvalidatesCache)
     auto loadBalancer = makeLoadBalancer();
 
     auto const request = boost::json::object{{"command", "server_info"}};
+
+    EXPECT_CALL(*randomGenerator_, uniform(0, 1)).WillOnce(Return(0)).WillOnce(Return(1));
 
     EXPECT_CALL(
         sourceFactory_.sourceAt(0),

--- a/tests/unit/etlng/LoadBalancerTests.cpp
+++ b/tests/unit/etlng/LoadBalancerTests.cpp
@@ -144,7 +144,7 @@ struct LoadBalancerConstructorNgTests : util::prometheus::WithPrometheus, MockBa
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        return std::make_unique<LoadBalancer>(
+        auto lb = std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
             backend_,
@@ -152,6 +152,8 @@ struct LoadBalancerConstructorNgTests : util::prometheus::WithPrometheus, MockBa
             networkManager_,
             [this](auto&&... args) -> SourcePtr { return sourceFactory_(std::forward<decltype(args)>(args)...); }
         );
+        lb->setSeed(0);
+        return lb;
     }
 
 protected:
@@ -450,11 +452,6 @@ TEST_F(LoadBalancer3SourcesNgTests, forwardingUpdate)
 }
 
 struct LoadBalancerLoadInitialLedgerNgTests : LoadBalancerOnConnectHookNgTests {
-    LoadBalancerLoadInitialLedgerNgTests()
-    {
-        util::Random::setSeed(0);
-    }
-
 protected:
     uint32_t const sequence_ = 123;
     uint32_t const numMarkers_ = 16;
@@ -522,7 +519,6 @@ TEST_F(LoadBalancerLoadInitialLedgerCustomNumMarkersNgTests, loadInitialLedger)
     EXPECT_CALL(sourceFactory_.sourceAt(1), run);
     auto loadBalancer = makeLoadBalancer();
 
-    util::Random::setSeed(0);
     EXPECT_CALL(sourceFactory_.sourceAt(0), hasLedger(sequence_)).WillOnce(Return(true));
     EXPECT_CALL(sourceFactory_.sourceAt(0), loadInitialLedger(sequence_, numMarkers_, testing::_))
         .WillOnce(Return(response_));
@@ -533,7 +529,6 @@ TEST_F(LoadBalancerLoadInitialLedgerCustomNumMarkersNgTests, loadInitialLedger)
 struct LoadBalancerFetchLegerNgTests : LoadBalancerOnConnectHookNgTests {
     LoadBalancerFetchLegerNgTests()
     {
-        util::Random::setSeed(0);
         response_.second.set_validated(true);
     }
 
@@ -607,7 +602,6 @@ TEST_F(LoadBalancerFetchLegerNgTests, fetch_bothSourcesFail)
 struct LoadBalancerForwardToRippledNgTests : LoadBalancerConstructorNgTests, SyncAsioContextTest {
     LoadBalancerForwardToRippledNgTests()
     {
-        util::Random::setSeed(0);
         EXPECT_CALL(sourceFactory_.sourceAt(0), forwardToRippled).WillOnce(Return(boost::json::object{}));
         EXPECT_CALL(sourceFactory_.sourceAt(0), run);
         EXPECT_CALL(sourceFactory_.sourceAt(1), forwardToRippled).WillOnce(Return(boost::json::object{}));

--- a/tests/unit/etlng/LoadBalancerTests.cpp
+++ b/tests/unit/etlng/LoadBalancerTests.cpp
@@ -144,16 +144,17 @@ struct LoadBalancerConstructorNgTests : util::prometheus::WithPrometheus, MockBa
     makeLoadBalancer()
     {
         auto const cfg = getParseLoadBalancerConfig(configJson_);
-        auto lb = std::make_unique<LoadBalancer>(
+        std::unique_ptr<util::RandomGeneratorInterface> randomGenerator = std::make_unique<util::MTRandomGenerator>();
+        randomGenerator->setSeed(0);
+        return std::make_unique<LoadBalancer>(
             cfg,
             ioContext_,
             backend_,
             subscriptionManager_,
+            std::move(randomGenerator),
             networkManager_,
             [this](auto&&... args) -> SourcePtr { return sourceFactory_(std::forward<decltype(args)>(args)...); }
         );
-        lb->setSeed(0);
-        return lb;
     }
 
 protected:

--- a/tests/unit/util/RandomTests.cpp
+++ b/tests/unit/util/RandomTests.cpp
@@ -30,18 +30,19 @@ using namespace util;
 
 struct RandomTests : public ::testing::Test {
     static std::vector<int>
-    generateRandoms(size_t const numRandoms = 1000)
+    generateRandoms(UniformRandomGenerator& urng, size_t const numRandoms = 1000)
     {
         std::vector<int> v;
         v.reserve(numRandoms);
-        std::ranges::generate_n(std::back_inserter(v), numRandoms, []() { return Random::uniform(0, 1000); });
+        std::ranges::generate_n(std::back_inserter(v), numRandoms, [&urng]() { return urng.uniform(0, 1000); });
         return v;
     }
 };
 
 TEST_F(RandomTests, Uniform)
 {
-    std::ranges::for_each(generateRandoms(), [](int const& e) {
+    UniformRandomGenerator urng;
+    std::ranges::for_each(generateRandoms(urng), [](int const& e) {
         EXPECT_GE(e, 0);
         EXPECT_LE(e, 1000);
     });
@@ -49,11 +50,13 @@ TEST_F(RandomTests, Uniform)
 
 TEST_F(RandomTests, FixedSeed)
 {
-    Random::setSeed(42);
-    std::vector<int> const v1 = generateRandoms();
+    UniformRandomGenerator urng;
 
-    Random::setSeed(42);
-    std::vector<int> const v2 = generateRandoms();
+    urng.setSeed(42);
+    std::vector<int> const v1 = generateRandoms(urng);
+
+    urng.setSeed(42);
+    std::vector<int> const v2 = generateRandoms(urng);
 
     ASSERT_EQ(v1.size(), v2.size());
     for (size_t i = 0; i < v1.size(); ++i) {

--- a/tests/unit/util/RandomTests.cpp
+++ b/tests/unit/util/RandomTests.cpp
@@ -30,19 +30,21 @@ using namespace util;
 
 struct RandomTests : public ::testing::Test {
     static std::vector<int>
-    generateRandoms(UniformRandomGenerator& urng, size_t const numRandoms = 1000)
+    generateRandoms(MTRandomGenerator& randomGenerator, size_t const numRandoms = 1000)
     {
         std::vector<int> v;
         v.reserve(numRandoms);
-        std::ranges::generate_n(std::back_inserter(v), numRandoms, [&urng]() { return urng.uniform(0, 1000); });
+        std::ranges::generate_n(std::back_inserter(v), numRandoms, [&randomGenerator]() {
+            return randomGenerator.uniform(0, 1000);
+        });
         return v;
     }
 };
 
 TEST_F(RandomTests, Uniform)
 {
-    UniformRandomGenerator urng;
-    std::ranges::for_each(generateRandoms(urng), [](int const& e) {
+    MTRandomGenerator randomGenerator;
+    std::ranges::for_each(generateRandoms(randomGenerator), [](int const& e) {
         EXPECT_GE(e, 0);
         EXPECT_LE(e, 1000);
     });
@@ -50,13 +52,13 @@ TEST_F(RandomTests, Uniform)
 
 TEST_F(RandomTests, FixedSeed)
 {
-    UniformRandomGenerator urng;
+    MTRandomGenerator randomGenerator;
 
-    urng.setSeed(42);
-    std::vector<int> const v1 = generateRandoms(urng);
+    randomGenerator.setSeed(42);
+    std::vector<int> const v1 = generateRandoms(randomGenerator);
 
-    urng.setSeed(42);
-    std::vector<int> const v2 = generateRandoms(urng);
+    randomGenerator.setSeed(42);
+    std::vector<int> const v2 = generateRandoms(randomGenerator);
 
     ASSERT_EQ(v1.size(), v2.size());
     for (size_t i = 0; i < v1.size(); ++i) {


### PR DESCRIPTION
Work on: https://github.com/XRPLF/clio/issues/1221
It will allow to not just implement this, but also test it using new mock.