### PR TITLE
ci: Wrap GitHub CI conditionals in curly braces

### DIFF
--- a/.github/workflows/build_impl.yml
+++ b/.github/workflows/build_impl.yml
@@ -93,7 +93,7 @@ jobs:
           disable_ccache: ${{ inputs.disable_cache }}
 
       - name: Setup conan on macOS
-        if: runner.os == 'macOS'
+        if: ${{ runner.os == 'macOS' }}
         shell: bash
         run: ./.github/scripts/conan/init.sh
 
@@ -162,7 +162,7 @@ jobs:
         run: strip build/clio_integration_tests
 
       - name: Upload clio_server
-        if: inputs.upload_clio_server && !inputs.code_coverage && !inputs.analyze_build_time
+        if: ${{ inputs.upload_clio_server && !inputs.code_coverage && !inputs.analyze_build_time }}
         uses: actions/upload-artifact@v4
         with:
           name: clio_server_${{ runner.os }}_${{ inputs.build_type }}_${{ inputs.conan_profile }}
@@ -183,7 +183,7 @@ jobs:
           path: build/clio_integration_tests
 
       - name: Upload Clio Linux package
-        if: inputs.package
+        if: ${{ inputs.package }}
         uses: actions/upload-artifact@v4
         with:
           name: clio_deb_package_${{ runner.os }}_${{ inputs.build_type }}_${{ inputs.conan_profile }}

--- a/.github/workflows/test_impl.yml
+++ b/.github/workflows/test_impl.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     container: ${{ inputs.container != '' && fromJson(inputs.container) || null }}
 
-    if: inputs.run_unit_tests
+    if: ${{ inputs.run_unit_tests }}
 
     env:
       # TODO: remove completely when we have fixed all currently existing issues with sanitizers
@@ -63,15 +63,15 @@ jobs:
         run: chmod +x ./clio_tests
 
       - name: Run clio_tests (regular)
-        if: env.SANITIZER_IGNORE_ERRORS == 'false'
+        if: ${{ env.SANITIZER_IGNORE_ERRORS == 'false' }}
         run: ./clio_tests
 
       - name: Run clio_tests (sanitizer errors ignored)
-        if: env.SANITIZER_IGNORE_ERRORS == 'true'
+        if: ${{ env.SANITIZER_IGNORE_ERRORS == 'true' }}
         run: ./.github/scripts/execute-tests-under-sanitizer ./clio_tests
 
       - name: Check for sanitizer report
-        if: env.SANITIZER_IGNORE_ERRORS == 'true'
+        if: ${{ env.SANITIZER_IGNORE_ERRORS == 'true' }}
         shell: bash
         id: check_report
         run: |
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Upload sanitizer report
-        if: env.SANITIZER_IGNORE_ERRORS == 'true' && steps.check_report.outputs.found_report == 'true'
+        if: ${{ env.SANITIZER_IGNORE_ERRORS == 'true' && steps.check_report.outputs.found_report == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: sanitizer_report_${{ runner.os }}_${{ inputs.build_type }}_${{ inputs.conan_profile }}
@@ -90,7 +90,7 @@ jobs:
           include-hidden-files: true
 
       - name: Create an issue
-        if: false && env.SANITIZER_IGNORE_ERRORS == 'true' && steps.check_report.outputs.found_report == 'true'
+        if: ${{ false && env.SANITIZER_IGNORE_ERRORS == 'true' && steps.check_report.outputs.found_report == 'true' }}
         uses: ./.github/actions/create_issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -108,7 +108,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     container: ${{ inputs.container != '' && fromJson(inputs.container) || null }}
 
-    if: inputs.run_integration_tests
+    if: ${{ inputs.run_integration_tests }}
 
     services:
       scylladb:

--- a/.github/workflows/update_docker_ci.yml
+++ b/.github/workflows/update_docker_ci.yml
@@ -61,7 +61,7 @@ jobs:
           files: "docker/compilers/gcc/**"
 
       - uses: ./.github/actions/build_docker_image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -99,7 +99,7 @@ jobs:
           files: "docker/compilers/gcc/**"
 
       - uses: ./.github/actions/build_docker_image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -140,7 +140,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -148,14 +148,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        if: github.repository_owner == 'XRPLF' && github.event_name != 'pull_request'
+        if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
 
       - name: Create and push multi-arch manifest
-        if: github.event_name != 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ github.event_name != 'pull_request' && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           push_image() {
             image=$1
@@ -188,7 +188,7 @@ jobs:
           files: "docker/compilers/clang/**"
 
       - uses: ./.github/actions/build_docker_image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -224,7 +224,7 @@ jobs:
           files: "docker/tools/**"
 
       - uses: ./.github/actions/build_docker_image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -255,7 +255,7 @@ jobs:
           files: "docker/tools/**"
 
       - uses: ./.github/actions/build_docker_image
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -289,7 +289,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
@@ -297,7 +297,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push multi-arch manifest
-        if: github.event_name != 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ github.event_name != 'pull_request' && steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           image=${{ needs.repo.outputs.GHCR_REPO }}/clio-tools
           docker buildx imagetools create \

--- a/.github/workflows/upload_conan_deps.yml
+++ b/.github/workflows/upload_conan_deps.yml
@@ -77,7 +77,7 @@ jobs:
           disable_ccache: true
 
       - name: Setup conan on macOS
-        if: runner.os == 'macOS'
+        if: ${{ runner.os == 'macOS' }}
         shell: bash
         run: ./.github/scripts/conan/init.sh
 
@@ -94,9 +94,9 @@ jobs:
           build_type: ${{ matrix.build_type }}
 
       - name: Login to Conan
-        if: github.repository_owner == 'XRPLF' && github.event_name != 'pull_request'
+        if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' }}
         run: conan remote login -p ${{ secrets.CONAN_PASSWORD }} xrplf ${{ secrets.CONAN_USERNAME }}
 
       - name: Upload Conan packages
-        if: github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule'
+        if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule' }}
         run: conan upload "*" -r=xrplf --confirm ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}


### PR DESCRIPTION
This change wraps remaining GitHub conditionals in `${{ .. }}`, for consistency and to reduce unexpected failures, because it has been previously observed that not all conditionals work without those curly braces.