### PR TITLE
chore: Add defines for asan/tsan to conan profile

### DIFF
--- a/docker/ci/conan/sanitizer_template.profile
+++ b/docker/ci/conan/sanitizer_template.profile
@@ -29,9 +29,9 @@ tools.build:exelinkflags+={{ sanitizer_link_flags }}
 tools.build:sharedlinkflags+={{ sanitizer_link_flags }}
 
 {% if sanitizer == "address" %}
-    *:tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
+    tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
 {% elif sanitizer == "thread" %}
-    *:tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
+    tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
 {% endif %}
 
 tools.info.package_id:confs+=["tools.build:cflags", "tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags", "tools.build:defines"]

--- a/docker/ci/conan/sanitizer_template.profile
+++ b/docker/ci/conan/sanitizer_template.profile
@@ -3,7 +3,11 @@
 {% set sanitizer_opt_map = {"asan": "address", "tsan": "thread", "ubsan": "undefined"} %}
 {% set sanitizer = sanitizer_opt_map[sani] %}
 
-{% set sanitizer_b2_flags_map = {"address": "define=BOOST_USE_ASAN=1 context-impl=ucontext address-sanitizer=on", "thread": "thread-sanitizer=on", "undefined": "undefined-sanitizer=on"} %}
+{% set sanitizer_b2_flags_map = {
+    "address": "context-impl=ucontext address-sanitizer=norecover",
+    "thread": "context-impl=ucontext thread-sanitizer=norecover",
+    "undefined": "undefined-sanitizer=norecover"
+} %}
 {% set sanitizer_b2_flags_str = sanitizer_b2_flags_map[sanitizer] %}
 
 {% set sanitizer_build_flags_str = "-fsanitize=" ~ sanitizer ~ " -g -O1 -fno-omit-frame-pointer" %}
@@ -23,5 +27,11 @@ tools.build:cflags+={{ sanitizer_build_flags }}
 tools.build:cxxflags+={{ sanitizer_build_flags }}
 tools.build:exelinkflags+={{ sanitizer_link_flags }}
 tools.build:sharedlinkflags+={{ sanitizer_link_flags }}
+
+{% if sanitizer == "address" %}
+    boost/*:tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
+{% elif sanitizer == "thread" %}
+    boost/*:tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
+{% endif %}
 
 tools.info.package_id:confs+=["tools.build:cflags", "tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags"]

--- a/docker/ci/conan/sanitizer_template.profile
+++ b/docker/ci/conan/sanitizer_template.profile
@@ -29,9 +29,9 @@ tools.build:exelinkflags+={{ sanitizer_link_flags }}
 tools.build:sharedlinkflags+={{ sanitizer_link_flags }}
 
 {% if sanitizer == "address" %}
-    boost/*:tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
+    tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
 {% elif sanitizer == "thread" %}
-    boost/*:tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
+    tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
 {% endif %}
 
 tools.info.package_id:confs+=["tools.build:cflags", "tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags"]

--- a/docker/ci/conan/sanitizer_template.profile
+++ b/docker/ci/conan/sanitizer_template.profile
@@ -29,9 +29,9 @@ tools.build:exelinkflags+={{ sanitizer_link_flags }}
 tools.build:sharedlinkflags+={{ sanitizer_link_flags }}
 
 {% if sanitizer == "address" %}
-    tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
+    *:tools.build:defines+=["BOOST_USE_ASAN", "BOOST_USE_UCONTEXT"]
 {% elif sanitizer == "thread" %}
-    tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
+    *:tools.build:defines+=["BOOST_USE_TSAN", "BOOST_USE_UCONTEXT"]
 {% endif %}
 
-tools.info.package_id:confs+=["tools.build:cflags", "tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags"]
+tools.info.package_id:confs+=["tools.build:cflags", "tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags", "tools.build:defines"]


### PR DESCRIPTION
We found out that building TSAN with ucontext helps to uncover lots of issues. Many of them are probably solved by one fix but either way to run TSAN in CI this change should be necessary.
Also defining flags right in the profile will allow us to clean up our CMakeLists.txt with regards to sanitizers.
`norecover` setting suggested by @mathbunnyru - this will force the suite to stop once any tsan/asan error is detected.