### PR TITLE
feat: Async framework `submit` on strand/ctx

### DIFF
--- a/src/util/Assert.hpp
+++ b/src/util/Assert.hpp
@@ -22,6 +22,7 @@
 #include "util/SourceLocation.hpp"
 
 #include <boost/log/core/core.hpp>
+#include <fmt/base.h>
 
 #include <functional>
 #include <string_view>

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -90,10 +90,10 @@ public:
 
         return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
             if constexpr (std::is_void_v<RetType>) {
-                std::invoke(fn);
+                std::invoke(std::move(fn));
                 return {};
             } else {
-                return std::make_any<RetType>(std::invoke(fn));
+                return std::make_any<RetType>(std::invoke(std::move(fn)));
             }
         }));
     }
@@ -223,7 +223,7 @@ public:
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
             pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                std::invoke(fn);
+                std::invoke(std::move(fn));
                 return {};
             })
         );

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -231,7 +231,7 @@ public:
 
     /**
      * @brief Schedule an operation on the execution context without expectations of a result
-     * @note Errors are caught internally and logged as errors
+     * @note Exceptions are caught internally and `ASSERT`ed on
      *
      * @param fn The block of code to execute
      */

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -230,6 +230,18 @@ public:
     }
 
     /**
+     * @brief Schedule an operation on the execution context without expectations of a result
+     * @note Errors are caught internally and logged as errors
+     *
+     * @param fn The block of code to execute
+     */
+    void
+    submit(SomeHandlerWithoutStopToken auto&& fn)
+    {
+        pimpl_->submit(std::forward<decltype(fn)>(fn));
+    }
+
+    /**
      * @brief Make a strand for this execution context
      *
      * @return A strand for this execution context
@@ -276,6 +288,7 @@ private:
         virtual impl::ErasedOperation
             scheduleAfter(std::chrono::milliseconds, std::function<std::any(AnyStopToken, bool)>) = 0;
         virtual impl::ErasedOperation executeRepeatedly(std::chrono::milliseconds, std::function<std::any()>) = 0;
+        virtual void submit(std::function<void()>) = 0;
         virtual AnyStrand
         makeStrand() = 0;
         virtual void
@@ -321,6 +334,12 @@ private:
         executeRepeatedly(std::chrono::milliseconds interval, std::function<std::any()> fn) override
         {
             return ctx.executeRepeatedly(interval, std::move(fn));
+        }
+
+        void
+        submit(std::function<void()> fn) override
+        {
+            return ctx.submit(std::move(fn));
         }
 
         AnyStrand

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -85,15 +85,15 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn())>;
+        using RetType = std::decay_t<decltype(std::invoke(fn))>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
             if constexpr (std::is_void_v<RetType>) {
-                fn();
+                std::invoke(fn);
                 return {};
             } else {
-                return std::make_any<RetType>(fn());
+                return std::make_any<RetType>(std::invoke(fn));
             }
         }));
     }
@@ -217,13 +217,13 @@ public:
     [[nodiscard]] auto
     executeRepeatedly(SomeStdDuration auto interval, SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn())>;
+        using RetType = std::decay_t<decltype(std::invoke(fn))>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
             pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                fn();
+                std::invoke(fn);
                 return {};
             })
         );

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -88,12 +88,12 @@ public:
         using RetType = std::decay_t<decltype(std::invoke(fn))>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
-        return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
+        return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)] mutable -> std::any {
             if constexpr (std::is_void_v<RetType>) {
-                std::invoke(std::move(fn));
+                std::invoke(std::forward<decltype(fn)>(fn));
                 return {};
             } else {
-                return std::make_any<RetType>(std::invoke(std::move(fn)));
+                return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn)));
             }
         }));
     }
@@ -222,8 +222,8 @@ public:
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
-            pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                std::invoke(std::move(fn));
+            pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] mutable -> std::any {
+                std::invoke(std::forward<decltype(fn)>(fn));
                 return {};
             })
         );

--- a/src/util/async/AnyExecutionContext.hpp
+++ b/src/util/async/AnyExecutionContext.hpp
@@ -85,7 +85,7 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(std::invoke(fn))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)] mutable -> std::any {
@@ -109,17 +109,19 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWith<AnyStopToken> auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>()))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
-        return AnyOperation<RetType>(pimpl_->execute([fn = std::forward<decltype(fn)>(fn)](auto stopToken) -> std::any {
-            if constexpr (std::is_void_v<RetType>) {
-                fn(std::move(stopToken));
-                return {};
-            } else {
-                return std::make_any<RetType>(fn(std::move(stopToken)));
-            }
-        }));
+        return AnyOperation<RetType>(
+            pimpl_->execute([fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable -> std::any {
+                if constexpr (std::is_void_v<RetType>) {
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
+                    return {};
+                } else {
+                    return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
+                }
+            })
+        );
     }
 
     /**
@@ -134,16 +136,16 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWith<AnyStopToken> auto&& fn, SomeStdDuration auto timeout)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>()))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(pimpl_->execute(
-            [fn = std::forward<decltype(fn)>(fn)](auto stopToken) -> std::any {
+            [fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    fn(std::move(stopToken));
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                     return {};
                 } else {
-                    return std::make_any<RetType>(fn(std::move(stopToken)));
+                    return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
                 }
             },
             std::chrono::duration_cast<std::chrono::milliseconds>(timeout)
@@ -162,17 +164,17 @@ public:
     [[nodiscard]] auto
     scheduleAfter(SomeStdDuration auto delay, SomeHandlerWith<AnyStopToken> auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>()))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(delay);
         return AnyOperation<RetType>(
-            pimpl_->scheduleAfter(millis, [fn = std::forward<decltype(fn)>(fn)](auto stopToken) -> std::any {
+            pimpl_->scheduleAfter(millis, [fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    fn(std::move(stopToken));
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                     return {};
                 } else {
-                    return std::make_any<RetType>(fn(std::move(stopToken)));
+                    return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
                 }
             })
         );
@@ -191,17 +193,19 @@ public:
     [[nodiscard]] auto
     scheduleAfter(SomeStdDuration auto delay, SomeHandlerWith<AnyStopToken, bool> auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>(), true))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken, bool>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(delay);
         return AnyOperation<RetType>(pimpl_->scheduleAfter(
-            millis, [fn = std::forward<decltype(fn)>(fn)](auto stopToken, auto cancelled) -> std::any {
+            millis, [fn = std::forward<decltype(fn)>(fn)](auto stopToken, auto cancelled) mutable -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    fn(std::move(stopToken), cancelled);
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken), cancelled);
                     return {};
                 } else {
-                    return std::make_any<RetType>(fn(std::move(stopToken), cancelled));
+                    return std::make_any<RetType>(
+                        std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken), cancelled)
+                    );
                 }
             }
         ));
@@ -217,7 +221,7 @@ public:
     [[nodiscard]] auto
     executeRepeatedly(SomeStdDuration auto interval, SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(std::invoke(fn))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -155,7 +155,7 @@ public:
 
     /**
      * @brief Schedule an operation on the execution context without expectations of a result
-     * @note Errors are caught internally and logged as errors
+     * @note Exceptions are caught internally and `ASSERT`ed on
      *
      * @param fn The block of code to execute
      */

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -68,12 +68,12 @@ public:
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
-            pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
+            pimpl_->execute([fn = std::forward<decltype(fn)>(fn)] mutable -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    std::invoke(std::move(fn));
+                    std::invoke(std::forward<decltype(fn)>(fn));
                     return {};
                 } else {
-                    return std::make_any<RetType>(std::invoke(std::move(fn)));
+                    return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn)));
                 }
             })
         );
