### PR TITLE
docs: Set `ws_port` to 6006 in example config

### DIFF
--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -31,7 +31,7 @@
   "etl_sources": [
     {
       "ip": "127.0.0.1",
-      "ws_port": "6005",
+      "ws_port": "6006",
       "grpc_port": "50051"
     }
   ],


### PR DESCRIPTION
This matches default `rippled` configuration