### PR TITLE
feat: Add build information to `clio_server --version`

### DIFF
--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -1,5 +1,29 @@
 find_package(Git REQUIRED)
 
+if (DEFINED ENV{GITHUB_BRANCH_NAME})
+  set(GIT_BUILD_BRANCH $ENV{GITHUB_BRANCH_NAME})
+  set(GITHUB_HEAD_SHA $ENV{GITHUB_HEAD_SHA})
+  string(SUBSTRING ${GITHUB_HEAD_SHA} 0 7 GIT_COMMIT_HASH)
+else ()
+  set(GIT_COMMAND branch --show-current)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE GIT_BUILD_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
+  )
+
+  set(GIT_COMMAND rev-parse --short HEAD)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
+  )
+endif ()
+
+set(GIT_COMMAND show -s --date=format:%Y%m%d%H%M%S --format=%cd)
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE BUILD_DATE
+  OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
+)
+
 set(GIT_COMMAND describe --tags --exact-match)
 execute_process(
   COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND}
@@ -12,38 +36,14 @@ execute_process(
 
 if (RC EQUAL 0)
   message(STATUS "Found tag '${TAG}' in git. Will use it as Clio version")
+
   set(CLIO_VERSION "${TAG}")
   set(DOC_CLIO_VERSION "${TAG}")
 else ()
   message(STATUS "Error finding tag in git: ${ERR}")
   message(STATUS "Will use 'YYYYMMDDHMS-<branch>-<git-rev>' as Clio version")
 
-  set(GIT_COMMAND show -s --date=format:%Y%m%d%H%M%S --format=%cd)
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE DATE
-    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
-  )
-
-  if (DEFINED ENV{GITHUB_BRANCH_NAME})
-    # Please, see .github/actions/cmake/action.yml for details
-    set(BRANCH $ENV{GITHUB_BRANCH_NAME})
-    set(GITHUB_HEAD_SHA $ENV{GITHUB_HEAD_SHA})
-    string(SUBSTRING ${GITHUB_HEAD_SHA} 0 7 REV)
-  else ()
-    set(GIT_COMMAND branch --show-current)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE BRANCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
-    )
-
-    set(GIT_COMMAND rev-parse --short HEAD)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE REV
-      OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
-    )
-  endif ()
-
-  set(CLIO_VERSION "${DATE}-${BRANCH}-${REV}")
+  set(CLIO_VERSION "${BUILD_DATE}-${GIT_BUILD_BRANCH}-${GIT_COMMIT_HASH}")
   set(DOC_CLIO_VERSION "develop")
 endif ()
 

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -23,6 +23,10 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
 )
 
+message(STATUS "Git branch: ${GIT_BUILD_BRANCH}")
+message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
+message(STATUS "Build date: ${BUILD_DATE}")
+
 set(GIT_COMMAND describe --tags --exact-match)
 execute_process(
   COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND}

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -2,8 +2,7 @@ find_package(Git REQUIRED)
 
 if (DEFINED ENV{GITHUB_BRANCH_NAME})
   set(GIT_BUILD_BRANCH $ENV{GITHUB_BRANCH_NAME})
-  set(GITHUB_HEAD_SHA $ENV{GITHUB_HEAD_SHA})
-  string(SUBSTRING ${GITHUB_HEAD_SHA} 0 7 GIT_COMMIT_HASH)
+  set(GIT_COMMIT_HASH $ENV{GITHUB_HEAD_SHA})
 else ()
   set(GIT_COMMAND branch --show-current)
   execute_process(
@@ -11,7 +10,7 @@ else ()
     OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
   )
 
-  set(GIT_COMMAND rev-parse --short HEAD)
+  set(GIT_COMMAND rev-parse HEAD)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY
@@ -41,9 +40,11 @@ if (RC EQUAL 0)
   set(DOC_CLIO_VERSION "${TAG}")
 else ()
   message(STATUS "Error finding tag in git: ${ERR}")
-  message(STATUS "Will use 'YYYYMMDDHMS-<branch>-<git-rev>' as Clio version")
+  message(STATUS "Will use 'YYYYMMDDHMS-<branch>-<git short rev>' as Clio version")
 
