### PR TITLE
fix: remove MPTIssuanceID from tx

### DIFF
--- a/src/feed/impl/TransactionFeed.cpp
+++ b/src/feed/impl/TransactionFeed.cpp
@@ -209,7 +209,6 @@ TransactionFeed::pub(
 
         auto& txnPubobj = pubObj[txKey].as_object();
         rpc::insertDeliverMaxAlias(txnPubobj, version);
-        rpc::insertMPTIssuanceID(txnPubobj, meta);
 
         Json::Value nftJson;
         ripple::RPC::insertNFTSyntheticInJson(nftJson, tx, *meta);

--- a/src/rpc/RPCHelpers.cpp
+++ b/src/rpc/RPCHelpers.cpp
@@ -260,7 +260,6 @@ toExpandedJson(
     auto metaJson = toJson(*meta);
     insertDeliveredAmount(metaJson, txn, meta, blobs.date);
     insertDeliverMaxAlias(txnJson, apiVersion);
-    insertMPTIssuanceID(txnJson, meta);
 
     if (nftEnabled == NFTokenjson::ENABLE) {
         Json::Value nftJson;
@@ -316,64 +315,6 @@ insertDeliveredAmount(
         }
         return true;
     }
-    return false;
-}
-
-/**
- * @brief Get the delivered amount
- *
- * @param meta The metadata
- * @return The mpt_issuance_id or std::nullopt if not available
- */
-static std::optional<ripple::uint192>
-getMPTIssuanceID(std::shared_ptr<ripple::TxMeta const> const& meta)
-{
-    ripple::TxMeta const& transactionMeta = *meta;
-
-    for (ripple::STObject const& node : transactionMeta.getNodes()) {
-        if (node.getFieldU16(ripple::sfLedgerEntryType) != ripple::ltMPTOKEN_ISSUANCE ||
-            node.getFName() != ripple::sfCreatedNode)
-            continue;
-
-        auto const& mptNode = node.peekAtField(ripple::sfNewFields).downcast<ripple::STObject>();
-        return ripple::makeMptID(mptNode[ripple::sfSequence], mptNode[ripple::sfIssuer]);
-    }
-
-    return {};
-}
-
-/**
- * @brief Check if transaction has a new MPToken created
- *
- * @param txnJson The transaction Json
- * @param meta The metadata
- * @return true if the transaction can have a mpt_issuance_id
- */
-static bool
-canHaveMPTIssuanceID(boost::json::object const& txnJson, std::shared_ptr<ripple::TxMeta const> const& meta)
-{
-    if (txnJson.at(JS(TransactionType)).is_string() and
-        not boost::iequals(txnJson.at(JS(TransactionType)).as_string(), JS(MPTokenIssuanceCreate)))
-        return false;
-
-    if (meta->getResultTER() != ripple::tesSUCCESS)
-        return false;
-
-    return true;
-}
-
-bool
-insertMPTIssuanceID(boost::json::object& txnJson, std::shared_ptr<ripple::TxMeta const> const& meta)
-{
-    if (!canHaveMPTIssuanceID(txnJson, meta))
-        return false;
-
-    if (auto const id = getMPTIssuanceID(meta)) {
-        txnJson[JS(mpt_issuance_id)] = ripple::to_string(*id);
-        return true;
-    }
-
-    assert(false);
     return false;
 }
 

--- a/src/rpc/RPCHelpers.hpp
+++ b/src/rpc/RPCHelpers.hpp
@@ -200,16 +200,6 @@ insertDeliveredAmount(
 );
 
 /**
- * @brief Add "mpt_issuance_id" into MPTokenIssuanceCreate transaction json.
- *
- * @param txnJson The transaction Json object
- * @param meta The metadata object
- * @return true if the "mpt_issuance_id" is added to the metadata json object
- */
-bool
-insertMPTIssuanceID(boost::json::object& txnJson, std::shared_ptr<ripple::TxMeta const> const& meta);
-
-/**
  * @brief Convert STBase object to JSON
  *
  * @param obj The object to convert

--- a/tests/unit/rpc/handlers/AccountTxTests.cpp
+++ b/tests/unit/rpc/handlers/AccountTxTests.cpp
@@ -56,7 +56,6 @@ constexpr auto kNFT_ID = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76
 constexpr auto kNFT_ID2 = "05FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DA";
 constexpr auto kNFT_ID3 = "15FB0EB4B899F056FA095537C5817163801F544BAFCEA39C995D76DB4D16F9DF";
 constexpr auto kINDEX = "E6DBAFC99223B42257915A63DFC6B0C032D4070F9A574B255AD97466726FC322";
-constexpr auto kMPT_ISSUANCE_ID = "000000014B4E9C06F24296074F7BC48F92A97916C6DC5EA9";
 
 }  // namespace
 
@@ -1638,7 +1637,6 @@ TEST_F(RPCAccountTxHandlerTest, MPTTxs_API_v2)
                         "Sequence": 1,
                         "SigningPubKey": "74657374",
                         "TransactionType": "MPTokenIssuanceCreate",
-                        "mpt_issuance_id": "{}",
                         "ledger_index": 11,
                         "ctid": "C000000B00000000",
                         "date": 1
@@ -1651,8 +1649,7 @@ TEST_F(RPCAccountTxHandlerTest, MPTTxs_API_v2)
         kACCOUNT,
         kACCOUNT,
         kLEDGER_HASH,
-        kACCOUNT,
-        kMPT_ISSUANCE_ID
+        kACCOUNT
     );
 
     auto mptTx = createMPTIssuanceCreateTxWithMetadata(kACCOUNT, 50, 1);


### PR DESCRIPTION
fixes #2332 : Essentially, remove `mpt_issuance_id`  for `MPTokenIssuanceCreate`