### PR TITLE
ci: Use intermediate environment variables for improved security

### DIFF
--- a/.github/actions/build-clio/action.yml
+++ b/.github/actions/build-clio/action.yml
@@ -21,9 +21,11 @@ runs:
 
     - name: Build targets
       shell: bash
+      env:
+        CMAKE_TARGETS: ${{ inputs.targets }}
       run: |
         cd build
         cmake \
           --build . \
           --parallel "${{ steps.number_of_threads.outputs.threads_number }}" \
-          --target ${{ inputs.targets }}
+          --target ${CMAKE_TARGETS}

--- a/.github/actions/create-issue/action.yml
+++ b/.github/actions/create-issue/action.yml
@@ -28,12 +28,17 @@ runs:
     - name: Create an issue
       id: create_issue
       shell: bash
+      env:
+        ISSUE_BODY: ${{ inputs.body }}
+        ISSUE_ASSIGNEES: ${{ inputs.assignees }}
+        ISSUE_LABELS: ${{ inputs.labels }}
+        ISSUE_TITLE: ${{ inputs.title }}
       run: |
-        echo -e '${{ inputs.body }}' > issue.md
+        echo -e "${ISSUE_BODY}" > issue.md
         gh issue create \
-          --assignee '${{ inputs.assignees }}' \
-          --label '${{ inputs.labels }}' \
-          --title '${{ inputs.title }}' \
+          --assignee "${ISSUE_ASSIGNEES}" \
+          --label "${ISSUE_LABELS}" \
+          --title "${ISSUE_TITLE}" \
           --body-file ./issue.md \
           > create_issue.log
         created_issue="$(sed 's|.*/||' create_issue.log)"

--- a/.github/actions/get-threads-number/action.yml
+++ b/.github/actions/get-threads-number/action.yml
@@ -29,8 +29,10 @@ runs:
     - name: Shift and export number of threads
       id: number_of_threads_export
       shell: bash
+      env:
+        SUBTRACT_THREADS: ${{ inputs.subtract_threads }}
       run: |
         num_of_threads="${{ steps.mac_threads.outputs.num || steps.linux_threads.outputs.num }}"
-        shift_by="${{ inputs.subtract_threads }}"
+        shift_by="${SUBTRACT_THREADS}"
         shifted="$((num_of_threads - shift_by))"
         echo "num=$(( shifted > 1 ? shifted : 1 ))" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-clio-docker-image.yml
+++ b/.github/workflows/build-clio-docker-image.yml
@@ -56,9 +56,12 @@ jobs:
       - name: Download Clio binary from url
         if: ${{ inputs.clio_server_binary_url != null }}
         shell: bash
+        env:
+          BINARY_URL: ${{ inputs.clio_server_binary_url }}
+          BINARY_SHA256: ${{ inputs.binary_sha256 }}
         run: |
-          wget "${{inputs.clio_server_binary_url}}" -P ./docker/clio/artifact/
-          if [ "$(sha256sum ./docker/clio/clio_server | awk '{print $1}')" != "${{inputs.binary_sha256}}" ]; then
+          wget "${BINARY_URL}" -P ./docker/clio/artifact/
+          if [ "$(sha256sum ./docker/clio/clio_server | awk '{print $1}')" != "${BINARY_SHA256}" ]; then
             echo "Binary sha256 sum doesn't match"
             exit 1
           fi

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -17,8 +17,10 @@ jobs:
           custom_labels: '{"build":"build", "feat":"enhancement", "fix":"bug", "docs":"documentation", "test":"testability", "ci":"ci", "style":"refactoring", "refactor":"refactoring", "perf":"performance", "chore":"tooling"}'
 
       - name: Check if message starts with upper-case letter
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "${{ github.event.pull_request.title }}" =~ ^[a-z]+:\ [\[A-Z] ]]; then
+          if [[ ! "${PR_TITLE}" =~ ^[a-z]+:\ [\[A-Z] ]]; then
             echo "Error: PR title must start with an upper-case letter."
             exit 1
           fi

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -221,12 +221,14 @@ jobs:
       - name: Verify expected version
         if: ${{ inputs.expected_version != '' }}
         shell: bash
+        env:
+          INPUT_EXPECTED_VERSION: ${{ inputs.expected_version }}
         run: |
           set -e
-          EXPECTED_VERSION="clio-${{ inputs.expected_version }}"
+          EXPECTED_VERSION="clio-${INPUT_EXPECTED_VERSION}"
           actual_version=$(./build/clio_server --version)
           if [[ "$actual_version" != "$EXPECTED_VERSION" ]]; then
-            echo "Expected version '$EXPECTED_VERSION', but got '$actual_version'"
+            echo "Expected version '${EXPECTED_VERSION}', but got '${actual_version}'"
             exit 1
           fi
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -67,10 +67,12 @@ jobs:
 
       - name: Create release notes
         shell: bash
+        env:
+          RELEASE_HEADER: ${{ inputs.header }}
         run: |
           echo "# Release notes" > "${RUNNER_TEMP}/release_notes.md"
           echo "" >> "${RUNNER_TEMP}/release_notes.md"
-          printf '%s\n' "${{ inputs.header }}" >> "${RUNNER_TEMP}/release_notes.md"
+          printf '%s\n' "${RELEASE_HEADER}" >> "${RUNNER_TEMP}/release_notes.md"
 
       - name: Generate changelog
         shell: bash
@@ -95,18 +97,25 @@ jobs:
       - name: Remove current release and tag
         if: ${{ github.event_name != 'pull_request' && inputs.overwrite_release }}
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          gh release delete ${{ inputs.version }} --yes || true
-          git push origin :${{ inputs.version }} || true
+          gh release delete "${RELEASE_VERSION}" --yes || true
+          git push origin :"${RELEASE_VERSION}" || true
 
       - name: Publish release
         if: ${{ github.event_name != 'pull_request' }}
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          PRERELEASE_OPTION: ${{ inputs.prerelease && '--prerelease' || '' }}
+          RELEASE_TITLE: ${{ inputs.title }}
+          DRAFT_OPTION: ${{ inputs.draft && '--draft' || '' }}
         run: |
-          gh release create "${{ inputs.version }}" \
-            ${{ inputs.prerelease && '--prerelease' || '' }} \
-            --title "${{ inputs.title }}" \
+          gh release create "${RELEASE_VERSION}" \
+            ${PRERELEASE_OPTION} \
+            --title "${RELEASE_TITLE}" \
             --target "${GITHUB_SHA}" \
-            ${{ inputs.draft && '--draft' || '' }} \
+            ${DRAFT_OPTION} \
             --notes-file "${RUNNER_TEMP}/release_notes.md" \
             ./release_artifacts/clio_server*

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -99,4 +99,6 @@ jobs:
 
       - name: Upload Conan packages
         if: ${{ github.repository_owner == 'XRPLF' && github.event_name != 'pull_request' && github.event_name != 'schedule' }}
-        run: conan upload "*" -r=xrplf --confirm ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
+        env:
+          FORCE_OPTION: ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
+        run: conan upload "*" -r=xrplf --confirm ${FORCE_OPTION}


### PR DESCRIPTION
Please see https://github.com/XRPLF/rippled/pull/5822

I used `$ENVVAR` approach because:

1. That's what GitHub does in their example: https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
2. It's more clear, because it's just regular env variable
3. And it's easier to read
4. Instead of relying on sometimes unexpected behaviour of GitHub Actions expressions, it will be pure shell (bash) syntax
5. If something goes wrong, you will be able to set env variables and test it locally more easily