### PR TITLE
chore: Change default `max_queue_size` to 1000

### DIFF
--- a/docs/config-description.md
+++ b/docs/config-description.md
@@ -293,7 +293,7 @@ This document provides a list of all available Clio configuration properties in 
 
 - **Required**: True
 - **Type**: int
-- **Default value**: `1`
+- **Default value**: `1000`
 - **Constraints**: The minimum value is `1`. The maximum value is `4294967295`.
 - **Description**: The maximum size of the server's request queue. If set to `0`, this means there is no queue size limit.
 

--- a/docs/examples/config/example-config.json
+++ b/docs/examples/config/example-config.json
@@ -61,7 +61,7 @@
     "ip": "0.0.0.0",
     "port": 51233,
     // Max number of requests to queue up before rejecting further requests.
-    // Defaults to 0, which disables the limit.
+    // Defaults to 1000 (use 0 to make the queue unbound).
     "max_queue_size": 500,
     // If request contains header with authorization, Clio will check if it matches the prefix 'Password ' + this value's sha256 hash
     // If matches, the request will be considered as admin request

--- a/src/util/config/ConfigDefinition.cpp
+++ b/src/util/config/ConfigDefinition.cpp
@@ -328,7 +328,7 @@ getClioConfig()
               .withConstraint(gValidateUint32)},
          {"server.ip", ConfigValue{ConfigType::String}.withConstraint(gValidateIp)},
          {"server.port", ConfigValue{ConfigType::Integer}.withConstraint(gValidatePort)},
-         {"server.max_queue_size", ConfigValue{ConfigType::Integer}.defaultValue(1).withConstraint(gValidateUint32)},
+         {"server.max_queue_size", ConfigValue{ConfigType::Integer}.defaultValue(1000).withConstraint(gValidateUint32)},
          {"server.local_admin", ConfigValue{ConfigType::Boolean}.optional()},
          {"server.admin_password", ConfigValue{ConfigType::String}.optional()},
          {"server.processing_policy",


### PR DESCRIPTION
This PR fixes the value of `max_queue_size`. It was 0 by default before we accidentally changed it to 1. 1 does not make sense because that makes the work queue essentially single-threaded. 0 is too permissive as well. 