### PR TITLE
fix: Workaround an edge case exception in `AmendmentCenter`

### DIFF
--- a/src/data/AmendmentCenter.cpp
+++ b/src/data/AmendmentCenter.cpp
@@ -146,9 +146,12 @@ AmendmentCenter::isEnabled(AmendmentKey const& key, uint32_t seq) const
 bool
 AmendmentCenter::isEnabled(boost::asio::yield_context yield, AmendmentKey const& key, uint32_t seq) const
 {
-    if (auto const listAmendments = fetchAmendmentsList(yield, seq); listAmendments)
-        return lookupAmendment(all_, *listAmendments, key);
-
+    try {
+        if (auto const listAmendments = fetchAmendmentsList(yield, seq); listAmendments)
+            return lookupAmendment(all_, *listAmendments, key);
+    } catch (std::runtime_error const&) {
+        return false;  // Some old ledger does not contain Amendments ledger object so do best we can for now
+    }
     return false;
 }
 
@@ -157,13 +160,19 @@ AmendmentCenter::isEnabled(boost::asio::yield_context yield, std::vector<Amendme
 {
     namespace rg = std::ranges;
 
-    if (auto const listAmendments = fetchAmendmentsList(yield, seq); listAmendments) {
-        std::vector<bool> out;
-        rg::transform(keys, std::back_inserter(out), [this, &listAmendments](auto const& key) {
-            return lookupAmendment(all_, *listAmendments, key);
-        });
+    try {
+        if (auto const listAmendments = fetchAmendmentsList(yield, seq); listAmendments) {
+            std::vector<bool> out;
+            rg::transform(keys, std::back_inserter(out), [this, &listAmendments](auto const& key) {
+                return lookupAmendment(all_, *listAmendments, key);
+            });
 
-        return out;
+            return out;
+        }
+    } catch (std::runtime_error const&) {
+        return std::vector<bool>(
+            keys.size(), false
+        );  // Some old ledger does not contain Amendments ledger object so do best we can for now
     }
 
     return std::vector<bool>(keys.size(), false);

--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <iterator>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -45,7 +45,6 @@
 #include <algorithm>
 #include <iterator>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/tests/unit/data/AmendmentCenterTests.cpp
+++ b/tests/unit/data/AmendmentCenterTests.cpp
@@ -104,16 +104,13 @@ TEST_F(AmendmentCenterTest, IsMultipleEnabled)
     });
 }
 
-TEST_F(AmendmentCenterTest, IsEnabledThrowsWhenUnavailable)
+TEST_F(AmendmentCenterTest, IsEnabledReturnsFalseWhenAmendmentsLedgerObjectUnavailable)
 {
     EXPECT_CALL(*backend_, doFetchLedgerObject(ripple::keylet::amendments().key, kSEQ, testing::_))
         .WillOnce(testing::Return(std::nullopt));
 
     runSpawn([this](auto yield) {
-        EXPECT_THROW(
-            { [[maybe_unused]] auto const result = amendmentCenter.isEnabled(yield, "irrelevant", kSEQ); },
-            std::runtime_error
-        );
+        EXPECT_NO_THROW(EXPECT_FALSE(amendmentCenter.isEnabled(yield, "irrelevant", kSEQ)));
     });
 }
 
@@ -124,6 +121,21 @@ TEST_F(AmendmentCenterTest, IsEnabledReturnsFalseWhenNoAmendments)
         .WillOnce(testing::Return(amendments.getSerializer().peekData()));
 
     runSpawn([this](auto yield) { EXPECT_FALSE(amendmentCenter.isEnabled(yield, "irrelevant", kSEQ)); });
+}
+
+TEST_F(AmendmentCenterTest, IsEnabledReturnsVectorOfFalseWhenAmendmentsLedgerObjectUnavailable)
+{
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ripple::keylet::amendments().key, kSEQ, testing::_))
+        .WillOnce(testing::Return(std::nullopt));
+
+    runSpawn([this](auto yield) {
+        std::vector<data::AmendmentKey> const keys{"fixUniversalNumber", "ImmediateOfferKilled"};
+        std::vector<bool> vec;
+        EXPECT_NO_THROW(vec = amendmentCenter.isEnabled(yield, keys, kSEQ));
+
+        EXPECT_EQ(vec.size(), keys.size());
+        EXPECT_TRUE(std::ranges::all_of(vec, std::logical_not<>{}));
+    });
 }
 
 TEST_F(AmendmentCenterTest, IsEnabledReturnsVectorOfFalseWhenNoAmendments)


### PR DESCRIPTION
Fixes #2881

From my tests the output of `account_info` is now identical with `xrpld`.
I'd like to investigate this further in the future and possibly find a better fix if there is one in #2895 