### PR TITLE
chore: Use boost::asio::ssl::stream instead of boost::beast::ssl_stream

### DIFF
--- a/src/util/requests/impl/StreamData.hpp
+++ b/src/util/requests/impl/StreamData.hpp
@@ -78,8 +78,8 @@ private:
     }
 };
 
-using SslTcpStreamData = SslStreamData<boost::beast::ssl_stream<boost::beast::tcp_stream>>;
+using SslTcpStreamData = SslStreamData<boost::asio::ssl::stream<boost::beast::tcp_stream>>;
 using SslWsStreamData =
-    SslStreamData<boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>;
+    SslStreamData<boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beast::tcp_stream>>>;
 
 }  // namespace util::requests::impl

--- a/src/util/requests/impl/WsConnectionImpl.hpp
+++ b/src/util/requests/impl/WsConnectionImpl.hpp
@@ -124,6 +124,6 @@ public:
 
 using PlainWsConnection = WsConnectionImpl<boost::beast::websocket::stream<boost::beast::tcp_stream>>;
 using SslWsConnection =
-    WsConnectionImpl<boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>;
+    WsConnectionImpl<boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beast::tcp_stream>>>;
 
 }  // namespace util::requests::impl

--- a/src/web/SslHttpSession.hpp
+++ b/src/web/SslHttpSession.hpp
@@ -61,7 +61,7 @@ using tcp = boost::asio::ip::tcp;
 template <SomeServerHandler HandlerType>
 class SslHttpSession : public impl::HttpBase<SslHttpSession, HandlerType>,
                        public std::enable_shared_from_this<SslHttpSession<HandlerType>> {
-    boost::beast::ssl_stream<boost::beast::tcp_stream> stream_;
+    boost::asio::ssl::stream<boost::beast::tcp_stream> stream_;
     std::reference_wrapper<util::TagDecoratorFactory const> tagFactory_;
     std::uint32_t maxWsSendingQueueSize_;
 
@@ -113,7 +113,7 @@ public:
     ~SslHttpSession() override = default;
 
     /** @return The SSL stream. */
-    boost::beast::ssl_stream<boost::beast::tcp_stream>&
+    boost::asio::ssl::stream<boost::beast::tcp_stream>&
     stream()
     {
         return stream_;

--- a/src/web/SslWsSession.hpp
+++ b/src/web/SslWsSession.hpp
@@ -51,7 +51,7 @@ namespace web {
  */
 template <SomeServerHandler HandlerType>
 class SslWsSession : public impl::WsBase<SslWsSession, HandlerType> {
-    using StreamType = boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>;
+    using StreamType = boost::beast::websocket::stream<boost::asio::ssl::stream<boost::beast::tcp_stream>>;
     StreamType ws_;
 
 public:
@@ -68,7 +68,7 @@ public:
      * @param maxWsSendingQueueSize The maximum size of the sending queue for websocket
      */
     explicit SslWsSession(
-        boost::beast::ssl_stream<boost::beast::tcp_stream>&& stream,
+        boost::asio::ssl::stream<boost::beast::tcp_stream>&& stream,
         std::string ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,
@@ -107,7 +107,7 @@ template <SomeServerHandler HandlerType>
 class SslWsUpgrader : public std::enable_shared_from_this<SslWsUpgrader<HandlerType>> {
     using std::enable_shared_from_this<SslWsUpgrader<HandlerType>>::shared_from_this;
 
-    boost::beast::ssl_stream<boost::beast::tcp_stream> https_;
+    boost::asio::ssl::stream<boost::beast::tcp_stream> https_;
     boost::optional<http::request_parser<http::string_body>> parser_;
     boost::beast::flat_buffer buffer_;
     std::string ip_;
@@ -133,7 +133,7 @@ public:
      * @param maxWsSendingQueueSize The maximum size of the sending queue for websocket
      */
     SslWsUpgrader(
-        boost::beast::ssl_stream<boost::beast::tcp_stream> stream,
+        boost::asio::ssl::stream<boost::beast::tcp_stream> stream,
         std::string ip,
         std::reference_wrapper<util::TagDecoratorFactory const> tagFactory,
         std::reference_wrapper<dosguard::DOSGuardInterface> dosGuard,

--- a/tests/common/util/TestHttpClient.cpp
+++ b/tests/common/util/TestHttpClient.cpp
@@ -148,7 +148,7 @@ HttpsSyncClient::syncPost(std::string const& host, std::string const& port, std:
     ctx.set_verify_mode(ssl::verify_none);
 
     tcp::resolver resolver(ioc);
-    boost::beast::ssl_stream<boost::beast::tcp_stream> stream(ioc, ctx);
+    boost::asio::ssl::stream<boost::beast::tcp_stream> stream(ioc, ctx);
 
 // We can't fix this so have to ignore
 #pragma GCC diagnostic push

--- a/tests/common/util/TestWebSocketClient.hpp
+++ b/tests/common/util/TestWebSocketClient.hpp
@@ -80,7 +80,7 @@ public:
 
 class WebServerSslSyncClient {
     boost::asio::io_context ioc_;
-    std::optional<boost::beast::websocket::stream<boost::beast::ssl_stream<boost::asio::ip::tcp::socket>>> ws_;
+    std::optional<boost::beast::websocket::stream<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>> ws_;
 
 public:
     void


### PR DESCRIPTION
Fix: https://github.com/XRPLF/clio/issues/1610