### PR TITLE
ci: Put debian package to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,24 +92,6 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  package:
-    name: Build packages
-
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/clio-ci:067449c3f8ae6755ea84752ea2962b589fe56c8f" }'
-      conan_profile: gcc
-      build_type: Release
-      download_ccache: true
-      upload_ccache: false
-      code_coverage: false
-      static: true
-      upload_clio_server: false
-      package: true
-      targets: package
-      analyze_build_time: false
-
   check_config:
     name: Check Config Description
     needs: build-and-test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,6 +68,24 @@ jobs:
       download_ccache: false
       upload_ccache: false
 
+  package:
+    name: Build debian package
+
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runs_on: heavy
+      container: '{ "image": "ghcr.io/xrplf/clio-ci:067449c3f8ae6755ea84752ea2962b589fe56c8f" }'
+      conan_profile: gcc
+      build_type: Release
+      download_ccache: false
+      upload_ccache: false
+      code_coverage: false
+      static: true
+      upload_clio_server: false
+      package: true
+      targets: package
+      analyze_build_time: false
+
   analyze_build_time:
     name: Analyze Build Time
 
@@ -109,7 +127,7 @@ jobs:
           echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
   nightly_release:
-    needs: [build-and-test, get_date]
+    needs: [build-and-test, package, get_date]
     uses: ./.github/workflows/reusable-release.yml
     with:
       delete_pattern: "nightly-*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,26 @@ jobs:
       upload_ccache: false
       expected_version: ${{ github.event_name == 'push' && github.ref_name || '' }}
 
+  package:
+    name: Build debian package
+
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      runs_on: heavy
+      container: '{ "image": "ghcr.io/xrplf/clio-ci:067449c3f8ae6755ea84752ea2962b589fe56c8f" }'
+      conan_profile: gcc
+      build_type: Release
+      download_ccache: false
+      upload_ccache: false
+      code_coverage: false
+      static: true
+      upload_clio_server: false
+      package: true
+      targets: package
+      analyze_build_time: false
+
   release:
-    needs: build-and-test
+    needs: [build-and-test, package]
     uses: ./.github/workflows/reusable-release.yml
     with:
       delete_pattern: ""

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -69,6 +69,9 @@ jobs:
           path: release_artifacts
           pattern: clio_server_*
 
+      - name: Prepare release artifacts
+        run: .github/scripts/prepare-release-artifacts.sh release_artifacts
+
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           path: release_artifacts
@@ -90,9 +93,6 @@ jobs:
           BASE_COMMIT="$(git merge-base HEAD $LAST_TAG_COMMIT)"
           git-cliff "${BASE_COMMIT}..HEAD" --ignore-tags "nightly|-b|-rc"
           cat CHANGELOG.md >> "${RUNNER_TEMP}/release_notes.md"
-
-      - name: Prepare release artifacts
-        run: .github/scripts/prepare-release-artifacts.sh release_artifacts
 
       - name: Upload release notes
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -127,4 +127,4 @@ jobs:
             --target "${GITHUB_SHA}" \
             ${DRAFT_OPTION} \
             --notes-file "${RUNNER_TEMP}/release_notes.md" \
-            ./release_artifacts/clio_server*
+            ./release_artifacts/clio_*

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -69,6 +69,11 @@ jobs:
           path: release_artifacts
           pattern: clio_server_*
 
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: release_artifacts
+          pattern: clio_deb_package_*
+
       - name: Create release notes
         env:
           RELEASE_HEADER: ${{ inputs.header }}


### PR DESCRIPTION
This adds a Debian package to the release (including nightly release).

Since we package nightly, there is no sense in running it in PRs and on every commit, so it should reduce the number of builds.