### PR TITLE
fix: ASAN issues from runSpawnWithTimeout

### DIFF
--- a/tests/common/util/AsioContextTestFixture.hpp
+++ b/tests/common/util/AsioContextTestFixture.hpp
@@ -113,40 +113,11 @@ struct SyncAsioContextTest : virtual public NoLoggerFixture {
         runContext();
     }
 
-    template <typename F>
-    void
-    runSpawnWithTimeout(std::chrono::steady_clock::duration timeout, F&& f, bool allowMockLeak = false)
-    {
-        boost::asio::io_context timerCtx;
-        boost::asio::steady_timer timer{timerCtx, timeout};
-        util::spawn(timerCtx, [this, &timer](boost::asio::yield_context yield) {
-            boost::system::error_code errorCode;
-            timer.async_wait(yield[errorCode]);
-            ctx_.stop();
-            EXPECT_TRUE(false) << "Test timed out";
-        });
-        std::thread timerThread{[&timerCtx]() { timerCtx.run(); }};
-
-        testing::MockFunction<void()> call;
-        if (allowMockLeak)
-            testing::Mock::AllowLeak(&call);
-
-        util::spawn(ctx_, [&](boost::asio::yield_context yield) {
-            f(yield);
-            call.Call();
-        });
-
-        EXPECT_CALL(call, Call());
-        runContext();
-
-        timerCtx.stop();
-        timerThread.join();
-    }
-
     void
     runContext()
     {
-        ctx_.run();
+        static constexpr auto kTIMEOUT = std::chrono::seconds{30};
+        ctx_.run_for(kTIMEOUT);
         ctx_.restart();
     }
 

--- a/tests/unit/util/BlockingCacheTests.cpp
+++ b/tests/unit/util/BlockingCacheTests.cpp
@@ -157,7 +157,7 @@ TEST_P(BlockingCacheWaitTest, WaitForUpdate)
     if (GetParam().updateSuccessful)
         EXPECT_CALL(mockVerifier, Call(value)).WillOnce(Return(GetParam().verifierAccepts));
 
-    runSpawnWithTimeout(std::chrono::seconds{1}, [&](boost::asio::yield_context yield) {
+    runSpawn([&](boost::asio::yield_context yield) {
         auto result = cache->asyncGet(yield, mockUpdater.AsStdFunction(), mockVerifier.AsStdFunction());
 
         if (GetParam().updateSuccessful) {
@@ -244,7 +244,5 @@ TEST_F(BlockingCacheTest, UpdateFromTwoCoroutinesHappensOnlyOnce)
         ASSERT_EQ(result.value(), value);
     };
 
-    runSpawnWithTimeout(std::chrono::seconds{1}, [&](boost::asio::yield_context yield) {
-        util::spawn(yield, updatingCoroutine);
-    });
+    runSpawn([&](boost::asio::yield_context yield) { util::spawn(yield, updatingCoroutine); });
 }

--- a/tests/unit/web/ng/impl/WsConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/WsConnectionTests.cpp
@@ -397,7 +397,7 @@ TEST_F(WebWsConnectionTests, CloseCalledFromMultipleSubCoroutines)
     testing::StrictMock<testing::MockFunction<void()>> closeCalled;
     EXPECT_CALL(closeCalled, Call).Times(2);
 
-    runSpawnWithTimeout(std::chrono::seconds{1}, [&](boost::asio::yield_context yield) {
+    runSpawn([&](boost::asio::yield_context yield) {
         auto wsConnection = acceptConnection(yield);
         util::CoroutineGroup coroutines{yield};
         for ([[maybe_unused]] int const i : std::ranges::iota_view{0, 2}) {


### PR DESCRIPTION
`runSpawnWithTimeout` is triggering ASAN in the same way ClusterCommunicationService did. Since it was not used widely it's easier to remove it and add a global timeout for all `runSpawn` tests. To be clear, no tests should ever hang, not even for 1s. The `runSpawnWithTimeout` was added to guard against this in CI but realistically we should not have code that hangs added to the codebase and get all the way to CI. It may happen sometimes and we can fix the test and move on.