### PR TITLE
chore: Do not generate source files and use target_compile_definition…

### DIFF
--- a/.github/workflows/build_impl.yml
+++ b/.github/workflows/build_impl.yml
@@ -184,7 +184,6 @@ jobs:
 
       # This is run as part of the build job, because it requires the following:
       # - source code
-      # - generated source code (Build.cpp)
       # - conan packages
       # - .gcno files in build directory
       #

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 .sanitizer-report
 CMakeUserPresets.json
 config.json
-src/util/build/Build.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_PROJECT_INCLUDE_BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClioVersion.cmake)
-
 project(clio VERSION ${CLIO_VERSION} HOMEPAGE_URL "https://github.com/XRPLF/clio"
         DESCRIPTION "An XRP Ledger API Server"
 )

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -1,7 +1,3 @@
-#[===================================================================[
-   write version to source
-#]===================================================================]
-
 find_package(Git REQUIRED)
 
 set(GIT_COMMAND describe --tags --exact-match)
@@ -47,5 +43,3 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif ()
 
 message(STATUS "Build version: ${CLIO_VERSION}")
-
-configure_file(${CMAKE_CURRENT_LIST_DIR}/Build.cpp.in ${CMAKE_CURRENT_LIST_DIR}/../src/util/build/Build.cpp)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,9 +1,10 @@
+add_subdirectory(build)
+
 add_library(clio_util)
 
 target_sources(
   clio_util
   PRIVATE Assert.cpp
-          build/Build.cpp
           Coroutine.cpp
           CoroutineGroup.cpp
           log/Logger.cpp
@@ -57,6 +58,7 @@ target_link_libraries(
          Threads::Threads
          clio_options
          clio_rpc_center
+         clio_build_version
 )
 
 # FIXME: needed on gcc-12, clang-16 and AppleClang for now (known boost 1.82 issue for some compilers)

--- a/src/util/build/Build.cpp
+++ b/src/util/build/Build.cpp
@@ -23,19 +23,22 @@
 
 namespace util::build {
 
-static constexpr char versionString[] = "@CLIO_VERSION@"; // NOLINT(readability-identifier-naming)
+#ifndef CLIO_VERSION
+#error "CLIO_VERSION must be defined"
+#endif
+static constexpr char versionString[] = CLIO_VERSION;
 
 std::string const&
 getClioVersionString()
 {
-    static std::string const value = versionString; // NOLINT(readability-identifier-naming)
+    static std::string const value = versionString;  // NOLINT(readability-identifier-naming)
     return value;
 }
 
 std::string const&
 getClioFullVersionString()
 {
-    static std::string const value = "clio-" + getClioVersionString(); // NOLINT(readability-identifier-naming)
+    static std::string const value = "clio-" + getClioVersionString();  // NOLINT(readability-identifier-naming)
     return value;
 }
 

--- a/src/util/build/CMakeLists.txt
+++ b/src/util/build/CMakeLists.txt
@@ -1,0 +1,6 @@
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/ClioVersion.cmake)
+
+add_library(clio_build_version)
+target_sources(clio_build_version PRIVATE Build.cpp)
+target_link_libraries(clio_build_version PUBLIC clio_options)
+target_compile_definitions(clio_build_version PRIVATE CLIO_VERSION="${CLIO_VERSION}")


### PR DESCRIPTION
…s to set version

Advantages:
- not modifying src dir in build time (`git clean` will also remove less)
- simpler codecov (if we decide to move it to separate stage in the future)
- The cpp file is perfectly valid, so it will be treated as a C++ files by all the tooling
- No need to use CMAKE_PROJECT_INCLUDE_BEFORE, should work fine without it
- Instead of generating + recompiling, we will just be doing recompilation of 1 file