### PR TITLE
chore: Disable flaky DisconnectClientOnInactivity

### DIFF
--- a/tests/unit/web/ng/impl/WsConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/WsConnectionTests.cpp
@@ -108,7 +108,9 @@ TEST_F(WebWsConnectionTests, WasUpgraded)
     });
 }
 
-TEST_F(WebWsConnectionTests, DisconnectClientOnInactivity)
+// This test is either flaky or incorrect
+// see https://github.com/XRPLF/clio/issues/2700
+TEST_F(WebWsConnectionTests, DISABLED_DisconnectClientOnInactivity)
 {
     boost::asio::io_context clientCtx;
     auto work = boost::asio::make_work_guard(clientCtx);

--- a/tests/unit/web/ng/impl/WsConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/WsConnectionTests.cpp
@@ -131,9 +131,7 @@ TEST_F(WebWsConnectionTests, DisconnectClientOnInactivity)
         auto const start = std::chrono::steady_clock::now();
         auto const receivedMessage = wsConnection->receive(yield);
         auto const end = std::chrono::steady_clock::now();
-        EXPECT_LT(
-            end - start, std::chrono::milliseconds{8}
-        );  // Should be 2 ms, increase to workaround slow CI and sanitizer builds.
+        EXPECT_LT(end - start, std::chrono::milliseconds{4});  // Should be 2 ms, double it in case of slow CI.
 
         EXPECT_FALSE(receivedMessage.has_value());
         EXPECT_EQ(receivedMessage.error().value(), boost::asio::error::no_permission);

--- a/tests/unit/web/ng/impl/WsConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/WsConnectionTests.cpp
@@ -131,7 +131,9 @@ TEST_F(WebWsConnectionTests, DisconnectClientOnInactivity)
         auto const start = std::chrono::steady_clock::now();
         auto const receivedMessage = wsConnection->receive(yield);
         auto const end = std::chrono::steady_clock::now();
-        EXPECT_LT(end - start, std::chrono::milliseconds{4});  // Should be 2 ms, double it in case of slow CI.
+        EXPECT_LT(
+            end - start, std::chrono::milliseconds{8}
+        );  // Should be 2 ms, increase to workaround slow CI and sanitizer builds.
 
         EXPECT_FALSE(receivedMessage.has_value());
         EXPECT_EQ(receivedMessage.error().value(), boost::asio::error::no_permission);


### PR DESCRIPTION
This test is the last flaky test as evident from running an ASAN build of clio_tests on x86 docker on a arm Mac (should be slower than CI and anything really). Created #2700 to address it properly