@@ -146,8 +146,8 @@ public:
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
-            pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                std::invoke(std::move(fn));
+            pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] mutable -> std::any {
+                std::invoke(std::forward<decltype(fn)>(fn));
                 return {};
             })
         );

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -92,12 +92,12 @@ public:
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
-            pimpl_->execute([fn = std::forward<decltype(fn)>(fn)](auto stopToken) -> std::any {
+            pimpl_->execute([fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    fn(std::move(stopToken));
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                     return {};
                 } else {
-                    return std::make_any<RetType>(fn(std::move(stopToken)));
+                    return std::make_any<RetType>(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
                 }
             })
         );
@@ -118,12 +118,14 @@ public:
 
         return AnyOperation<RetType>(  //
             pimpl_->execute(
-                [fn = std::forward<decltype(fn)>(fn)](auto stopToken) -> std::any {
+                [fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable -> std::any {
                     if constexpr (std::is_void_v<RetType>) {
-                        fn(std::move(stopToken));
+                        std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                         return {};
                     } else {
-                        return std::make_any<RetType>(fn(std::move(stopToken)));
+                        return std::make_any<RetType>(
+                            std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken))
+                        );
                     }
                 },
                 std::chrono::duration_cast<std::chrono::milliseconds>(timeout)

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -64,7 +64,7 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(std::invoke(fn))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
@@ -88,7 +88,7 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWith<AnyStopToken> auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>()))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
@@ -113,7 +113,7 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWith<AnyStopToken> auto&& fn, SomeStdDuration auto timeout)
     {
-        using RetType = std::decay_t<decltype(fn(std::declval<AnyStopToken>()))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn), AnyStopToken>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
@@ -143,7 +143,7 @@ public:
     [[nodiscard]] auto
     executeRepeatedly(SomeStdDuration auto interval, SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(std::invoke(fn))>;
+        using RetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -153,6 +153,18 @@ public:
         );
     }
 
+    /**
+     * @brief Schedule an operation on the execution context without expectations of a result
+     * @note Errors are caught internally and logged as errors
+     *
+     * @param fn The block of code to execute
+     */
+    void
+    submit(SomeHandlerWithoutStopToken auto&& fn)
+    {
+        pimpl_->submit(std::forward<decltype(fn)>(fn));
+    }
+
 private:
     struct Concept {
         virtual ~Concept() = default;
@@ -165,6 +177,7 @@ private:
         [[nodiscard]] virtual impl::ErasedOperation execute(std::function<std::any()>) = 0;
         [[nodiscard]] virtual impl::ErasedOperation
             executeRepeatedly(std::chrono::milliseconds, std::function<std::any()>) = 0;
+        virtual void submit(std::function<void()>) = 0;
     };
 
     template <typename StrandType>
@@ -193,6 +206,12 @@ private:
         executeRepeatedly(std::chrono::milliseconds interval, std::function<std::any()> fn) override
         {
             return strand.executeRepeatedly(interval, std::move(fn));
+        }
+
+        void
+        submit(std::function<void()> fn) override
+        {
+            return strand.submit(std::move(fn));
         }
     };
 

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -70,10 +70,10 @@ public:
         return AnyOperation<RetType>(  //
             pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    std::invoke(fn);
+                    std::invoke(std::move(fn));
                     return {};
                 } else {
-                    return std::make_any<RetType>(std::invoke(fn));
+                    return std::make_any<RetType>(std::invoke(std::move(fn)));
                 }
             })
         );
@@ -147,7 +147,7 @@ public:
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
             pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                std::invoke(fn);
+                std::invoke(std::move(fn));
                 return {};
             })
         );

--- a/src/util/async/AnyStrand.hpp
+++ b/src/util/async/AnyStrand.hpp
@@ -64,16 +64,16 @@ public:
     [[nodiscard]] auto
     execute(SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn())>;
+        using RetType = std::decay_t<decltype(std::invoke(fn))>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         return AnyOperation<RetType>(  //
             pimpl_->execute([fn = std::forward<decltype(fn)>(fn)]() -> std::any {
                 if constexpr (std::is_void_v<RetType>) {
-                    fn();
+                    std::invoke(fn);
                     return {};
                 } else {
-                    return std::make_any<RetType>(fn());
+                    return std::make_any<RetType>(std::invoke(fn));
                 }
             })
         );
