### PR TITLE
test: Fix integration tests

### DIFF
--- a/tests/integration/data/BackendFactoryTests.cpp
+++ b/tests/integration/data/BackendFactoryTests.cpp
@@ -81,7 +81,7 @@ public:
         // drop the keyspace for next test
         data::cassandra::Handle const handle{TestGlobals::instance().backendHost};
         EXPECT_TRUE(handle.connect());
-        EXPECT_TRUE(handle.execute("DROP KEYSPACE " + std::string{kKEYSPACE}));
+        EXPECT_TRUE(handle.execute("DROP KEYSPACE IF EXISTS " + std::string{kKEYSPACE}));
     }
 };
 
@@ -98,7 +98,7 @@ TEST_F(BackendCassandraFactoryTest, CreateCassandraBackendDBDisconnect)
         {"database": {
             "type": "cassandra",
             "cassandra": {
-                "contact_points": "127.0.0.2"
+                "contact_points": "128.0.2.1"
             }
         }}
     )JSON");

--- a/tests/integration/data/cassandra/BaseTests.cpp
+++ b/tests/integration/data/cassandra/BaseTests.cpp
@@ -111,7 +111,7 @@ TEST_F(BackendCassandraBaseTest, ConnectionFailTimeout)
     Settings settings;
     settings.connectionTimeout = std::chrono::milliseconds{30};
     settings.connectionInfo =
-        Settings::ContactPoints{.contactPoints = "192.0.2.1", .port = std::nullopt};
+        Settings::ContactPoints{.contactPoints = "128.0.2.1", .port = std::nullopt};
 
     Handle const handle{settings};
     auto const f = handle.asyncConnect();

--- a/tests/integration/data/cassandra/BaseTests.cpp
+++ b/tests/integration/data/cassandra/BaseTests.cpp
@@ -111,7 +111,7 @@ TEST_F(BackendCassandraBaseTest, ConnectionFailTimeout)
     Settings settings;
     settings.connectionTimeout = std::chrono::milliseconds{30};
     settings.connectionInfo =
-        Settings::ContactPoints{.contactPoints = "127.0.0.2", .port = std::nullopt};
+        Settings::ContactPoints{.contactPoints = "192.0.2.1", .port = std::nullopt};
 
     Handle const handle{settings};
     auto const f = handle.asyncConnect();


### PR DESCRIPTION
Fix 2 issues in integration tests:
- `127.0.0.2` is forwarded to localhost on macos
- Keyspace is always dropped in test's destructor but it may not exist 