### PR TITLE
fix: Remove integration_tests reference in requirements()

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -51,7 +51,7 @@ class ClioConan(ConanFile):
     )
 
     def requirements(self):
-        if self.options.tests or self.options.integration_tests:
+        if self.options.tests:
             self.requires('gtest/1.14.0')
         if self.options.benchmark:
             self.requires('benchmark/1.9.4')


### PR DESCRIPTION
Trying to build `clio_server` with `tests=False` lets you get to an undefined option:

```
ERROR: conanfile.py (clio/None): Error in requirements() method, line 54
        if self.options.tests or self.options.integration_tests:
        ConanException: option 'integration_tests' doesn't exist
Possible options are ['tests', 'benchmark']
```