### PR TITLE
ci: Pass version explicitly and don't rely on tags

### DIFF
--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: true
     default: "false"
   version:
-    description: Version to set in the build
+    description: Version of the clio_server binary
     required: false
     default: ""
 

--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: Whether to generate Debian package
     required: true
     default: "false"
+  version:
+    description: Version to set in the build
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -67,6 +71,9 @@ runs:
         # This way it works both for PRs and pushes to branches.
         GITHUB_BRANCH_NAME: "${{ github.head_ref || github.ref_name }}"
         GITHUB_HEAD_SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
+        #
+        # If tag is being pushed, or it's a nightly release, we use that version.
+        FORCE_VERSION: ${{ inputs.version }}
       run: |
         cmake \
           -B "${BUILD_DIR}" \

--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -73,7 +73,7 @@ runs:
         GITHUB_HEAD_SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
         #
         # If tag is being pushed, or it's a nightly release, we use that version.
-        FORCE_VERSION: ${{ inputs.version }}
+        FORCE_CLIO_VERSION: ${{ inputs.version }}
       run: |
         cmake \
           -B "${BUILD_DIR}" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,8 +28,20 @@ defaults:
     shell: bash
 
 jobs:
+  get_date:
+    name: Get Date
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.get_date.outputs.date }}
+    steps:
+      - name: Get current date
+        id: get_date
+        run: |
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
   build-and-test:
     name: Build and Test
+    needs: get_date
 
     strategy:
       fail-fast: false
@@ -67,9 +79,11 @@ jobs:
       upload_clio_server: true
       download_ccache: false
       upload_ccache: false
+      version: nightly-${{ needs.get_date.outputs.date }}
 
   package:
     name: Build debian package
+    needs: get_date
 
     uses: ./.github/workflows/reusable-build.yml
     with:
@@ -83,11 +97,13 @@ jobs:
       static: true
       upload_clio_server: false
       package: true
+      version: nightly-${{ needs.get_date.outputs.date }}
       targets: package
       analyze_build_time: false
 
   analyze_build_time:
     name: Analyze Build Time
+    needs: get_date
 
     strategy:
       fail-fast: false
@@ -114,17 +130,7 @@ jobs:
       upload_clio_server: false
       targets: all
       analyze_build_time: true
-
-  get_date:
-    name: Get Date
-    runs-on: ubuntu-latest
-    outputs:
-      date: ${{ steps.get_date.outputs.date }}
-    steps:
-      - name: Get current date
-        id: get_date
-        run: |
-          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      version: nightly-${{ needs.get_date.outputs.date }}
 
   nightly_release:
     needs: [build-and-test, package, get_date]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       upload_clio_server: true
       download_ccache: false
       upload_ccache: false
-      expected_version: ${{ github.event_name == 'push' && github.ref_name || '' }}
+      version: ${{ github.event_name == 'push' && github.ref_name || '' }}
 
   package:
     name: Build debian package
@@ -60,6 +60,7 @@ jobs:
       static: true
       upload_clio_server: false
       package: true
+      version: ${{ github.event_name == 'push' && github.ref_name || '' }}
       targets: package
       analyze_build_time: false
 

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -63,17 +63,17 @@ on:
         type: string
         default: all
 
-      expected_version:
-        description: Expected version of the clio_server binary
-        required: false
-        type: string
-        default: ""
-
       package:
         description: Whether to generate Debian package
         required: false
         type: boolean
         default: false
+
+      version:
+        description: Version of the clio_server binary
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -90,8 +90,8 @@ jobs:
       upload_clio_server: ${{ inputs.upload_clio_server }}
       targets: ${{ inputs.targets }}
       analyze_build_time: false
-      expected_version: ${{ inputs.expected_version }}
       package: ${{ inputs.package }}
+      version: ${{ inputs.version }}
 
   test:
     needs: build

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -222,6 +222,10 @@ jobs:
         run: |
           set -e
           EXPECTED_VERSION="clio-${INPUT_VERSION}"
+          if [[ ${{ inputs.build_type }} == "Debug" ]]; then
+            EXPECTED_VERSION="${EXPECTED_VERSION}+DEBUG"
+          fi
+
           actual_version=$(./build/clio_server --version | head -n 1)
           if [[ "${actual_version}" != "${EXPECTED_VERSION}" ]]; then
             echo "Expected version '${EXPECTED_VERSION}', but got '${actual_version}'"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -60,16 +60,16 @@ on:
         required: true
         type: boolean
 
-      expected_version:
-        description: Expected version of the clio_server binary
-        required: false
-        type: string
-        default: ""
-
       package:
         description: Whether to generate Debian package
         required: false
         type: boolean
+
+      version:
+        description: Version of the clio_server binary
+        required: false
+        type: string
+        default: ""
 
     secrets:
       CODECOV_TOKEN:
@@ -93,10 +93,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
-          # We need to fetch tags to have correct version in the release
-          # The workaround is based on https://github.com/actions/checkout/issues/1467
-          fetch-tags: true
-          ref: ${{ github.ref }}
 
       - name: Prepare runner
         uses: XRPLF/actions/prepare-runner@65da1c59e81965eeb257caa3587b9d45066fb925
@@ -139,6 +135,7 @@ jobs:
           static: ${{ inputs.static }}
           time_trace: ${{ inputs.analyze_build_time }}
           package: ${{ inputs.package }}
