### PR TITLE
chore: Pin ruamel.yaml<0.19 in pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
+      # https://github.com/pre-commit/pre-commit-hooks/issues/1229
+      # regarding ruamel.yaml version
       - id: check-added-large-files
+        additional_dependencies: [ruamel.yaml<0.19]
       - id: check-executables-have-shebangs
+        additional_dependencies: [ruamel.yaml<0.19]
       - id: check-shebang-scripts-are-executable
+        additional_dependencies: [ruamel.yaml<0.19]
       - id: end-of-file-fixer
+        additional_dependencies: [ruamel.yaml<0.19]
       - id: trailing-whitespace
+        additional_dependencies: [ruamel.yaml<0.19]
 
   # Autoformat: YAML, JSON, Markdown, etc.
   - repo: https://github.com/rbubley/mirrors-prettier


### PR DESCRIPTION
Please, see https://github.com/pre-commit/pre-commit-hooks/issues/1229