### PR TITLE
feat: Run sanitizers for Debug builds as well

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -37,12 +37,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: ["gcc", "clang"]
-        sanitizer_ext: [".asan", ".tsan", ".ubsan"]
+        compiler: [gcc, clang]
+        sanitizer_ext: [.asan, .tsan, .ubsan]
+        build_type: [Release, Debug]
         exclude:
           # Currently, clang.tsan unit tests hang
           - compiler: clang
             sanitizer_ext: .tsan
+            build_type: Release
+          - compiler: clang
+            sanitizer_ext: .tsan
+            build_type: Debug
 
     uses: ./.github/workflows/build_and_test.yml
     with:
@@ -50,7 +55,7 @@ jobs:
       container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
       disable_cache: true
       conan_profile: ${{ matrix.compiler }}${{ matrix.sanitizer_ext }}
-      build_type: Release
+      build_type: ${{ matrix.build_type }}
       static: false
       run_unit_tests: true
       run_integration_tests: false

--- a/.github/workflows/test_impl.yml
+++ b/.github/workflows/test_impl.yml
@@ -85,7 +85,7 @@ jobs:
         if: env.SANITIZER_IGNORE_ERRORS == 'true' && steps.check_report.outputs.found_report == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.conan_profile }}_report
+          name: sanitizer_report_${{ runner.os }}_${{ inputs.build_type }}_${{ inputs.conan_profile }}
           path: .sanitizer-report/*
           include-hidden-files: true
 


### PR DESCRIPTION
Instead of overriding `-O3` with `-O1` for sanitized builds, let's run sanitized debug builds.
The thing is the generated code might be significantly different for different optimization levels, so it would be better to test the debug builds as well.

Closes: https://github.com/XRPLF/clio/issues/2209