### PR TITLE
style: Mark spdlog fwd declararations as NOLINT(readability-identifie…

### DIFF
--- a/src/util/log/Logger.hpp
+++ b/src/util/log/Logger.hpp
@@ -35,10 +35,10 @@
 // to avoid including the spdlog headers in this header file.
 namespace spdlog {
 
-class logger;
+class logger;  // NOLINT(readability-identifier-naming)
 
 namespace sinks {
-class sink;
+class sink;  // NOLINT(readability-identifier-naming)
 }  // namespace sinks
 
 }  // namespace spdlog


### PR DESCRIPTION
…r-naming)

Fix: https://github.com/XRPLF/clio/issues/2422