+          version: ${{ inputs.version }}
 
       - name: Build Clio
         uses: ./.github/actions/build-clio
@@ -218,15 +215,15 @@ jobs:
         if: ${{ inputs.code_coverage }}
         uses: ./.github/actions/code-coverage
 
-      - name: Verify expected version
-        if: ${{ inputs.expected_version != '' }}
+      - name: Verify version is expected
+        if: ${{ inputs.version != '' }}
         env:
-          INPUT_EXPECTED_VERSION: ${{ inputs.expected_version }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -e
-          EXPECTED_VERSION="clio-${INPUT_EXPECTED_VERSION}"
-          actual_version=$(./build/clio_server --version)
-          if [[ "$actual_version" != "$EXPECTED_VERSION" ]]; then
+          EXPECTED_VERSION="clio-${INPUT_VERSION}"
+          actual_version=$(./build/clio_server --version | head -n 1)
+          if [[ "${actual_version}" != "${EXPECTED_VERSION}" ]]; then
             echo "Expected version '${EXPECTED_VERSION}', but got '${actual_version}'"
             exit 1
           fi

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -27,11 +27,11 @@ message(STATUS "Git branch: ${GIT_BUILD_BRANCH}")
 message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
 message(STATUS "Build date: ${BUILD_DATE}")
 
-if (DEFINED ENV{FORCE_VERSION} AND NOT "$ENV{FORCE_VERSION}" STREQUAL "")
-  message(STATUS "Using explicitly provided '${FORCE_VERSION}' as Clio version")
+if (DEFINED ENV{FORCE_CLIO_VERSION} AND NOT "$ENV{FORCE_CLIO_VERSION}" STREQUAL "")
+  message(STATUS "Using explicitly provided '${FORCE_CLIO_VERSION}' as Clio version")
 
-  set(CLIO_VERSION "$ENV{FORCE_VERSION}")
-  set(DOC_CLIO_VERSION "$ENV{FORCE_VERSION}")
+  set(CLIO_VERSION "$ENV{FORCE_CLIO_VERSION}")
+  set(DOC_CLIO_VERSION "$ENV{FORCE_CLIO_VERSION}")
 else ()
   message(STATUS "Using 'YYYYMMDDHMS-<branch>-<git short rev>' as Clio version")
 

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -27,23 +27,13 @@ message(STATUS "Git branch: ${GIT_BUILD_BRANCH}")
 message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
 message(STATUS "Build date: ${BUILD_DATE}")
 
-set(GIT_COMMAND describe --tags --exact-match)
-execute_process(
-  COMMAND ${GIT_EXECUTABLE} ${GIT_COMMAND}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE TAG
-  RESULT_VARIABLE RC
-  ERROR_VARIABLE ERR
-  OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE
-)
-
-if (RC EQUAL 0)
+if (DEFINED ENV{FORCE_VERSION} AND NOT "$ENV{FORCE_VERSION}" STREQUAL "")
   message(STATUS "Found tag '${TAG}' in git. Will use it as Clio version")
 
-  set(CLIO_VERSION "${TAG}")
-  set(DOC_CLIO_VERSION "${TAG}")
+  set(CLIO_VERSION "$ENV{FORCE_VERSION}")
+  set(DOC_CLIO_VERSION "$ENV{FORCE_VERSION}")
 else ()
-  message(STATUS "Error finding tag in git: ${ERR}")
+  message(STATUS "Version was not provided via FORCE_VERSION environment variable.")
   message(STATUS "Will use 'YYYYMMDDHMS-<branch>-<git short rev>' as Clio version")
 
   string(SUBSTRING ${GIT_COMMIT_HASH} 0 7 GIT_COMMIT_HASH_SHORT)

--- a/cmake/ClioVersion.cmake
+++ b/cmake/ClioVersion.cmake
@@ -28,13 +28,12 @@ message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
 message(STATUS "Build date: ${BUILD_DATE}")
 
 if (DEFINED ENV{FORCE_VERSION} AND NOT "$ENV{FORCE_VERSION}" STREQUAL "")
-  message(STATUS "Found tag '${TAG}' in git. Will use it as Clio version")
+  message(STATUS "Using explicitly provided '${FORCE_VERSION}' as Clio version")
 
   set(CLIO_VERSION "$ENV{FORCE_VERSION}")
   set(DOC_CLIO_VERSION "$ENV{FORCE_VERSION}")
 else ()
-  message(STATUS "Version was not provided via FORCE_VERSION environment variable.")
-  message(STATUS "Will use 'YYYYMMDDHMS-<branch>-<git short rev>' as Clio version")
+  message(STATUS "Using 'YYYYMMDDHMS-<branch>-<git short rev>' as Clio version")
 
   string(SUBSTRING ${GIT_COMMIT_HASH} 0 7 GIT_COMMIT_HASH_SHORT)
 


### PR DESCRIPTION
Relying on tags doesn't work when making nightly releases.
If we make a nightly release first time, version will be sth like `develop-<date>-<short-rev>`.
But if we don't commit for a while and nightly runs again, we will see previously created tag, and will use it.

This PR makes our build process not rely on tags, and purely rely on the type of event being triggered and passes this information to CMake explicitly.