### PR TITLE
fix: Flush buffers before renaming cache file

### DIFF
--- a/src/data/impl/LedgerCacheFile.cpp
+++ b/src/data/impl/LedgerCacheFile.cpp
@@ -115,6 +115,11 @@ LedgerCacheFile::write(DataView dataView)
     auto const hash = file.hash();
     file.write(hash.data(), decltype(hash)::bytes);
 
+    // flush internal buffer explicitly before renaming
+    if (auto const expectedSuccess = file.close(); not expectedSuccess.has_value()) {
+        return expectedSuccess;
+    }
+
     try {
         std::filesystem::rename(newFilePath, path_);
     } catch (std::exception const& e) {

--- a/src/data/impl/OutputFile.cpp
+++ b/src/data/impl/OutputFile.cpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <expected>
 #include <ios>
 #include <string>
 #include <utility>
@@ -57,6 +58,16 @@ OutputFile::hash() const
 {
     auto sum = shasum_;
     return std::move(sum).finalize();
+}
+
+std::expected<void, std::string>
+OutputFile::close()
+{
+    file_.close();
+    if (not file_) {
+        return std::unexpected{"Error closing cache file"};
+    }
+    return {};
 }
 
 }  // namespace data::impl

--- a/src/data/impl/OutputFile.hpp
+++ b/src/data/impl/OutputFile.hpp
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <expected>
 #include <fstream>
 #include <string>
 
@@ -59,6 +60,9 @@ public:
 
     ripple::uint256
     hash() const;
+
+    std::expected<void, std::string>
+    close();
 
 private:
     void


### PR DESCRIPTION
If clio shuts itself down due to exceeding graceful period when cache is saved and renamed but the buffers are not flushed, we may end up with a corrupted cache file. Clio will detect corruption and will not load corrupted cache file, but we could avoid it by explicitly flushing ofstream buffer.