### PR TITLE
chore: Add trufflehog security tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
             --ignore-words=pre-commit-hooks/codespell_ignore.txt,
           ]
 
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: 6641d4ba5b684fffe195b9820345de1bf19f3181 # frozen: v3.89.2
+    hooks:
+      - id: trufflehog
+        entry: trufflehog git file://. --since-commit HEAD --no-verification --fail
+
   # Running some C++ hooks before clang-format
   # to ensure that the style is consistent.
   - repo: local


### PR DESCRIPTION
Tool works locally and doesn't require internet connection, if `--no-verification` is passed.
I also tried to add `secret.cpp` with github PAT and the tool detected it.