### PR TITLE
WIP: fix race condition in ETL

### DIFF
--- a/src/etl/ETLService.cpp
+++ b/src/etl/ETLService.cpp
@@ -173,6 +173,7 @@ ETLService::ETLService(
     , state_(std::move(state))
     , startSequence_(config.get().maybeValue<uint32_t>("start_sequence"))
     , finishSequence_(config.get().maybeValue<uint32_t>("finish_sequence"))
+    , writeCommandStrand_(ctx_.makeStrand())
 {
     ASSERT(not state_->isWriting, "ETL should never start in writer mode");
 
@@ -231,6 +232,12 @@ void
 ETLService::stop()
 {
     LOG(log_.info()) << "Stop called";
+    systemStateWriteCommandSubscription_.disconnect();
+    auto count = runningWriteCommandHandlers_.load();
+    while (count != 0) {
+        runningWriteCommandHandlers_.wait(count);  // Blocks until value changes
+        count = runningWriteCommandHandlers_.load();
+    }
 
     if (mainLoop_)
         mainLoop_->wait();
@@ -350,26 +357,37 @@ ETLService::startMonitor(uint32_t seq)
 
     systemStateWriteCommandSubscription_ =
         state_->writeCommandSignal.connect([this](SystemState::WriteCommand command) {
-            switch (command) {
-                case etl::SystemState::WriteCommand::StartWriting:
-                    attemptTakeoverWriter();
-                    break;
-                case etl::SystemState::WriteCommand::StopWriting:
-                    giveUpWriter();
-                    break;
-            }
+            ++runningWriteCommandHandlers_;
+            writeCommandStrand_.submit([this, command]() {
+                switch (command) {
+                    case etl::SystemState::WriteCommand::StartWriting:
+                        attemptTakeoverWriter();
+                        break;
+                    case etl::SystemState::WriteCommand::StopWriting:
+                        giveUpWriter();
+                        break;
+                }
+                --runningWriteCommandHandlers_;
+            });
         });
 
     monitorNewSeqSubscription_ = monitor_->subscribeToNewSequence([this](uint32_t seq) {
         LOG(log_.info()) << "ETLService (via Monitor) got new seq from db: " << seq;
 
-        if (not state_->isWriting) {
+        auto const cacheNeedsUpdate = backend_->cache().latestLedgerSequence() < seq;
+        auto const backendRange = backend_->fetchLedgerRange();
+        auto const backendNeedsUpdate = backendRange.has_value() and backendRange->maxSequence < seq;
+
+        if (cacheNeedsUpdate or backendNeedsUpdate) {
             auto const diff = data::synchronousAndRetryOnTimeout([this, seq](auto yield) {
                 return backend_->fetchLedgerDiff(seq, yield);
             });
 
-            cacheUpdater_->update(seq, diff);
-            backend_->updateRange(seq);
+            if (cacheNeedsUpdate)
+                cacheUpdater_->update(seq, diff);
+
+            if (backendNeedsUpdate)
+                backend_->updateRange(seq);
         }
 
         publisher_->publish(seq, {});

--- a/src/etl/ETLService.hpp
+++ b/src/etl/ETLService.hpp
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 /*
     This file is part of clio: https://github.com/XRPLF/clio
     Copyright (c) 2025, the clio developers.
@@ -52,6 +52,7 @@
 #include "feed/SubscriptionManagerInterface.hpp"
 #include "util/async/AnyExecutionContext.hpp"
 #include "util/async/AnyOperation.hpp"
+#include "util/async/AnyStrand.hpp"
 #include "util/config/ConfigDefinition.hpp"
 #include "util/log/Logger.hpp"
 
@@ -69,6 +70,7 @@
 #include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/TxMeta.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -117,6 +119,8 @@ class ETLService : public ETLServiceInterface {
     boost::signals2::scoped_connection monitorNewSeqSubscription_;
     boost::signals2::scoped_connection monitorDbStalledSubscription_;
     boost::signals2::scoped_connection systemStateWriteCommandSubscription_;
+    util::async::AnyStrand writeCommandStrand_;
+    std::atomic<size_t> runningWriteCommandHandlers_{0};
 
     std::optional<util::async::AnyOperation<void>> mainLoop_;
 

--- a/src/util/async/context/impl/Execution.hpp
+++ b/src/util/async/context/impl/Execution.hpp
@@ -36,17 +36,19 @@ struct SpawnDispatchStrategy {
     {
         auto op = outcome.getOperation();
 
-        util::spawn(
-            ctx.getExecutor(),
-            [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)](auto yield) mutable {
-                if constexpr (SomeStoppableOutcome<OutcomeType>) {
+        if constexpr (SomeStoppableOutcome<OutcomeType>) {
+            util::spawn(
+                ctx.getExecutor(),
+                [outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)](auto yield) mutable {
                     auto& stopSource = outcome.getStopSource();
                     std::invoke(std::forward<decltype(fn)>(fn), outcome, stopSource, stopSource[yield]);
-                } else {
-                    std::invoke(std::forward<decltype(fn)>(fn), outcome);
                 }
-            }
-        );
+            );
+        } else {
+            boost::asio::post([outcome = std::forward<OutcomeType>(outcome), fn = std::forward<FnType>(fn)]() mutable {
+                std::invoke(std::forward<decltype(fn)>(fn), outcome);
+            });
+        }
 
         return op;
     }
@@ -55,7 +57,7 @@ struct SpawnDispatchStrategy {
     static void
     post(ContextType& ctx, FnType&& fn)
     {
-        util::spawn(ctx.getExecutor(), [fn = std::forward<FnType>(fn)](auto) mutable {
+        boost::asio::post(ctx.getExecutor(), [fn = std::forward<FnType>(fn)]() mutable {
             std::invoke(std::forward<decltype(fn)>(fn));
         });
     }


### PR DESCRIPTION
This is a WIP fix for potential race condition introduced here: #2842 

- `taskManager_` should be protected by a strand
- Async framework changed to post where possible since spawn may be inlined and it may cause a deadlock in ETL

We should check that it is not possible to update cache twice or skip a ledger somewhere.