### PR TITLE
Add gRPC Timeout and keepalive to handle stuck connections

### DIFF
--- a/src/etl/impl/GrpcSource.cpp
+++ b/src/etl/impl/GrpcSource.cpp
@@ -60,6 +60,11 @@ GrpcSource::GrpcSource(std::string const& ip, std::string const& grpcPort, std::
         ss << resolverResult.begin()->endpoint();
         grpc::ChannelArguments chArgs;
         chArgs.SetMaxReceiveMessageSize(-1);
+        // Configure keepalive to detect dead connections faster
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 10000);           // Send keepalive ping every 10 seconds
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5000);         // Wait 5 seconds for keepalive response
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);  // Allow keepalive pings when no calls
+        chArgs.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);    // No limit on pings without data
         stub_ = org::xrpl::rpc::v1::XRPLedgerAPIService::NewStub(
             grpc::CreateCustomChannel(ss.str(), grpc::InsecureChannelCredentials(), chArgs)
         );
@@ -79,6 +84,8 @@ GrpcSource::fetchLedger(uint32_t sequence, bool getObjects, bool getObjectNeighb
     // Ledger header with txns and metadata
     org::xrpl::rpc::v1::GetLedgerRequest request;
     grpc::ClientContext context;
+    // Set a deadline to prevent indefinite blocking
+    context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(30));
 
     request.mutable_ledger()->set_sequence(sequence);
     request.set_transactions(true);

--- a/src/etlng/impl/GrpcSource.cpp
+++ b/src/etlng/impl/GrpcSource.cpp
@@ -70,6 +70,11 @@ GrpcSource::GrpcSource(std::string const& ip, std::string const& grpcPort)
     try {
         grpc::ChannelArguments chArgs;
         chArgs.SetMaxReceiveMessageSize(-1);
+        // Configure keepalive to detect dead connections faster
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 10000);           // Send keepalive ping every 10 seconds
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5000);         // Wait 5 seconds for keepalive response
+        chArgs.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);  // Allow keepalive pings when no calls
+        chArgs.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);    // No limit on pings without data
 
         stub_ = org::xrpl::rpc::v1::XRPLedgerAPIService::NewStub(
             grpc::CreateCustomChannel(resolve(ip, grpcPort), grpc::InsecureChannelCredentials(), chArgs)
@@ -91,6 +96,8 @@ GrpcSource::fetchLedger(uint32_t sequence, bool getObjects, bool getObjectNeighb
     // Ledger header with txns and metadata
     org::xrpl::rpc::v1::GetLedgerRequest request;
     grpc::ClientContext context;
+    // Set a deadline to prevent indefinite blocking
+    context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(30));
 
     request.mutable_ledger()->set_sequence(sequence);
     request.set_transactions(true);


### PR DESCRIPTION
# gRPC Timeout Fix for ETL Hanging Issue

## Problem Summary

Clio was getting stuck and not pulling ledger data from rippled after migrating from Ubuntu 20.04 to Ubuntu 24.04. The ETL process would freeze for approximately 1.5 hours, then recover briefly, then repeat the cycle.

### Root Cause

The `fetchLedger()` function in both `GrpcSource` implementations was making gRPC calls **without any timeout**, causing indefinite blocking when:
- A rippled node accepts the connection but never responds
- Network issues cause packets to be dropped silently  
- The rippled node hangs internally while processing the request
- TCP connection issues occur (more common in Ubuntu 24.04 due to kernel changes)

### Log Evidence

At `19:08:05.462977`, the ETL attempted to fetch ledger 90533:
```
2025-10-06 19:08:05.462977 deb:ETL - Attempting to execute func. ledger sequence = 90533 - source = {validated range: 5-90533, ip: 10.170.13.191...
```

The log then **completely stopped** with no further ETL activity, confirming the gRPC call was blocked indefinitely.

## Solution

Applied **minimal changes** to prevent gRPC blocking:

### 1. Added 30-Second Timeout to gRPC Calls

Modified `fetchLedger()` in both:
- `src/etl/impl/GrpcSource.cpp`
- `src/etlng/impl/GrpcSource.cpp`

**Change:**
```cpp
grpc::ClientContext context;

// Set a deadline to prevent indefinite blocking
context.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(30));
```

### 2. Added gRPC Keepalive Configuration

Modified constructor in both `GrpcSource` implementations to add keepalive settings:

```cpp
// Configure keepalive to detect dead connections faster
chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 10000);           // Send keepalive ping every 10 seconds
chArgs.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5000);         // Wait 5 seconds for keepalive response
chArgs.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);  // Allow keepalive pings when no calls
chArgs.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);    // No limit on pings without data
```

**Benefits:**
- Detects dead connections within 15 seconds (10s + 5s timeout)
- Prevents accumulation of zombie connections
- Works proactively before calls are made
- Compatible with HTTP/2 keepalive mechanism
