### PR TITLE
chore: Add more AI folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ CMakeUserPresets.json
 config.json
 CLAUDE.md
 .claude/**
+.agents/**
+.augment/**


### PR DESCRIPTION
This PR adds `.augment` and `.agents` to `.gitignore`.