### PR TITLE
ci: Don't download ccache on develop branch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -116,7 +116,7 @@ jobs:
           code_coverage: ${{ inputs.code_coverage }}
 
       - name: Restore ccache cache
-        if: ${{ inputs.download_ccache }}
+        if: ${{ inputs.download_ccache && github.ref != 'refs/heads/develop' }}
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: restore_cache
         with:


### PR DESCRIPTION
We don't want to download it on develop, otherwise:
- it will constantly grow
- we actually want to check in develop that clio builds fine from source