### PR TITLE
ci: Add dependencies for Debian packages

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -38,6 +38,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         clang-tidy-${LLVM_TOOLS_VERSION} \
         clang-tools-${LLVM_TOOLS_VERSION} \
+        dpkg-dev \
+        file \
         git \
         git-lfs \
         graphviz \


### PR DESCRIPTION
A few additional tools are required during Debian package generation.