### PR TITLE
ci: Add libatomic as dependency for pre-commit image

### DIFF
--- a/docker/pre-commit/Dockerfile
+++ b/docker/pre-commit/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         curl \
         git \
+        libatomic1 \
         software-properties-common \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Same as in https://github.com/XRPLF/ci/commit/a8c7be18944ad85c0a2c6d6459b9efcf2f080c2a