@@ -141,13 +141,13 @@ public:
     [[nodiscard]] auto
     executeRepeatedly(SomeStdDuration auto interval, SomeHandlerWithoutStopToken auto&& fn)
     {
-        using RetType = std::decay_t<decltype(fn())>;
+        using RetType = std::decay_t<decltype(std::invoke(fn))>;
         static_assert(not std::is_same_v<RetType, std::any>);
 
         auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
         return AnyOperation<RetType>(  //
             pimpl_->executeRepeatedly(millis, [fn = std::forward<decltype(fn)>(fn)] -> std::any {
-                fn();
+                std::invoke(fn);
                 return {};
             })
         );

--- a/src/util/async/README.md
+++ b/src/util/async/README.md
@@ -91,11 +91,14 @@ Scheduled operations can be aborted by calling
 
 ### Error handling
 
-By default, exceptions that happen during the execution of user-provided code are caught and returned in the error channel of `std::expected` as an instance of the `ExecutionError` struct. The user can then extract the error message by calling `what()` or directly accessing the `message` member.
+For APIs that return an Operation, by default, exceptions that happen during the execution of user-provided code are caught and returned in the error channel of `std::expected` as an instance of the `ExecutionError` struct. The user can then extract the error message by calling `what()` or directly accessing the `message` member.
+In the `submit` API however, exceptions are caught and `ASSERT`ed on.
 
 ### Returned value
 
-If the user-provided lambda returns anything but `void`, the type and value will propagate through the operation object and can be received by calling `get` which will block until a value or an error is available.
+For `submit` API the return type is always `void`.
+
+For other APIs, if the user-provided lambda returns anything but `void`, the type and value will propagate through the operation object and can be received by calling `get` which will block until a value or an error is available.
 
 The `wait` member function can be used when the user just wants to wait for the value to become available but not necessarily getting at the value just yet.
 
@@ -121,6 +124,12 @@ Since this wrapper does not know which operation type it's wrapping it only prov
 This section provides some examples. For more examples take a look at `ExecutionContextBenchmarks`, `AsyncExecutionContextTests` and `AnyExecutionContextTests`.
 
 ### Regular operation
+
+#### One shot tasks
+
+```cpp
+ctx.submit([]() { /* do something */ });
+```
 
 #### Awaiting and reading values
 

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -139,7 +139,7 @@ class BasicExecutionContext {
 public:
     /** @brief Whether operations on this execution context are noexcept */
     static constexpr bool kIS_NOEXCEPT = noexcept(ErrorHandlerType::wrap([](auto&) { throw 0; })) and
-        noexcept(ErrorHandlerType::silence([] { throw 0; }));
+        noexcept(ErrorHandlerType::catchAndAssert([] { throw 0; }));
 
     using ContextHolderType = ContextType;
 
@@ -364,14 +364,14 @@ public:
 
     /**
      * @brief Schedule an operation on the execution context without expectations of a result
-     * @note Errors are caught internally and logged as errors
+     * @note Exceptions are caught internally and `ASSERT`ed on
      *
      * @param fn The block of code to execute
      */
     void
     submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
     {
-        DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+        DispatcherType::post(context_, ErrorHandlerType::catchAndAssert(fn));
     }
 
     /**

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -368,10 +368,10 @@ public:
      *
      * @param fn The block of code to execute
      */
-    [[nodiscard]] auto
+    void
     submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
     {
-        return DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+        DispatcherType::post(context_, ErrorHandlerType::silence(fn));
     }
 
     /**

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -216,11 +216,11 @@ public:
                 delay,
                 [this, timeout, fn = std::forward<decltype(fn)>(fn)](auto) mutable {
                     return this->execute(
-                        [fn = std::forward<decltype(fn)>(fn)](auto stopToken) {
+                        [fn = std::forward<decltype(fn)>(fn)](auto stopToken) mutable {
                             if constexpr (std::is_void_v<FnRetType>) {
-                                fn(std::move(stopToken));
+                                std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                             } else {
-                                return fn(std::move(stopToken));
+                                return std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                             }
                         },
                         timeout

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -138,7 +138,8 @@ class BasicExecutionContext {
 
 public:
     /** @brief Whether operations on this execution context are noexcept */
-    static constexpr bool kIS_NOEXCEPT = noexcept(ErrorHandlerType::wrap([](auto&) { throw 0; }));
+    static constexpr bool kIS_NOEXCEPT = noexcept(ErrorHandlerType::wrap([](auto&) { throw 0; })) and
+        noexcept(ErrorHandlerType::silence([] { throw 0; }));
 
     using ContextHolderType = ContextType;
 
@@ -350,12 +351,12 @@ public:
             context_,
             impl::outcomeForHandler<StopSourceType>(fn),
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
-                using FnRetType = std::decay_t<decltype(fn())>;
+                using FnRetType = std::decay_t<decltype(std::invoke(fn))>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    fn();
+                    std::invoke(fn);
                     outcome.setValue();
                 } else {
-                    outcome.setValue(fn());
+                    outcome.setValue(std::invoke(fn));
                 }
             })
         );

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -362,6 +362,18 @@ public:
     }
 
     /**
+     * @brief Schedule an operation on the execution context without expectations of a result
+     * @note Errors are caught internally and logged as errors
+     *
+     * @param fn The block of code to execute
+     */
+    [[nodiscard]] auto
+    submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
+    {
+        return DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+    }
+
+    /**
      * @brief Create a strand for this execution context
      *
      * @return A strand for this execution context

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -210,7 +210,7 @@ public:
                 delay, std::forward<decltype(fn)>(fn), timeout
             );
         } else {
-            using FnRetType = std::decay_t<decltype(fn(std::declval<StopToken>()))>;
+            using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken>>;
             return ScheduledOperation<FnRetType>(
                 impl::extractAssociatedExecutor(*this),
                 delay,
@@ -250,7 +250,7 @@ public:
                 delay, std::forward<decltype(fn)>(fn), timeout
             );
         } else {
-            using FnRetType = std::decay_t<decltype(fn(std::declval<StopToken>(), true))>;
+            using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken, bool>>;
             return ScheduledOperation<FnRetType>(
                 impl::extractAssociatedExecutor(*this),
                 delay,
@@ -311,7 +311,7 @@ public:
                 [[maybe_unused]] auto timeoutHandler =
                     impl::getTimeoutHandleIfNeeded(TimerContextProvider::getContext(*this), timeout, stopSource);
 
-                using FnRetType = std::decay_t<decltype(fn(std::declval<StopToken>()))>;
+                using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken>>;
                 if constexpr (std::is_void_v<FnRetType>) {
                     fn(std::move(stopToken));
                     outcome.setValue();
@@ -351,12 +351,12 @@ public:
             context_,
             impl::outcomeForHandler<StopSourceType>(fn),
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
-                using FnRetType = std::decay_t<decltype(std::invoke(fn))>;
+                using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    std::invoke(fn);
+                    std::invoke(std::move(fn));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(std::invoke(fn));
+                    outcome.setValue(std::invoke(std::move(fn)));
                 }
             })
         );

--- a/src/util/async/context/BasicExecutionContext.hpp
+++ b/src/util/async/context/BasicExecutionContext.hpp
@@ -257,11 +257,11 @@ public:
                 [this, timeout, fn = std::forward<decltype(fn)>(fn)](auto ec) mutable {
                     return this->execute(
                         [fn = std::forward<decltype(fn)>(fn),
-                         isAborted = (ec == boost::asio::error::operation_aborted)](auto stopToken) {
+                         isAborted = (ec == boost::asio::error::operation_aborted)](auto stopToken) mutable {
                             if constexpr (std::is_void_v<FnRetType>) {
-                                fn(std::move(stopToken), isAborted);
+                                std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken), isAborted);
                             } else {
-                                return fn(std::move(stopToken), isAborted);
+                                return std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken), isAborted);
                             }
                         },
                         timeout
@@ -313,10 +313,10 @@ public:
 
                 using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    fn(std::move(stopToken));
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(fn(std::move(stopToken)));
+                    outcome.setValue(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
                 }
             })
         );
@@ -353,10 +353,10 @@ public:
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
                 using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    std::invoke(std::move(fn));
+                    std::invoke(std::forward<decltype(fn)>(fn));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(std::invoke(std::move(fn)));
+                    outcome.setValue(std::invoke(std::forward<decltype(fn)>(fn)));
                 }
             })
         );

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -56,7 +56,7 @@ struct SpawnDispatchStrategy {
     static void
     post(ContextType& ctx, auto&& fn)
     {
-        util::spawn(ctx.getExecutor(), [fn = std::forward<decltype(fn)>(fn)](auto) mutable { fn(); });
+        util::spawn(ctx.getExecutor(), [fn = std::forward<decltype(fn)>(fn)](auto) mutable { std::invoke(fn); });
     }
 };
 
@@ -111,7 +111,7 @@ struct SyncDispatchStrategy {
     static void
     post([[maybe_unused]] ContextType& ctx, auto&& fn)
     {
-        fn();
+        std::invoke(fn);
     }
 };
 

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -42,9 +42,9 @@ struct SpawnDispatchStrategy {
              fn = std::forward<decltype(fn)>(fn)](auto yield) mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    fn(outcome, stopSource, stopSource[yield]);
+                    std::invoke(fn, outcome, stopSource, stopSource[yield]);
                 } else {
-                    fn(outcome);
+                    std::invoke(fn, outcome);
                 }
             }
         );
@@ -72,9 +72,9 @@ struct PostDispatchStrategy {
             [outcome = std::forward<decltype(outcome)>(outcome), fn = std::forward<decltype(fn)>(fn)]() mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    fn(outcome, stopSource, stopSource.getToken());
+                    std::invoke(fn, outcome, stopSource, stopSource.getToken());
                 } else {
-                    fn(outcome);
+                    std::invoke(fn, outcome);
                 }
             }
         );
@@ -99,9 +99,9 @@ struct SyncDispatchStrategy {
 
         if constexpr (SomeStoppableOutcome<OutcomeType>) {
             auto& stopSource = outcome.getStopSource();
-            fn(outcome, stopSource, stopSource.getToken());
+            std::invoke(fn, outcome, stopSource, stopSource.getToken());
         } else {
-            fn(outcome);
+            std::invoke(fn, outcome);
         }
 
         return op;

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -55,7 +55,9 @@ struct SpawnDispatchStrategy {
     static void
     post(ContextType& ctx, FnType&& fn)
     {
-        util::spawn(ctx.getExecutor(), [fn = std::forward<FnType>(fn)](auto) mutable { std::invoke(std::move(fn)); });
+        util::spawn(ctx.getExecutor(), [fn = std::forward<FnType>(fn)](auto) mutable {
+            std::invoke(std::forward<decltype(fn)>(fn));
+        });
     }
 };
 

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -51,6 +51,13 @@ struct SpawnDispatchStrategy {
 
         return op;
     }
+
+    template <typename ContextType>
+    static void
+    post(ContextType& ctx, auto&& fn)
+    {
+        util::spawn(ctx.getExecutor(), [fn = std::forward<decltype(fn)>(fn)](auto) mutable { fn(); });
+    }
 };
 
 struct PostDispatchStrategy {
@@ -74,6 +81,13 @@ struct PostDispatchStrategy {
 
         return op;
     }
+
+    template <typename ContextType>
+    static void
+    post(ContextType& ctx, auto&& fn)
+    {
+        boost::asio::post(ctx.getExecutor(), std::forward<decltype(fn)>(fn));
+    }
 };
 
 struct SyncDispatchStrategy {
@@ -91,6 +105,13 @@ struct SyncDispatchStrategy {
         }
 
         return op;
+    }
+
+    template <typename ContextType>
+    static void
+    post([[maybe_unused]] ContextType& ctx, auto&& fn)
+    {
+        fn();
     }
 };
 

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -41,9 +41,9 @@ struct SpawnDispatchStrategy {
             [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)](auto yield) mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    std::invoke(std::move(fn), outcome, stopSource, stopSource[yield]);
+                    std::invoke(std::forward<decltype(fn)>(fn), outcome, stopSource, stopSource[yield]);
                 } else {
-                    std::invoke(std::move(fn), outcome);
+                    std::invoke(std::forward<decltype(fn)>(fn), outcome);
                 }
             }
         );
@@ -70,9 +70,9 @@ struct PostDispatchStrategy {
             ctx.getExecutor(), [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)]() mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    std::invoke(std::move(fn), outcome, stopSource, stopSource.getToken());
+                    std::invoke(std::forward<decltype(fn)>(fn), outcome, stopSource, stopSource.getToken());
                 } else {
-                    std::invoke(std::move(fn), outcome);
+                    std::invoke(std::forward<decltype(fn)>(fn), outcome);
                 }
             }
         );

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -30,21 +30,20 @@
 namespace util::async::impl {
 
 struct SpawnDispatchStrategy {
-    template <typename ContextType, SomeOutcome OutcomeType>
+    template <typename ContextType, SomeOutcome OutcomeType, typename FnType>
     [[nodiscard]] static auto
-    dispatch(ContextType& ctx, OutcomeType&& outcome, auto&& fn)
+    dispatch(ContextType& ctx, OutcomeType&& outcome, FnType&& fn)
     {
         auto op = outcome.getOperation();
 
         util::spawn(
             ctx.getExecutor(),
-            [outcome = std::forward<decltype(outcome)>(outcome),
-             fn = std::forward<decltype(fn)>(fn)](auto yield) mutable {
+            [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)](auto yield) mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    std::invoke(fn, outcome, stopSource, stopSource[yield]);
+                    std::invoke(std::move(fn), outcome, stopSource, stopSource[yield]);
                 } else {
-                    std::invoke(fn, outcome);
+                    std::invoke(std::move(fn), outcome);
                 }
             }
         );
@@ -52,29 +51,28 @@ struct SpawnDispatchStrategy {
         return op;
     }
 
-    template <typename ContextType>
+    template <typename ContextType, typename FnType>
     static void
-    post(ContextType& ctx, auto&& fn)
+    post(ContextType& ctx, FnType&& fn)
     {
-        util::spawn(ctx.getExecutor(), [fn = std::forward<decltype(fn)>(fn)](auto) mutable { std::invoke(fn); });
+        util::spawn(ctx.getExecutor(), [fn = std::forward<FnType>(fn)](auto) mutable { std::invoke(std::move(fn)); });
     }
 };
 
 struct PostDispatchStrategy {
-    template <typename ContextType, SomeOutcome OutcomeType>
+    template <typename ContextType, SomeOutcome OutcomeType, typename FnType>
     [[nodiscard]] static auto
-    dispatch(ContextType& ctx, OutcomeType&& outcome, auto&& fn)
+    dispatch(ContextType& ctx, OutcomeType&& outcome, FnType&& fn)
     {
         auto op = outcome.getOperation();
 
         boost::asio::post(
-            ctx.getExecutor(),
-            [outcome = std::forward<decltype(outcome)>(outcome), fn = std::forward<decltype(fn)>(fn)]() mutable {
+            ctx.getExecutor(), [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)]() mutable {
                 if constexpr (SomeStoppableOutcome<OutcomeType>) {
                     auto& stopSource = outcome.getStopSource();
-                    std::invoke(fn, outcome, stopSource, stopSource.getToken());
+                    std::invoke(std::move(fn), outcome, stopSource, stopSource.getToken());
                 } else {
-                    std::invoke(fn, outcome);
+                    std::invoke(std::move(fn), outcome);
                 }
             }
         );
@@ -82,36 +80,36 @@ struct PostDispatchStrategy {
         return op;
     }
 
-    template <typename ContextType>
+    template <typename ContextType, typename FnType>
     static void
-    post(ContextType& ctx, auto&& fn)
+    post(ContextType& ctx, FnType&& fn)
     {
-        boost::asio::post(ctx.getExecutor(), std::forward<decltype(fn)>(fn));
+        boost::asio::post(ctx.getExecutor(), std::forward<FnType>(fn));
     }
 };
 
 struct SyncDispatchStrategy {
-    template <typename ContextType, SomeOutcome OutcomeType>
+    template <typename ContextType, SomeOutcome OutcomeType, typename FnType>
     [[nodiscard]] static auto
-    dispatch([[maybe_unused]] ContextType& ctx, OutcomeType outcome, auto&& fn)
+    dispatch([[maybe_unused]] ContextType& ctx, OutcomeType outcome, FnType&& fn)
     {
         auto op = outcome.getOperation();
 
         if constexpr (SomeStoppableOutcome<OutcomeType>) {
             auto& stopSource = outcome.getStopSource();
-            std::invoke(fn, outcome, stopSource, stopSource.getToken());
+            std::invoke(std::forward<FnType>(fn), outcome, stopSource, stopSource.getToken());
         } else {
-            std::invoke(fn, outcome);
+            std::invoke(std::forward<FnType>(fn), outcome);
         }
 
         return op;
     }
 
-    template <typename ContextType>
+    template <typename ContextType, typename FnType>
     static void
-    post([[maybe_unused]] ContextType& ctx, auto&& fn)
+    post([[maybe_unused]] ContextType& ctx, FnType&& fn)
     {
-        std::invoke(fn);
+        std::invoke(std::forward<FnType>(fn));
     }
 };
 

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -128,6 +128,12 @@ public:
             return RepeatedOperation(impl::extractAssociatedExecutor(*this), interval, std::forward<decltype(fn)>(fn));
         }
     }
+
+    [[nodiscard]] auto
+    submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
+    {
+        return DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+    }
 };
 
 }  // namespace util::async::impl

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -129,10 +129,10 @@ public:
         }
     }
 
-    [[nodiscard]] auto
+    void
     submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
     {
-        return DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+        DispatcherType::post(context_, ErrorHandlerType::silence(fn));
     }
 };
 

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -83,10 +83,10 @@ public:
 
                 using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    fn(std::move(stopToken));
+                    std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(fn(std::move(stopToken)));
+                    outcome.setValue(std::invoke(std::forward<decltype(fn)>(fn), std::move(stopToken)));
                 }
             })
         );

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -132,7 +132,7 @@ public:
     void
     submit(SomeHandlerWithoutStopToken auto&& fn) noexcept(kIS_NOEXCEPT)
     {
-        DispatcherType::post(context_, ErrorHandlerType::silence(fn));
+        DispatcherType::post(context_, ErrorHandlerType::catchAndAssert(fn));
     }
 };
 

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -110,10 +110,10 @@ public:
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
                 using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    std::invoke(std::move(fn));
+                    std::invoke(std::forward<decltype(fn)>(fn));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(std::invoke(std::move(fn)));
+                    outcome.setValue(std::invoke(std::forward<decltype(fn)>(fn)));
                 }
             })
         );

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -108,12 +108,12 @@ public:
             context_,
             impl::outcomeForHandler<StopSourceType>(fn),
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
-                using FnRetType = std::decay_t<decltype(fn())>;
+                using FnRetType = std::decay_t<decltype(std::invoke(fn))>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    fn();
+                    std::invoke(fn);
                     outcome.setValue();
                 } else {
-                    outcome.setValue(fn());
+                    outcome.setValue(std::invoke(fn));
                 }
             })
         );

--- a/src/util/async/context/impl/Strand.hpp
+++ b/src/util/async/context/impl/Strand.hpp
@@ -81,7 +81,7 @@ public:
                     TimerContextProvider::getContext(parentContext_.get()), timeout, stopSource
                 );
 
-                using FnRetType = std::decay_t<decltype(fn(std::declval<StopToken>()))>;
+                using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), StopToken>>;
                 if constexpr (std::is_void_v<FnRetType>) {
                     fn(std::move(stopToken));
                     outcome.setValue();
@@ -108,12 +108,12 @@ public:
             context_,
             impl::outcomeForHandler<StopSourceType>(fn),
             ErrorHandlerType::wrap([fn = std::forward<decltype(fn)>(fn)](auto& outcome) mutable {
-                using FnRetType = std::decay_t<decltype(std::invoke(fn))>;
+                using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
                 if constexpr (std::is_void_v<FnRetType>) {
-                    std::invoke(fn);
+                    std::invoke(std::move(fn));
                     outcome.setValue();
                 } else {
-                    outcome.setValue(std::invoke(fn));
+                    outcome.setValue(std::invoke(std::move(fn)));
                 }
             })
         );

--- a/src/util/async/context/impl/Utils.hpp
+++ b/src/util/async/context/impl/Utils.hpp
@@ -66,7 +66,7 @@ outcomeForHandler(auto&& fn)
 
         return StoppableOutcome<RetType, StopSourceType>();
     } else {
-        using FnRetType = decltype(fn());
+        using FnRetType = decltype(std::invoke(fn));
         using RetType = std::expected<FnRetType, ExecutionError>;
 
         return Outcome<RetType>();

--- a/src/util/async/context/impl/Utils.hpp
+++ b/src/util/async/context/impl/Utils.hpp
@@ -29,6 +29,7 @@
 
 #include <expected>
 #include <optional>
+#include <type_traits>
 
 namespace util::async::impl {
 
@@ -61,12 +62,12 @@ template <SomeStopSource StopSourceType>
 outcomeForHandler(auto&& fn)
 {
     if constexpr (SomeHandlerWith<decltype(fn), typename StopSourceType::Token>) {
-        using FnRetType = decltype(fn(std::declval<typename StopSourceType::Token>()));
+        using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn), typename StopSourceType::Token>>;
         using RetType = std::expected<FnRetType, ExecutionError>;
 
         return StoppableOutcome<RetType, StopSourceType>();
     } else {
-        using FnRetType = decltype(std::invoke(fn));
+        using FnRetType = std::decay_t<std::invoke_result_t<decltype(fn)>>;
         using RetType = std::expected<FnRetType, ExecutionError>;
 
         return Outcome<RetType>();

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -55,9 +55,9 @@ struct DefaultErrorHandler {
     [[nodiscard]] static auto
     catchAndAssert(auto&& fn) noexcept  // note this is a lie when used with MockAssert (use MockAssertNoThrow)
     {
-        return [fn = std::forward<decltype(fn)>(fn)] {
+        return [fn = std::forward<decltype(fn)>(fn)] mutable {
             try {
-                std::invoke(std::move(std::move(fn)));
+                std::invoke(std::forward<decltype(fn)>(fn));
             } catch (std::exception const& e) {
                 ASSERT(false, "Exception caught: {}", e.what());
             } catch (...) {

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -21,6 +21,7 @@
 
 #include "util/async/Concepts.hpp"
 #include "util/async/Error.hpp"
+#include "util/log/Logger.hpp"
 
 #include <fmt/format.h>
 #include <fmt/std.h>
@@ -50,11 +51,33 @@ struct DefaultErrorHandler {
                 }
             };
     }
+
+    [[nodiscard]] static auto
+    silence(auto&& fn) noexcept
+    {
+        return [fn = std::forward<decltype(fn)>(fn)] {
+            try {
+                fn();
+            } catch (std::exception const& e) {
+                util::Logger log("AsyncFramework");
+                LOG(log.error()) << "Exception silenced: " << e.what() << " on thread " << std::this_thread::get_id();
+            } catch (...) {
+                util::Logger log("AsyncFramework");
+                LOG(log.error()) << "Unknown exception silenced on thread " << std::this_thread::get_id();
+            }
+        };
+    }
 };
 
 struct NoErrorHandler {
     [[nodiscard]] static constexpr auto
     wrap(auto&& fn)
+    {
+        return std::forward<decltype(fn)>(fn);
+    }
+
+    [[nodiscard]] static constexpr auto
+    silence(auto&& fn)
     {
         return std::forward<decltype(fn)>(fn);
     }

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -57,7 +57,7 @@ struct DefaultErrorHandler {
     {
         return [fn = std::forward<decltype(fn)>(fn)] {
             try {
-                fn();
+                std::invoke(fn);
             } catch (std::exception const& e) {
                 util::Logger log("AsyncFramework");
                 LOG(log.error()) << "Exception silenced: " << e.what() << " on thread " << std::this_thread::get_id();

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -19,9 +19,9 @@
 
 #pragma once
 
+#include "util/Assert.hpp"
 #include "util/async/Concepts.hpp"
 #include "util/async/Error.hpp"
-#include "util/log/Logger.hpp"
 
 #include <fmt/format.h>
 #include <fmt/std.h>
@@ -53,17 +53,15 @@ struct DefaultErrorHandler {
     }
 
     [[nodiscard]] static auto
-    silence(auto&& fn) noexcept
+    catchAndAssert(auto&& fn) noexcept  // note this is a lie when used with MockAssert (use MockAssertNoThrow)
     {
         return [fn = std::forward<decltype(fn)>(fn)] {
             try {
                 std::invoke(fn);
             } catch (std::exception const& e) {
-                util::Logger log("AsyncFramework");
-                LOG(log.error()) << "Exception silenced: " << e.what() << " on thread " << std::this_thread::get_id();
+                ASSERT(false, "Exception caught: {}", e.what());
             } catch (...) {
-                util::Logger log("AsyncFramework");
-                LOG(log.error()) << "Unknown exception silenced on thread " << std::this_thread::get_id();
+                ASSERT(false, "Unknown exception caught");
             }
         };
     }
@@ -77,7 +75,7 @@ struct NoErrorHandler {
     }
 
     [[nodiscard]] static constexpr auto
-    silence(auto&& fn)
+    catchAndAssert(auto&& fn)
     {
         return std::forward<decltype(fn)>(fn);
     }

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -39,7 +39,7 @@ struct DefaultErrorHandler {
         return
             [fn = std::forward<decltype(fn)>(fn)]<typename... Args>(SomeOutcome auto& outcome, Args&&... args) mutable {
                 try {
-                    fn(outcome, std::forward<Args>(args)...);
+                    std::invoke(std::forward<decltype(fn)>(fn), outcome, std::forward<Args>(args)...);
                 } catch (std::exception const& e) {
                     outcome.setValue(
                         std::unexpected(ExecutionError{fmt::format("{}", std::this_thread::get_id()), e.what()})

--- a/src/util/async/impl/ErrorHandling.hpp
+++ b/src/util/async/impl/ErrorHandling.hpp
@@ -57,7 +57,7 @@ struct DefaultErrorHandler {
     {
         return [fn = std::forward<decltype(fn)>(fn)] {
             try {
-                std::invoke(fn);
+                std::invoke(std::move(std::move(fn)));
             } catch (std::exception const& e) {
                 ASSERT(false, "Exception caught: {}", e.what());
             } catch (...) {

--- a/tests/common/data/cassandra/FakesAndMocks.hpp
+++ b/tests/common/data/cassandra/FakesAndMocks.hpp
@@ -124,6 +124,6 @@ struct FakeRetryPolicy {
     void
     retry(Fn&& fn)
     {
-        fn();
+        std::invoke(fn);
     }
 };

--- a/tests/common/data/cassandra/FakesAndMocks.hpp
+++ b/tests/common/data/cassandra/FakesAndMocks.hpp
@@ -124,6 +124,6 @@ struct FakeRetryPolicy {
     void
     retry(Fn&& fn)
     {
-        std::invoke(fn);
+        std::invoke(std::forward<decltype(fn)>(fn));
     }
 };

--- a/tests/common/util/MockAssert.hpp
+++ b/tests/common/util/MockAssert.hpp
@@ -28,7 +28,6 @@
 #include <string_view>
 
 namespace common::util {
-
 class WithMockAssert : virtual public testing::Test {
 public:
     struct MockAssertException {
@@ -64,11 +63,17 @@ public:
             common::util::WithMockAssert::MockAssertException                                                 \
         );                                                                                                    \
     } else if (dynamic_cast<common::util::WithMockAssertNoThrow*>(this) != nullptr) {                         \
-        testing::StrictMock<testing::MockFunction<void(std::string_view)>> callMock;                          \
-        ::util::impl::OnAssert::setAction([&callMock](std::string_view m) { callMock.Call(m); });             \
-        EXPECT_CALL(callMock, Call(testing::ContainsRegex(message_regex)));                                   \
+        struct MockGuard {                                                                                    \
+            testing::StrictMock<testing::MockFunction<void(std::string_view)>> mock;                          \
+            ~MockGuard()                                                                                      \
+            {                                                                                                 \
+                ::util::impl::OnAssert::resetAction();                                                        \
+            }                                                                                                 \
+        };                                                                                                    \
+        auto mockGuard = std::make_shared<MockGuard>();                                                       \
+        ::util::impl::OnAssert::setAction([mockGuard](std::string_view m) { mockGuard->mock.Call(m); });      \
+        EXPECT_CALL(mockGuard->mock, Call(testing::ContainsRegex(message_regex)));                            \
         statement;                                                                                            \
-        ::util::impl::OnAssert::resetAction();                                                                \
     } else {                                                                                                  \
         std::cerr << "EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE() can be used only inside test body" << std::endl; \
         std::terminate();                                                                                     \

--- a/tests/common/util/MockAssert.hpp
+++ b/tests/common/util/MockAssert.hpp
@@ -47,36 +47,42 @@ public:
     ~WithMockAssertNoThrow() override;
 };
 
+namespace impl {
+template <typename T>
+struct MockGuard {
+    T mock;
+    ~MockGuard()
+    {
+        ::util::impl::OnAssert::resetAction();
+    }
+};
+}  // namespace impl
+
 }  // namespace common::util
 
-#define EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE(statement, message_regex)                                        \
-    if (dynamic_cast<common::util::WithMockAssert*>(this) != nullptr) {                                       \
-        EXPECT_THROW(                                                                                         \
-            {                                                                                                 \
-                try {                                                                                         \
-                    statement;                                                                                \
-                } catch (common::util::WithMockAssert::MockAssertException const& e) {                        \
-                    EXPECT_THAT(e.message, testing::ContainsRegex(message_regex));                            \
-                    throw;                                                                                    \
-                }                                                                                             \
-            },                                                                                                \
-            common::util::WithMockAssert::MockAssertException                                                 \
-        );                                                                                                    \
-    } else if (dynamic_cast<common::util::WithMockAssertNoThrow*>(this) != nullptr) {                         \
-        struct MockGuard {                                                                                    \
-            testing::StrictMock<testing::MockFunction<void(std::string_view)>> mock;                          \
-            ~MockGuard()                                                                                      \
-            {                                                                                                 \
-                ::util::impl::OnAssert::resetAction();                                                        \
-            }                                                                                                 \
-        };                                                                                                    \
-        auto mockGuard = std::make_shared<MockGuard>();                                                       \
-        ::util::impl::OnAssert::setAction([mockGuard](std::string_view m) { mockGuard->mock.Call(m); });      \
-        EXPECT_CALL(mockGuard->mock, Call(testing::ContainsRegex(message_regex)));                            \
-        statement;                                                                                            \
-    } else {                                                                                                  \
-        std::cerr << "EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE() can be used only inside test body" << std::endl; \
-        std::terminate();                                                                                     \
+#define EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE(statement, message_regex)                                         \
+    if (dynamic_cast<common::util::WithMockAssert*>(this) != nullptr) {                                        \
+        EXPECT_THROW(                                                                                          \
+            {                                                                                                  \
+                try {                                                                                          \
+                    statement;                                                                                 \
+                } catch (common::util::WithMockAssert::MockAssertException const& e) {                         \
+                    EXPECT_THAT(e.message, testing::ContainsRegex(message_regex));                             \
+                    throw;                                                                                     \
+                }                                                                                              \
+            },                                                                                                 \
+            common::util::WithMockAssert::MockAssertException                                                  \
+        );                                                                                                     \
+    } else if (dynamic_cast<common::util::WithMockAssertNoThrow*>(this) != nullptr) {                          \
+        using MockGuardType =                                                                                  \
+            common::util::impl::MockGuard<testing::StrictMock<testing::MockFunction<void(std::string_view)>>>; \
+        auto mockGuard = std::make_shared<MockGuardType>();                                                    \
+        ::util::impl::OnAssert::setAction([mockGuard](std::string_view m) { mockGuard->mock.Call(m); });       \
+        EXPECT_CALL(mockGuard->mock, Call(testing::ContainsRegex(message_regex)));                             \
+        statement;                                                                                             \
+    } else {                                                                                                   \
+        std::cerr << "EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE() can be used only inside test body" << std::endl;  \
+        std::terminate();                                                                                      \
     }
 
 #define EXPECT_CLIO_ASSERT_FAIL(statement) EXPECT_CLIO_ASSERT_FAIL_WITH_MESSAGE(statement, ".*")

--- a/tests/common/util/MockExecutionContext.hpp
+++ b/tests/common/util/MockExecutionContext.hpp
@@ -84,6 +84,7 @@ struct MockExecutionContext {
         (std::chrono::milliseconds, std::function<std::any()>),
         ()
     );
+    MOCK_METHOD(void, submit, (std::function<void()>), ());
 
     MOCK_METHOD(MockStrand const&, makeStrand, (), ());
     MOCK_METHOD(void, stop, (), (const));

--- a/tests/common/util/MockLedgerFetcher.hpp
+++ b/tests/common/util/MockLedgerFetcher.hpp
@@ -20,12 +20,10 @@
 #pragma once
 
 #include "etl/LedgerFetcherInterface.hpp"
-#include "util/FakeFetchResponse.hpp"
 
 #include <gmock/gmock.h>
 
 #include <cstdint>
-#include <optional>
 
 struct MockLedgerFetcher {
     MOCK_METHOD(std::optional<FakeFetchResponse>, fetchData, (uint32_t), ());

--- a/tests/common/util/MockLedgerFetcher.hpp
+++ b/tests/common/util/MockLedgerFetcher.hpp
@@ -20,10 +20,12 @@
 #pragma once
 
 #include "etl/LedgerFetcherInterface.hpp"
+#include "util/FakeFetchResponse.hpp"
 
 #include <gmock/gmock.h>
 
 #include <cstdint>
+#include <optional>
 
 struct MockLedgerFetcher {
     MOCK_METHOD(std::optional<FakeFetchResponse>, fetchData, (uint32_t), ());

--- a/tests/common/util/MockStrand.hpp
+++ b/tests/common/util/MockStrand.hpp
@@ -69,4 +69,5 @@ struct MockStrand {
         (std::chrono::milliseconds, std::function<std::any()>),
         (const)
     );
+    MOCK_METHOD(void, submit, (std::function<void()>), (const));
 };

--- a/tests/unit/util/async/AsyncExecutionContextTests.cpp
+++ b/tests/unit/util/async/AsyncExecutionContextTests.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include "util/MockAssert.hpp"
 #include "util/Profiler.hpp"
 #include "util/async/Operation.hpp"
 #include "util/async/context/BasicExecutionContext.hpp"
@@ -38,7 +39,7 @@ using namespace util::async;
 using ::testing::Types;
 
 template <typename T>
-struct ExecutionContextTests : public ::testing::Test {
+struct ExecutionContextTests : public common::util::WithMockAssertNoThrow {
     using ExecutionContextType = T;
     ExecutionContextType ctx{2};
 
@@ -241,7 +242,7 @@ TYPED_TEST(ExecutionContextTests, repeatingOperationForceInvoke)
 
 TYPED_TEST(ExecutionContextTests, submit)
 {
-    ASSERT_NO_THROW(this->ctx.submit([] -> void { throw 0; }));
+    EXPECT_CLIO_ASSERT_FAIL(this->ctx.submit([] -> void { throw 0; }));
 
     std::atomic_uint32_t count = 0;
     std::binary_semaphore sem{0};
@@ -358,7 +359,7 @@ TYPED_TEST(ExecutionContextTests, strandedRepeatingOperationForceInvoke)
 TYPED_TEST(ExecutionContextTests, strandSubmit)
 {
     auto strand = this->ctx.makeStrand();
-    ASSERT_NO_THROW(strand.submit([] -> void { throw 0; }));
+    EXPECT_CLIO_ASSERT_FAIL(strand.submit([] -> void { throw 0; }));
 
     std::vector<int> results;
     std::binary_semaphore sem{0};

--- a/tests/unit/util/async/AsyncExecutionContextTests.cpp
+++ b/tests/unit/util/async/AsyncExecutionContextTests.cpp
@@ -32,6 +32,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 using namespace util::async;
 using ::testing::Types;
@@ -238,6 +239,32 @@ TYPED_TEST(ExecutionContextTests, repeatingOperationForceInvoke)
     EXPECT_EQ(callCount, 0uz);
 }
 
+TYPED_TEST(ExecutionContextTests, submit)
+{
+    ASSERT_NO_THROW(this->ctx.submit([] -> void { throw 0; }));
+
+    std::atomic_uint32_t count = 0;
+    std::binary_semaphore sem{0};
+
+    static constexpr auto kNUM_SUBMISSIONS = 1024;
+
+    for (auto i = 1; i <= kNUM_SUBMISSIONS; ++i) {
+        if (i == kNUM_SUBMISSIONS) {
+            this->ctx.submit([&count, &sem] {
+                ++count;
+                sem.release();
+            });
+        } else {
+            this->ctx.submit([&count] { ++count; });
+        }
+    }
+
+    sem.acquire();
+
+    // order is not guaranteed (see `strandSubmit` below)
+    ASSERT_EQ(count, static_cast<size_t>(kNUM_SUBMISSIONS));
+}
+
 TYPED_TEST(ExecutionContextTests, strandMove)
 {
     auto strand = this->ctx.makeStrand();
@@ -326,6 +353,35 @@ TYPED_TEST(ExecutionContextTests, strandedRepeatingOperationForceInvoke)
     res.abort();
 
     EXPECT_EQ(callCount, 0uz);
+}
+
+TYPED_TEST(ExecutionContextTests, strandSubmit)
+{
+    auto strand = this->ctx.makeStrand();
+    ASSERT_NO_THROW(strand.submit([] -> void { throw 0; }));
+
+    std::vector<int> results;
+    std::binary_semaphore sem{0};
+
+    static constexpr auto kNUM_SUBMISSIONS = 1024;
+
+    for (auto i = 1; i <= kNUM_SUBMISSIONS; ++i) {
+        if (i == kNUM_SUBMISSIONS) {
+            strand.submit([&results, &sem, i] {
+                results.push_back(i);
+                sem.release();
+            });
+        } else {
+            strand.submit([&results, i] { results.push_back(i); });
+        }
+    }
+
+    sem.acquire();
+
+    ASSERT_EQ(results.size(), static_cast<size_t>(kNUM_SUBMISSIONS));
+    for (int i = 0; i < kNUM_SUBMISSIONS; ++i) {
+        EXPECT_EQ(results[i], i + 1);
+    }
 }
 
 TYPED_TEST(AsyncExecutionContextTests, executeAutoAborts)

--- a/tests/unit/util/async/AsyncExecutionContextTests.cpp
+++ b/tests/unit/util/async/AsyncExecutionContextTests.cpp
@@ -39,7 +39,7 @@ using namespace util::async;
 using ::testing::Types;
 
 template <typename T>
-struct ExecutionContextTests : public common::util::WithMockAssertNoThrow {
+struct ExecutionContextTests : common::util::WithMockAssertNoThrow {
     using ExecutionContextType = T;
     ExecutionContextType ctx{2};
 


### PR DESCRIPTION
This adds a simple way to run one shot tasks that don't require a handle to retrieve the result (and no yield context).
It will come in handy for the publisher upgrade to AsyncContext.