### PR TITLE
fix: Faster implementation of work queue

### DIFF
--- a/benchmarks/rpc/WorkQueueBenchmarks.cpp
+++ b/benchmarks/rpc/WorkQueueBenchmarks.cpp
@@ -115,10 +115,8 @@ benchmarkWorkQueue(benchmark::State& state)
             });
         }
 
-        for (auto& t : threads) {
-            if (t.joinable())
-                t.join();
-        }
+        for (auto& t : threads)
+            t.join();
 
         queue.stop();
 

--- a/benchmarks/rpc/WorkQueueBenchmarks.cpp
+++ b/benchmarks/rpc/WorkQueueBenchmarks.cpp
@@ -29,13 +29,18 @@
 
 #include <benchmark/benchmark.h>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <boost/json/object.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <thread>
+#include <vector>
 
 using namespace rpc;
 using namespace util::config;
@@ -75,36 +80,56 @@ benchmarkWorkQueue(benchmark::State& state)
 {
     init();
 
-    auto const total = static_cast<size_t>(state.range(0));
-    auto const numThreads = static_cast<uint32_t>(state.range(1));
-    auto const maxSize = static_cast<uint32_t>(state.range(2));
-    auto const delayMs = static_cast<uint32_t>(state.range(3));
+    auto const queueThreads = static_cast<uint32_t>(state.range(0));
+    auto const clientThreads = static_cast<uint32_t>(state.range(1));
+    auto const itemsPerThread = static_cast<uint32_t>(state.range(2));
+    auto const maxSize = static_cast<uint32_t>(state.range(3));
+    auto const delayMs = static_cast<uint32_t>(state.range(4));
 
     for (auto _ : state) {
         std::atomic_size_t totalExecuted = 0uz;
         std::atomic_size_t totalQueued = 0uz;
 
         state.PauseTiming();
-        WorkQueue queue(numThreads, maxSize);
+        WorkQueue queue(queueThreads, maxSize);
         state.ResumeTiming();
 
-        for (auto i = 0uz; i < total; ++i) {
-            totalQueued += static_cast<std::size_t>(queue.postCoro(
-                [&delayMs, &totalExecuted](auto yield) {
-                    ++totalExecuted;
+        std::vector<std::thread> threads;
+        threads.reserve(clientThreads);
 
-                    boost::asio::steady_timer timer(yield.get_executor(), std::chrono::milliseconds{delayMs});
-                    timer.async_wait(yield);
-                },
-                /* isWhiteListed = */ false
-            ));
+        for (auto t = 0uz; t < clientThreads; ++t) {
+            threads.emplace_back([&] {
+                for (auto i = 0uz; i < itemsPerThread; ++i) {
+                    totalQueued += static_cast<std::size_t>(queue.postCoro(
+                        [&delayMs, &totalExecuted](auto yield) {
+                            ++totalExecuted;
+
+                            boost::asio::steady_timer timer(yield.get_executor(), std::chrono::milliseconds{delayMs});
+                            timer.async_wait(yield);
+
+                            std::this_thread::sleep_for(std::chrono::microseconds{10});
+                        },
+                        /* isWhiteListed = */ false
+                    ));
+                }
+            });
+        }
+
+        for (auto& t : threads) {
+            if (t.joinable())
+                t.join();
         }
 
         queue.stop();
 
         ASSERT(totalExecuted == totalQueued, "Totals don't match");
-        ASSERT(totalQueued <= total, "Queued more than requested");
-        ASSERT(totalQueued >= maxSize, "Queued less than maxSize");
+        ASSERT(totalQueued <= itemsPerThread * clientThreads, "Queued more than requested");
+
+        if (maxSize == 0) {
+            ASSERT(totalQueued == itemsPerThread * clientThreads, "Queued exactly the expected amount");
+        } else {
+            ASSERT(totalQueued >= std::min(maxSize, itemsPerThread * clientThreads), "Queued less than expected");
+        }
     }
 }
 
@@ -118,5 +143,5 @@ benchmarkWorkQueue(benchmark::State& state)
 */
 // TODO: figure out what happens on 1 thread
 BENCHMARK(benchmarkWorkQueue)
-    ->ArgsProduct({{1'000, 10'000, 100'000}, {2, 4, 8}, {0, 5'000}, {10, 100, 250}})
+    ->ArgsProduct({{2, 4, 8, 16}, {4, 8, 16}, {1'000, 10'000}, {0, 5'000}, {10, 100, 250}})
     ->Unit(benchmark::kMillisecond);

--- a/benchmarks/rpc/WorkQueueBenchmarks.cpp
+++ b/benchmarks/rpc/WorkQueueBenchmarks.cpp
@@ -80,18 +80,18 @@ benchmarkWorkQueue(benchmark::State& state)
 {
     init();
 
-    auto const queueThreads = static_cast<uint32_t>(state.range(0));
-    auto const clientThreads = static_cast<uint32_t>(state.range(1));
-    auto const itemsPerThread = static_cast<uint32_t>(state.range(2));
-    auto const maxSize = static_cast<uint32_t>(state.range(3));
-    auto const delayMs = static_cast<uint32_t>(state.range(4));
+    auto const wqThreads = static_cast<uint32_t>(state.range(0));
+    auto const maxQueueSize = static_cast<uint32_t>(state.range(1));
+    auto const clientThreads = static_cast<uint32_t>(state.range(2));
+    auto const itemsPerClient = static_cast<uint32_t>(state.range(3));
+    auto const clientProcessingMs = static_cast<uint32_t>(state.range(4));
 
     for (auto _ : state) {
         std::atomic_size_t totalExecuted = 0uz;
         std::atomic_size_t totalQueued = 0uz;
 
         state.PauseTiming();
-        WorkQueue queue(queueThreads, maxSize);
+        WorkQueue queue(wqThreads, maxQueueSize);
         state.ResumeTiming();
 
         std::vector<std::thread> threads;
@@ -99,12 +99,14 @@ benchmarkWorkQueue(benchmark::State& state)
 
         for (auto t = 0uz; t < clientThreads; ++t) {
             threads.emplace_back([&] {
-                for (auto i = 0uz; i < itemsPerThread; ++i) {
+                for (auto i = 0uz; i < itemsPerClient; ++i) {
                     totalQueued += static_cast<std::size_t>(queue.postCoro(
-                        [&delayMs, &totalExecuted](auto yield) {
+                        [&clientProcessingMs, &totalExecuted](auto yield) {
                             ++totalExecuted;
 
-                            boost::asio::steady_timer timer(yield.get_executor(), std::chrono::milliseconds{delayMs});
+                            boost::asio::steady_timer timer(
+                                yield.get_executor(), std::chrono::milliseconds{clientProcessingMs}
+                            );
                             timer.async_wait(yield);
 
                             std::this_thread::sleep_for(std::chrono::microseconds{10});
@@ -121,12 +123,12 @@ benchmarkWorkQueue(benchmark::State& state)
         queue.stop();
 
         ASSERT(totalExecuted == totalQueued, "Totals don't match");
-        ASSERT(totalQueued <= itemsPerThread * clientThreads, "Queued more than requested");
+        ASSERT(totalQueued <= itemsPerClient * clientThreads, "Queued more than requested");
 
-        if (maxSize == 0) {
-            ASSERT(totalQueued == itemsPerThread * clientThreads, "Queued exactly the expected amount");
+        if (maxQueueSize == 0) {
+            ASSERT(totalQueued == itemsPerClient * clientThreads, "Queued exactly the expected amount");
         } else {
-            ASSERT(totalQueued >= std::min(maxSize, itemsPerThread * clientThreads), "Queued less than expected");
+            ASSERT(totalQueued >= std::min(maxQueueSize, itemsPerClient * clientThreads), "Queued less than expected");
         }
     }
 }
@@ -141,5 +143,5 @@ benchmarkWorkQueue(benchmark::State& state)
 */
 // TODO: figure out what happens on 1 thread
 BENCHMARK(benchmarkWorkQueue)
-    ->ArgsProduct({{2, 4, 8, 16}, {4, 8, 16}, {1'000, 10'000}, {0, 5'000}, {10, 100, 250}})
+    ->ArgsProduct({{2, 4, 8, 16}, {0, 5'000}, {4, 8, 16}, {1'000, 10'000}, {10, 100, 250}})
     ->Unit(benchmark::kMillisecond);

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -25,9 +25,7 @@
 #include "util/prometheus/Label.hpp"
 #include "util/prometheus/Prometheus.hpp"
 
-#include <boost/asio/post.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/json/object.hpp>
 
 #include <chrono>
@@ -38,6 +36,27 @@
 #include <utility>
 
 namespace rpc {
+
+void
+WorkQueue::OneTimeCallable::setCallable(std::function<void()> func)
+{
+    func_ = func;
+}
+
+void
+WorkQueue::OneTimeCallable::operator()()
+{
+    if (not called_) {
+        func_();
+        called_ = true;
+    }
+}
+
+WorkQueue::OneTimeCallable::
+operator bool() const
+{
+    return func_.operator bool();
+}
 
 WorkQueue::WorkQueue(DontStartProcessingTag, std::uint32_t numWorkers, uint32_t maxSize)
     : queued_{PrometheusService::counterInt(
@@ -56,8 +75,6 @@ WorkQueue::WorkQueue(DontStartProcessingTag, std::uint32_t numWorkers, uint32_t 
           "The current number of tasks in the queue"
       )}
     , ioc_{numWorkers}
-    , strand_{ioc_.get_executor()}
-    , waitTimer_(ioc_)
 {
     if (maxSize != 0)
         maxSize_ = maxSize;
@@ -77,12 +94,32 @@ WorkQueue::~WorkQueue()
 void
 WorkQueue::startProcessing()
 {
-    util::spawn(strand_, [this](auto yield) {
-        ASSERT(not hasDispatcher_, "Dispatcher already running");
+    ASSERT(not processingStarted_, "Attempt to start processing work queue more than once");
+    processingStarted_ = true;
 
-        hasDispatcher_ = true;
-        dispatcherLoop(yield);
-    });
+    // Spawn workers for all tasks that were queued before processing started
+    auto const numTasks = size();
+    for (auto i = 0uz; i < numTasks; ++i) {
+        util::spawn(ioc_, [this](auto yield) {
+            std::optional<TaskType> task;
+            auto const spawnedAt = std::chrono::system_clock::now();
+
+            {
+                auto state = queueState_.lock();
+                task = state->popNext();
+            }
+
+            auto const takenAt = std::chrono::system_clock::now();
+            auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - spawnedAt).count();
+
+            ++queued_.get();
+            durationUs_.get() += waited;
+            LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
+
+            task->operator()(yield);
+            --curSize_.get();
+        });
+    }
 }
 
 bool
@@ -98,93 +135,53 @@ WorkQueue::postCoro(TaskType func, bool isWhiteListed, Priority priority)
         return false;
     }
 
-    ++curSize_.get();
-    auto needsWakeup = false;
+    auto const queuedAt = std::chrono::system_clock::now();
 
     {
-        auto state = dispatcherState_.lock();
-
-        needsWakeup = std::exchange(state->isIdle, false);
-
+        auto state = queueState_.lock();
         state->push(priority, std::move(func));
     }
 
-    if (needsWakeup)
-        boost::asio::post(strand_, [this] { waitTimer_.cancel(); });
+    ++curSize_.get();
 
-    return true;
-}
+    if (not processingStarted_)
+        return true;
 
-void
-WorkQueue::dispatcherLoop(boost::asio::yield_context yield)
-{
-    LOG(log_.info()) << "WorkQueue dispatcher starting";
-
-    // all ongoing tasks must be completed before stopping fully
-    while (not stopping_ or size() > 0) {
+    util::spawn(ioc_, [this, queuedAt](auto yield) {
         std::optional<TaskType> task;
 
         {
-            auto state = dispatcherState_.lock();
-
-            if (state->empty()) {
-                state->isIdle = true;
-            } else {
-                task = state->popNext();
-            }
+            auto state = queueState_.lock();
+            task = state->popNext();
         }
 
-        if (not stopping_ and not task.has_value()) {
-            waitTimer_.expires_at(std::chrono::steady_clock::time_point::max());
-            boost::system::error_code ec;
-            waitTimer_.async_wait(yield[ec]);
-        } else if (task.has_value()) {
-            util::spawn(
-                ioc_,
-                [this, spawnedAt = std::chrono::system_clock::now(), task = std::move(*task)](auto yield) mutable {
-                    auto const takenAt = std::chrono::system_clock::now();
-                    auto const waited =
-                        std::chrono::duration_cast<std::chrono::microseconds>(takenAt - spawnedAt).count();
+        auto const takenAt = std::chrono::system_clock::now();
+        auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - queuedAt).count();
 
-                    ++queued_.get();
-                    durationUs_.get() += waited;
-                    LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
+        ++queued_.get();
+        durationUs_.get() += waited;
+        LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
 
-                    task(yield);
+        task->operator()(yield);
+        --curSize_.get();
 
-                    --curSize_.get();
-                }
-            );
+        if (curSize_.get().value() == 0 && stopping_) {
+            auto onTasksComplete = onQueueEmpty_.lock();
+            ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
+            onTasksComplete->operator()();
         }
-    }
+    });
 
-    LOG(log_.info()) << "WorkQueue dispatcher shutdown requested - time to execute onTasksComplete";
-
-    {
-        auto onTasksComplete = onQueueEmpty_.lock();
-        ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
-        onTasksComplete->operator()();
-    }
-
-    LOG(log_.info()) << "WorkQueue dispatcher finished";
+    return true;
 }
 
 void
 WorkQueue::requestStop(std::function<void()> onQueueEmpty)
 {
     auto handler = onQueueEmpty_.lock();
-    *handler = std::move(onQueueEmpty);
+    handler->setCallable(std::move(onQueueEmpty));
 
     stopping_ = true;
-    auto needsWakeup = false;
-
-    {
-        auto state = dispatcherState_.lock();
-        needsWakeup = std::exchange(state->isIdle, false);
-    }
-
-    if (needsWakeup)
-        boost::asio::post(strand_, [this] { waitTimer_.cancel(); });
 }
 
 void
@@ -194,6 +191,10 @@ WorkQueue::stop()
         requestStop();
 
     ioc_.join();
+
+    auto onTasksComplete = onQueueEmpty_.lock();
+    ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
+    onTasksComplete->operator()();
 }
 
 WorkQueue

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -40,7 +40,7 @@ namespace rpc {
 void
 WorkQueue::OneTimeCallable::setCallable(std::function<void()> func)
 {
-    func_ = func;
+    func_ = std::move(func);
 }
 
 void
@@ -100,25 +100,7 @@ WorkQueue::startProcessing()
     // Spawn workers for all tasks that were queued before processing started
     auto const numTasks = size();
     for (auto i = 0uz; i < numTasks; ++i) {
-        util::spawn(ioc_, [this](auto yield) {
-            std::optional<TaskType> task;
-            auto const spawnedAt = std::chrono::system_clock::now();
-
-            {
-                auto state = queueState_.lock();
-                task = state->popNext();
-            }
-
-            auto const takenAt = std::chrono::system_clock::now();
-            auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - spawnedAt).count();
-
-            ++queued_.get();
-            durationUs_.get() += waited;
-            LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
-
-            task->operator()(yield);
-            --curSize_.get();
-        });
+        util::spawn(ioc_, [this](auto yield) { executeTask(std::chrono::system_clock::now(), yield); });
     }
 }
 
@@ -147,30 +129,7 @@ WorkQueue::postCoro(TaskType func, bool isWhiteListed, Priority priority)
     if (not processingStarted_)
         return true;
 
-    util::spawn(ioc_, [this, queuedAt](auto yield) {
-        std::optional<TaskType> task;
-
-        {
-            auto state = queueState_.lock();
-            task = state->popNext();
-        }
-
-        auto const takenAt = std::chrono::system_clock::now();
-        auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - queuedAt).count();
-
-        ++queued_.get();
-        durationUs_.get() += waited;
-        LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
-
-        task->operator()(yield);
-        --curSize_.get();
-
-        if (curSize_.get().value() == 0 && stopping_) {
-            auto onTasksComplete = onQueueEmpty_.lock();
-            ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
-            onTasksComplete->operator()();
-        }
-    });
+    util::spawn(ioc_, [this, queuedAt](auto yield) { executeTask(queuedAt, yield); });
 
     return true;
 }
@@ -226,6 +185,26 @@ size_t
 WorkQueue::size() const
 {
     return curSize_.get().value();
+}
+
+void
+WorkQueue::executeTask(std::chrono::system_clock::time_point opTime, boost::asio::yield_context yield)
+{
+    std::optional<TaskType> task;
+    {
+        auto state = queueState_.lock();
+        task = state->popNext();
+    }
+
+    auto const takenAt = std::chrono::system_clock::now();
+    auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - opTime).count();
+
+    ++queued_.get();
+    durationUs_.get() += waited;
+    LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
+
+    task->operator()(yield);
+    --curSize_.get();
 }
 
 }  // namespace rpc

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -32,6 +32,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iostream>
 #include <optional>
 #include <utility>
 
@@ -151,9 +152,11 @@ WorkQueue::stop()
 
     ioc_.join();
 
-    auto onTasksComplete = onQueueEmpty_.lock();
-    ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
-    onTasksComplete->operator()();
+    {
+        auto onTasksComplete = onQueueEmpty_.lock();
+        ASSERT(onTasksComplete->operator bool(), "onTasksComplete must be set when stopping is true.");
+        onTasksComplete->operator()();
+    }
 }
 
 WorkQueue
@@ -196,6 +199,7 @@ WorkQueue::executeTask(std::chrono::system_clock::time_point opTime, boost::asio
         task = state->popNext();
     }
 
+    ASSERT(task.has_value(), "Queue should not be empty as we spawn a coro with executeTask for each postCoro.");
     auto const takenAt = std::chrono::system_clock::now();
     auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - opTime).count();
 

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -32,7 +32,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iostream>
 #include <optional>
 #include <utility>
 

--- a/src/rpc/WorkQueue.cpp
+++ b/src/rpc/WorkQueue.cpp
@@ -101,7 +101,7 @@ WorkQueue::startProcessing()
     // Spawn workers for all tasks that were queued before processing started
     auto const numTasks = size();
     for (auto i = 0uz; i < numTasks; ++i) {
-        util::spawn(ioc_, [this](auto yield) { executeTask(std::chrono::system_clock::now(), yield); });
+        util::spawn(ioc_, [this](auto yield) { executeTask(yield); });
     }
 }
 
@@ -118,8 +118,6 @@ WorkQueue::postCoro(TaskType func, bool isWhiteListed, Priority priority)
         return false;
     }
 
-    auto const queuedAt = std::chrono::system_clock::now();
-
     {
         auto state = queueState_.lock();
         state->push(priority, std::move(func));
@@ -130,7 +128,7 @@ WorkQueue::postCoro(TaskType func, bool isWhiteListed, Priority priority)
     if (not processingStarted_)
         return true;
 
-    util::spawn(ioc_, [this, queuedAt](auto yield) { executeTask(queuedAt, yield); });
+    util::spawn(ioc_, [this](auto yield) { executeTask(yield); });
 
     return true;
 }
@@ -191,23 +189,27 @@ WorkQueue::size() const
 }
 
 void
-WorkQueue::executeTask(std::chrono::system_clock::time_point opTime, boost::asio::yield_context yield)
+WorkQueue::executeTask(boost::asio::yield_context yield)
 {
-    std::optional<TaskType> task;
+    std::optional<TaskWithTimestamp> taskWithTimestamp;
     {
         auto state = queueState_.lock();
-        task = state->popNext();
+        taskWithTimestamp = state->popNext();
     }
 
-    ASSERT(task.has_value(), "Queue should not be empty as we spawn a coro with executeTask for each postCoro.");
+    ASSERT(
+        taskWithTimestamp.has_value(),
+        "Queue should not be empty as we spawn a coro with executeTask for each postCoro."
+    );
     auto const takenAt = std::chrono::system_clock::now();
-    auto const waited = std::chrono::duration_cast<std::chrono::microseconds>(takenAt - opTime).count();
+    auto const waited =
+        std::chrono::duration_cast<std::chrono::microseconds>(takenAt - taskWithTimestamp->queuedAt).count();
 
     ++queued_.get();
     durationUs_.get() += waited;
     LOG(log_.info()) << "WorkQueue wait time: " << waited << ", queue size: " << size();
 
-    task->operator()(yield);
+    taskWithTimestamp->task(yield);
     --curSize_.get();
 }
 

--- a/src/rpc/WorkQueue.hpp
+++ b/src/rpc/WorkQueue.hpp
@@ -25,12 +25,8 @@
 #include "util/prometheus/Counter.hpp"
 #include "util/prometheus/Gauge.hpp"
 
-#include <boost/asio.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/asio/steady_timer.hpp>
-#include <boost/asio/strand.hpp>
 #include <boost/asio/thread_pool.hpp>
-#include <boost/json.hpp>
 #include <boost/json/object.hpp>
 
 #include <atomic>
@@ -76,11 +72,10 @@ public:
     };
 
 private:
-    struct DispatcherState {
+    struct QueueState {
         QueueType high;
         QueueType normal;
 
-        bool isIdle = false;
         size_t highPriorityCounter = 0;
 
         void
@@ -133,14 +128,26 @@ private:
 
     util::Logger log_{"RPC"};
     boost::asio::thread_pool ioc_;
-    boost::asio::strand<boost::asio::thread_pool::executor_type> strand_;
-    bool hasDispatcher_ = false;
 
     std::atomic_bool stopping_;
+    std::atomic_bool processingStarted_{false};
 
-    util::Mutex<std::function<void()>> onQueueEmpty_;
-    util::Mutex<DispatcherState> dispatcherState_;
-    boost::asio::steady_timer waitTimer_;
+    class OneTimeCallable {
+        std::function<void()> func_;
+        bool called_{false};
+
+    public:
+        void
+        setCallable(std::function<void()> func);
+
+        void
+        operator()();
+
+        explicit
+        operator bool() const;
+    };
+    util::Mutex<OneTimeCallable> onQueueEmpty_;
+    util::Mutex<QueueState> queueState_;
 
 public:
     struct DontStartProcessingTag {};
@@ -231,10 +238,6 @@ public:
      */
     [[nodiscard]] size_t
     size() const;
-
-private:
-    void
-    dispatcherLoop(boost::asio::yield_context yield);
 };
 
 }  // namespace rpc

--- a/src/rpc/WorkQueue.hpp
+++ b/src/rpc/WorkQueue.hpp
@@ -30,6 +30,7 @@
 #include <boost/json/object.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -238,6 +239,10 @@ public:
      */
     [[nodiscard]] size_t
     size() const;
+
+private:
+    void
+    executeTask(std::chrono::system_clock::time_point opTime, boost::asio::yield_context yield);
 };
 
 }  // namespace rpc

--- a/src/rpc/WorkQueue.hpp
+++ b/src/rpc/WorkQueue.hpp
@@ -61,7 +61,13 @@ struct Reportable {
  */
 class WorkQueue : public Reportable {
     using TaskType = std::function<void(boost::asio::yield_context)>;
-    using QueueType = std::queue<TaskType>;
+
+    struct TaskWithTimestamp {
+        TaskType task;
+        std::chrono::system_clock::time_point queuedAt;
+    };
+
+    using QueueType = std::queue<TaskWithTimestamp>;
 
 public:
     /**
@@ -80,14 +86,14 @@ private:
         size_t highPriorityCounter = 0;
 
         void
-        push(Priority priority, auto&& task)
+        push(Priority priority, TaskType&& task)
         {
             auto& queue = [this, priority] -> QueueType& {
                 if (priority == Priority::High)
                     return high;
                 return normal;
             }();
-            queue.push(std::forward<decltype(task)>(task));
+            queue.push(TaskWithTimestamp{.task = std::move(task), .queuedAt = std::chrono::system_clock::now()});
         }
 
         [[nodiscard]] bool
@@ -96,21 +102,21 @@ private:
             return high.empty() and normal.empty();
         }
 
-        [[nodiscard]] std::optional<TaskType>
+        [[nodiscard]] std::optional<TaskWithTimestamp>
         popNext()
         {
             if (not high.empty() and (highPriorityCounter < kTAKE_HIGH_PRIO or normal.empty())) {
-                auto task = std::move(high.front());
+                auto taskWithTimestamp = std::move(high.front());
                 high.pop();
                 ++highPriorityCounter;
-                return task;
+                return taskWithTimestamp;
             }
 
             if (not normal.empty()) {
-                auto task = std::move(normal.front());
+                auto taskWithTimestamp = std::move(normal.front());
                 normal.pop();
                 highPriorityCounter = 0;
-                return task;
+                return taskWithTimestamp;
             }
 
             return std::nullopt;
@@ -242,7 +248,7 @@ public:
 
 private:
     void
-    executeTask(std::chrono::system_clock::time_point opTime, boost::asio::yield_context yield);
+    executeTask(boost::asio::yield_context yield);
 };
 
 }  // namespace rpc

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -19,6 +19,7 @@
 
 #include "rpc/WorkQueue.hpp"
 #include "util/LoggerFixtures.hpp"
+#include "util/MockAssert.hpp"
 #include "util/MockPrometheus.hpp"
 #include "util/config/ConfigDefinition.hpp"
 #include "util/config/ConfigValue.hpp"
@@ -234,4 +235,23 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
 
     ASSERT_TRUE(res);
     queue.stop();
+}
+
+// Note: not using EXPECT_CLIO_ASSERT_FAIL because exception is swallowed by the WQ context
+struct WorkQueueDeathTest : WorkQueueMockPrometheusTest, common::util::WithMockAssert {};
+
+TEST_F(WorkQueueDeathTest, ExecuteTaskAssertsWhenQueueIsEmpty)
+{
+    [[maybe_unused]] auto& queuedMock = makeMock<CounterInt>("work_queue_queued_total_number", "");
+    [[maybe_unused]] auto& durationMock = makeMock<CounterInt>("work_queue_cumulative_tasks_duration_us", "");
+    auto& curSizeMock = makeMock<GaugeInt>("work_queue_current_size", "");
+
+    EXPECT_CALL(curSizeMock, value()).WillRepeatedly(::testing::Return(1));  // lie about the size
+    EXPECT_DEATH(
+        {
+            WorkQueue queue(WorkQueue::kDONT_START_PROCESSING_TAG, /* numWorkers = */ 1, /* maxSize = */ 2);
+            queue.startProcessing();  // the actual queue is empty which will lead to assertion failure
+        },
+        ".*"
+    );
 }

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -225,7 +225,6 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
     EXPECT_CALL(queuedMock, add(1));
     EXPECT_CALL(durationMock, add(::testing::Ge(0))).WillOnce([&](auto) {
         EXPECT_CALL(curSizeMock, add(-1));
-        EXPECT_CALL(curSizeMock, value()).WillOnce(::testing::Return(0));
         semaphore.release();
     });
 

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -207,11 +207,7 @@ TEST_F(WorkQueueStopTest, CallsOnTasksCompleteWhenStoppingOnLastTask)
     queue.stop();
 }
 
-struct WorkQueueMockPrometheusTest : WithMockPrometheus, RPCWorkQueueTestBase {
-    WorkQueueMockPrometheusTest() : RPCWorkQueueTestBase(/* workers = */ 1, /*maxQueueSize = */ 2)
-    {
-    }
-};
+struct WorkQueueMockPrometheusTest : WithMockPrometheus {};
 
 TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
 {
@@ -221,7 +217,9 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
 
     std::binary_semaphore semaphore{0};
 
-    EXPECT_CALL(curSizeMock, value()).WillOnce(::testing::Return(0)).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(curSizeMock, value())
+        .WillOnce(::testing::Return(0))   // in startProcessing
+        .WillOnce(::testing::Return(0));  // first check in postCoro
     EXPECT_CALL(curSizeMock, add(1));
     EXPECT_CALL(queuedMock, add(1));
     EXPECT_CALL(durationMock, add(::testing::Ge(0))).WillOnce([&](auto) {
@@ -230,8 +228,9 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
         semaphore.release();
     });
 
+    // Note: the queue is not in the fixture because above expectations must be setup before startProcessing runs
+    WorkQueue queue(/* numWorkers = */ 4, /* maxSize = */ 2);
     auto const res = queue.postCoro([&](auto /* yield */) { semaphore.acquire(); }, /* isWhiteListed = */ false);
 
     ASSERT_TRUE(res);
-    queue.stop();
 }

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include "rpc/WorkQueue.hpp"
-#include "util/LoggerFixtures.hpp"
 #include "util/MockAssert.hpp"
 #include "util/MockPrometheus.hpp"
 #include "util/config/ConfigDefinition.hpp"
@@ -58,7 +57,7 @@ struct RPCWorkQueueTestBase : public virtual ::testing::Test {
     }
 };
 
-struct WorkQueueTest : WithPrometheus, RPCWorkQueueTestBase, LoggerFixture {
+struct WorkQueueTest : WithPrometheus, RPCWorkQueueTestBase {
     WorkQueueTest() : RPCWorkQueueTestBase(/* workers = */ 4, /* maxQueueSize = */ 2)
     {
     }
@@ -115,7 +114,7 @@ TEST_F(WorkQueueTest, NonWhitelistedPreventSchedulingAtQueueLimitExceeded)
     EXPECT_TRUE(unblocked);
 }
 
-struct WorkQueueDelayedStartTest : WithPrometheus, LoggerFixture {
+struct WorkQueueDelayedStartTest : WithPrometheus {
     WorkQueue queue{WorkQueue::kDONT_START_PROCESSING_TAG, /* numWorkers = */ 1, /* maxSize = */ 100};
 };
 
@@ -265,9 +264,10 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
 }
 
 // Note: not using EXPECT_CLIO_ASSERT_FAIL because exception is swallowed by the WQ context
+// TODO [https://github.com/XRPLF/clio/issues/2906]: Enable the test once we figure out a better way to do it without
+// using up >2 minutes of CI time
 struct WorkQueueDeathTest : WorkQueueMockPrometheusTest, common::util::WithMockAssert {};
-
-TEST_F(WorkQueueDeathTest, ExecuteTaskAssertsWhenQueueIsEmpty)
+TEST_F(WorkQueueDeathTest, DISABLED_ExecuteTaskAssertsWhenQueueIsEmpty)
 {
     [[maybe_unused]] auto& queuedMock = makeMock<CounterInt>("work_queue_queued_total_number", "");
     [[maybe_unused]] auto& durationMock = makeMock<CounterInt>("work_queue_cumulative_tasks_duration_us", "");

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -31,10 +31,12 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
 #include <semaphore>
+#include <thread>
 #include <vector>
 
 using namespace util;
@@ -111,6 +113,31 @@ TEST_F(WorkQueueTest, NonWhitelistedPreventSchedulingAtQueueLimitExceeded)
 
     queue.stop();
     EXPECT_TRUE(unblocked);
+}
+
+struct WorkQueueDelayedStartTest : WithPrometheus, LoggerFixture {
+    WorkQueue queue{WorkQueue::kDONT_START_PROCESSING_TAG, /* numWorkers = */ 1, /* maxSize = */ 100};
+};
+
+TEST_F(WorkQueueDelayedStartTest, WaitTimeIncludesDelayBeforeStartProcessing)
+{
+    std::atomic_bool taskExecuted = false;
+
+    ASSERT_TRUE(queue.postCoro(
+        [&taskExecuted](auto /* yield */) { taskExecuted = true; },
+        /* isWhiteListed = */ true
+    ));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    queue.startProcessing();
+    queue.stop();
+
+    EXPECT_TRUE(taskExecuted);
+
+    auto const report = queue.report();
+    auto const durationUs = report.at("queued_duration_us").as_uint64();
+
+    EXPECT_GE(durationUs, 50000u) << "Wait time should include the delay before startProcessing";
 }
 
 struct WorkQueuePriorityTest : WithPrometheus, virtual ::testing::Test {

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -140,7 +140,7 @@ TEST_F(WorkQueueDelayedStartTest, WaitTimeIncludesDelayBeforeStartProcessing)
     EXPECT_GE(durationUs, 50000u) << "Wait time should include the delay before startProcessing";
 }
 
-struct WorkQueuePriorityTest : WithPrometheus, virtual ::testing::Test {
+struct WorkQueuePriorityTest : WithPrometheus {
     WorkQueue queue{WorkQueue::kDONT_START_PROCESSING_TAG, /* numWorkers = */ 1, /* maxSize = */ 100};
 };
 

--- a/tests/unit/rpc/WorkQueueTests.cpp
+++ b/tests/unit/rpc/WorkQueueTests.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include "rpc/WorkQueue.hpp"
+#include "util/LoggerFixtures.hpp"
 #include "util/MockPrometheus.hpp"
 #include "util/config/ConfigDefinition.hpp"
 #include "util/config/ConfigValue.hpp"
@@ -54,7 +55,7 @@ struct RPCWorkQueueTestBase : public virtual ::testing::Test {
     }
 };
 
-struct WorkQueueTest : WithPrometheus, RPCWorkQueueTestBase {
+struct WorkQueueTest : WithPrometheus, RPCWorkQueueTestBase, LoggerFixture {
     WorkQueueTest() : RPCWorkQueueTestBase(/* workers = */ 4, /* maxQueueSize = */ 2)
     {
     }
@@ -233,4 +234,5 @@ TEST_F(WorkQueueMockPrometheusTest, postCoroCounters)
     auto const res = queue.postCoro([&](auto /* yield */) { semaphore.acquire(); }, /* isWhiteListed = */ false);
 
     ASSERT_TRUE(res);
+    queue.stop();
 }


### PR DESCRIPTION
The new work queue implementation seems to be too slow because of its dispatcher component.
According to micro benchmark, this implementation appears to be nearly as fast as the original that did not support priorities.