### PR TITLE
ci: Use Python 3.13 in CI docker image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,28 +20,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 WORKDIR /root
 
-ARG LLVM_TOOLS_VERSION=20
-
-# Add repositories
+# Install common tools and dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         curl \
-        gnupg \
-        wget \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_TOOLS_VERSION} main" >> /etc/apt/sources.list \
-    && wget --progress=dot:giga -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-
-# Install packages
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
-        clang-tidy-${LLVM_TOOLS_VERSION} \
-        clang-tools-${LLVM_TOOLS_VERSION} \
         dpkg-dev \
         file \
         git \
         git-lfs \
+        gnupg \
         graphviz \
         jq \
         # libgmp, libmpfr and libncurses are gdb dependencies
@@ -50,19 +37,43 @@ RUN apt-get update \
         libncurses-dev \
         make \
         ninja-build \
-        python3 \
-        python3-pip \
+        wget \
         zip \
-    && pip3 install -q --upgrade --no-cache-dir pip \
-    && pip3 install -q --no-cache-dir \
-        # TODO: Remove this once we switch to newer Ubuntu base image
-        # lxml 6.0.0 is not compatible with our image
-        'lxml<6.0.0' \
-        \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python tools
+ARG PYTHON_VERSION=3.13
+
+RUN add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-venv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
+
+# Create a virtual environment for python tools
+RUN python${PYTHON_VERSION} -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install -q --no-cache-dir \
         cmake \
         conan==2.17.0 \
         gcovr \
-        pre-commit \
+        pre-commit
+
+# Install LLVM tools
+ARG LLVM_TOOLS_VERSION=20
+
+RUN echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_TOOLS_VERSION} main" >> /etc/apt/sources.list \
+    && wget --progress=dot:giga -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+        clang-tidy-${LLVM_TOOLS_VERSION} \
+        clang-tools-${LLVM_TOOLS_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -15,6 +15,7 @@ The image is based on Ubuntu 20.04 and contains:
 - gh 2.74
 - git-cliff 2.9.1
 - mold 2.40.1
+- Python 3.13
 - and some other useful tools
 
 Conan is set up to build Clio without any additional steps.


### PR DESCRIPTION
New `pre-commit-hooks` requires at least Python 3.9: https://github.com/pre-commit/pre-commit-hooks/releases/tag/v6.0.0

Let's just install the latest Python version available for our image

Checking this image works in: https://github.com/XRPLF/clio/pull/2494