### PR TITLE
ci: "Revert ci: [DEPENDABOT] bump actions/checkout from 4 to 5"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
       image: ghcr.io/xrplf/clio-ci:0d262e74bcd286ccd6fc36e45990ff2e6b8d8430
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/build_clio_docker_image.yml
+++ b/.github/workflows/build_clio_docker_image.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Download Clio binary from artifact
         if: ${{ inputs.artifact_name != null }}

--- a/.github/workflows/build_impl.yml
+++ b/.github/workflows/build_impl.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         uses: kuznetsss/workspace-cleanup@80b9863b45562c148927c3d53621ef354e5ae7ce # v1.0
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # We need to fetch tags to have correct version in the release

--- a/.github/workflows/check_libxrpl.yml
+++ b/.github/workflows/check_libxrpl.yml
@@ -20,7 +20,7 @@ jobs:
       image: ghcr.io/xrplf/clio-ci:0d262e74bcd286ccd6fc36e45990ff2e6b8d8430
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Create an issue
         uses: ./.github/actions/create_issue

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/clang-tidy_on_fix_merged.yml
+++ b/.github/workflows/clang-tidy_on_fix_merged.yml
@@ -13,7 +13,7 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Check last commit matches clang-tidy auto fixes
         id: check
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,7 +128,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Create an issue
         uses: ./.github/actions/create_issue

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release_impl.yml
+++ b/.github/workflows/release_impl.yml
@@ -51,7 +51,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_impl.yml
+++ b/.github/workflows/test_impl.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         uses: kuznetsss/workspace-cleanup@80b9863b45562c148927c3d53621ef354e5ae7ce # v1.0
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -52,7 +52,7 @@ jobs:
     needs: repo
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -90,7 +90,7 @@ jobs:
     needs: repo
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -128,7 +128,7 @@ jobs:
     needs: [repo, gcc-amd64, gcc-arm64]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -179,7 +179,7 @@ jobs:
     needs: repo
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -215,7 +215,7 @@ jobs:
     needs: [repo, gcc-merge]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -246,7 +246,7 @@ jobs:
     needs: [repo, gcc-merge]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -277,7 +277,7 @@ jobs:
     needs: [repo, tools-amd64, tools-arm64]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -312,7 +312,7 @@ jobs:
     needs: [repo, gcc-merge, clang, tools-merge]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build_docker_image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload_conan_deps.yml
+++ b/.github/workflows/upload_conan_deps.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Calculate conan matrix
         id: set-matrix
@@ -70,7 +70,7 @@ jobs:
       CONAN_PROFILE: ${{ matrix.compiler }}${{ matrix.sanitizer_ext }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Prepare runner
         uses: ./.github/actions/prepare_runner

--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Reverts XRPLF/clio#2443

heavy-arm64 doesn't support new nodejs, so let's revert this while we haven't updated