-  set(CLIO_VERSION "${BUILD_DATE}-${GIT_BUILD_BRANCH}-${GIT_COMMIT_HASH}")
+  string(SUBSTRING ${GIT_COMMIT_HASH} 0 7 GIT_COMMIT_HASH_SHORT)
+
+  set(CLIO_VERSION "${BUILD_DATE}-${GIT_BUILD_BRANCH}-${GIT_COMMIT_HASH_SHORT}")
   set(DOC_CLIO_VERSION "develop")
 endif ()
 

--- a/src/app/CliArgs.cpp
+++ b/src/app/CliArgs.cpp
@@ -77,7 +77,10 @@ CliArgs::parse(int argc, char const* argv[])
     }
 
     if (parsed.contains("version")) {
-        std::cout << util::build::getClioFullVersionString() << '\n';
+        std::cout << util::build::getClioFullVersionString() << '\n'
+                  << "Git commit hash: " << util::build::getGitCommitHash() << '\n'
+                  << "Git build branch: " << util::build::getGitBuildBranch() << '\n'
+                  << "Build date: " << util::build::getBuildDate() << '\n';
         return Action{Action::Exit{EXIT_SUCCESS}};
     }
 

--- a/src/util/build/Build.cpp
+++ b/src/util/build/Build.cpp
@@ -26,7 +26,20 @@ namespace util::build {
 #ifndef CLIO_VERSION
 #error "CLIO_VERSION must be defined"
 #endif
+#ifndef GIT_COMMIT_HASH
+#error "GIT_COMMIT_HASH must be defined"
+#endif
+#ifndef GIT_BUILD_BRANCH
+#error "GIT_BUILD_BRANCH must be defined"
+#endif
+#ifndef BUILD_DATE
+#error "BUILD_DATE must be defined"
+#endif
+
 static constexpr char kVERSION_STRING[] = CLIO_VERSION;
+static constexpr char kGIT_COMMIT_HASH[] = GIT_COMMIT_HASH;
+static constexpr char kGIT_BUILD_BRANCH[] = GIT_BUILD_BRANCH;
+static constexpr char kBUILD_DATE[] = BUILD_DATE;
 
 std::string const&
 getClioVersionString()
@@ -39,6 +52,27 @@ std::string const&
 getClioFullVersionString()
 {
     static std::string const value = "clio-" + getClioVersionString();  // NOLINT(readability-identifier-naming)
+    return value;
+}
+
+std::string const&
+getGitCommitHash()
+{
+    static std::string const value = kGIT_COMMIT_HASH;  // NOLINT(readability-identifier-naming)
+    return value;
+}
+
+std::string const&
+getGitBuildBranch()
+{
+    static std::string const value = kGIT_BUILD_BRANCH;  // NOLINT(readability-identifier-naming)
+    return value;
+}
+
+std::string const&
+getBuildDate()
+{
+    static std::string const value = kBUILD_DATE;  // NOLINT(readability-identifier-naming)
     return value;
 }
 

--- a/src/util/build/Build.hpp
+++ b/src/util/build/Build.hpp
@@ -29,4 +29,13 @@ getClioVersionString();
 std::string const&
 getClioFullVersionString();
 
+std::string const&
+getGitCommitHash();
+
+std::string const&
+getGitBuildBranch();
+
+std::string const&
+getBuildDate();
+
 }  // namespace util::build

--- a/src/util/build/CMakeLists.txt
+++ b/src/util/build/CMakeLists.txt
@@ -3,4 +3,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/ClioVersion.cmake)
 add_library(clio_build_version)
 target_sources(clio_build_version PRIVATE Build.cpp)
 target_link_libraries(clio_build_version PUBLIC clio_options)
-target_compile_definitions(clio_build_version PRIVATE CLIO_VERSION="${CLIO_VERSION}")
+target_compile_definitions(
+  clio_build_version PRIVATE CLIO_VERSION="${CLIO_VERSION}" GIT_COMMIT_HASH="${GIT_COMMIT_HASH}"
+                             GIT_BUILD_BRANCH="${GIT_BUILD_BRANCH}" BUILD_DATE="${BUILD_DATE}"
+)


### PR DESCRIPTION
```
~/D/o/c/build (add_build_info) > ./clio_server --version
clio-20260109134325-add_build_info-ea0e208
Git commit hash: ea0e2083294d32b14faae365adc72e6fb86f687e
Git build branch: add_build_info
Build date: 20260109134325
```