### PR TITLE
style: Add black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,11 @@ repos:
             --ignore-words=pre-commit-hooks/codespell_ignore.txt,
           ]
 
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.11.0
+    hooks:
+      - id: black
+
   # Running some C++ hooks before clang-format
   # to ensure that the style is consistent.
   - repo: local

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,62 +3,60 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
 
 class ClioConan(ConanFile):
-    name = 'clio'
-    license = 'ISC'
-    author = 'Alex Kremer <akremer@ripple.com>, John Freeman <jfreeman@ripple.com>, Ayaz Salikhov <asalikhov@ripple.com>'
-    url = 'https://github.com/xrplf/clio'
-    description = 'Clio RPC server'
-    settings = 'os', 'compiler', 'build_type', 'arch'
+    name = "clio"
+    license = "ISC"
+    author = "Alex Kremer <akremer@ripple.com>, John Freeman <jfreeman@ripple.com>, Ayaz Salikhov <asalikhov@ripple.com>"
+    url = "https://github.com/xrplf/clio"
+    description = "Clio RPC server"
+    settings = "os", "compiler", "build_type", "arch"
     options = {}
 
     requires = [
-        'boost/1.83.0',
-        'cassandra-cpp-driver/2.17.0',
-        'protobuf/3.21.12',
-        'grpc/1.50.1',
-        'openssl/1.1.1w',
-        'xrpl/3.0.0-rc1',
-        'zlib/1.3.1',
-        'libbacktrace/cci.20210118',
-        'spdlog/1.16.0',
+        "boost/1.83.0",
+        "cassandra-cpp-driver/2.17.0",
+        "protobuf/3.21.12",
+        "grpc/1.50.1",
+        "openssl/1.1.1w",
+        "xrpl/3.0.0-rc1",
+        "zlib/1.3.1",
+        "libbacktrace/cci.20210118",
+        "spdlog/1.16.0",
     ]
 
     default_options = {
-        'xrpl/*:tests': False,
-        'xrpl/*:rocksdb': False,
-        'cassandra-cpp-driver/*:shared': False,
-        'date/*:header_only': True,
-        'grpc/*:shared': False,
-        'grpc/*:secure': True,
-        'libpq/*:shared': False,
-        'lz4/*:shared': False,
-        'openssl/*:shared': False,
-        'protobuf/*:shared': False,
-        'protobuf/*:with_zlib': True,
-        'snappy/*:shared': False,
-        'gtest/*:no_main': True,
+        "xrpl/*:tests": False,
+        "xrpl/*:rocksdb": False,
+        "cassandra-cpp-driver/*:shared": False,
+        "date/*:header_only": True,
+        "grpc/*:shared": False,
+        "grpc/*:secure": True,
+        "libpq/*:shared": False,
+        "lz4/*:shared": False,
+        "openssl/*:shared": False,
+        "protobuf/*:shared": False,
+        "protobuf/*:with_zlib": True,
+        "snappy/*:shared": False,
+        "gtest/*:no_main": True,
     }
 
-    exports_sources = (
-        'CMakeLists.txt', 'cmake/*', 'src/*'
-    )
+    exports_sources = ("CMakeLists.txt", "cmake/*", "src/*")
 
     def requirements(self):
-        self.requires('gtest/1.14.0')
-        self.requires('benchmark/1.9.4')
-        self.requires('fmt/12.1.0', force=True)
+        self.requires("gtest/1.14.0")
+        self.requires("benchmark/1.9.4")
+        self.requires("fmt/12.1.0", force=True)
 
     def configure(self):
-        if self.settings.compiler == 'apple-clang':
-            self.options['boost'].visibility = 'global'
+        if self.settings.compiler == "apple-clang":
+            self.options["boost"].visibility = "global"
 
     def layout(self):
         cmake_layout(self)
         # Fix this setting to follow the default introduced in Conan 1.48
         # to align with our build instructions.
-        self.folders.generators = 'build/generators'
+        self.folders.generators = "build/generators"
 
-    generators = 'CMakeDeps'
+    generators = "CMakeDeps"
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/pre-commit-hooks/json_in_cpp.py
+++ b/pre-commit-hooks/json_in_cpp.py
@@ -4,7 +4,6 @@ import argparse
 import re
 from pathlib import Path
 
-
 PATTERN = r'R"JSON\((.*?)\)JSON"'
 
 
@@ -40,6 +39,7 @@ def fix_colon_spacing(cpp_content: str) -> str:
         raw_json = match.group(1)
         raw_json = re.sub(r'":\n\s*(\[|\{)', r'": \1', raw_json)
         return f'R"JSON({raw_json})JSON"'
+
     return re.sub(PATTERN, replace_json, cpp_content, flags=re.DOTALL)
 
 
@@ -49,12 +49,12 @@ def fix_indentation(cpp_content: str) -> str:
 
     lines = cpp_content.splitlines()
 
-    ends_with_newline = cpp_content.endswith('\n')
+    ends_with_newline = cpp_content.endswith("\n")
 
     def find_indentation(line: str) -> int:
         return len(line) - len(line.lstrip())
 
-    for (line_num, (line, next_line)) in enumerate(zip(lines[:-1], lines[1:])):
+    for line_num, (line, next_line) in enumerate(zip(lines[:-1], lines[1:])):
         if "JSON(" in line and ")JSON" not in line:
             indent = find_indentation(line)
             next_indent = find_indentation(next_line)
@@ -69,7 +69,11 @@ def fix_indentation(cpp_content: str) -> str:
                     if ")JSON" in lines[i]:
                         lines[i] = " " * indent + lines[i].lstrip()
                         break
-                    lines[i] = lines[i][by_how_much:] if by_how_much > 0 else " " * (-by_how_much) + lines[i]
+                    lines[i] = (
+                        lines[i][by_how_much:]
+                        if by_how_much > 0
+                        else " " * (-by_how_much) + lines[i]
+                    )
 
     result = "\n".join(lines)
 

--- a/tools/rebuild_conan.py
+++ b/tools/rebuild_conan.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import json
-import plumbum
 from pathlib import Path
+
+import plumbum
 
 THIS_DIR = Path(__file__).parent.resolve()
 ROOT_DIR = THIS_DIR.parent.resolve()
@@ -21,15 +22,23 @@ def rebuild():
         for profile in profiles:
             print(f"Rebuilding {profile} with build type {build_type}")
             with plumbum.local.cwd(ROOT_DIR):
-                CONAN[
-                    "install", ".",
-                    "--build=missing",
-                    f"--output-folder=build_{profile}_{build_type}",
-                    "-s", f"build_type={build_type}",
-                    "-o", "&:tests=True",
-                    "-o", "&:benchmark=True",
-                    "--profile:all", profile
-                ] & plumbum.FG
+                (
+                    CONAN[
+                        "install",
+                        ".",
+                        "--build=missing",
+                        f"--output-folder=build_{profile}_{build_type}",
+                        "-s",
+                        f"build_type={build_type}",
+                        "-o",
+                        "&:tests=True",
+                        "-o",
+                        "&:benchmark=True",
+                        "--profile:all",
+                        profile,
+                    ]
+                    & plumbum.FG
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I'm not happy I can't just save python files in Zed, it will automatically apply formatting.
`black` is quite standard, and looks quite nice, let's add it as a pre-commit hook