### PR TITLE
style: More clang-tidy identifier renaming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -189,8 +189,11 @@ CheckOptions:
   readability-identifier-naming.ParameterCase: camelBack
   readability-identifier-naming.FunctionCase: camelBack
   readability-identifier-naming.MemberCase: camelBack
+  readability-identifier-naming.PrivateMemberCase: camelBack
   readability-identifier-naming.PrivateMemberSuffix: _
+  readability-identifier-naming.ProtectedMemberCase: camelBack
   readability-identifier-naming.ProtectedMemberSuffix: _
+  readability-identifier-naming.PublicMemberCase: camelBack
   readability-identifier-naming.PublicMemberSuffix: ""
   readability-identifier-naming.FunctionIgnoredRegexp: ".*tag_invoke.*"
 

--- a/src/rpc/handlers/AccountMPTokenIssuances.cpp
+++ b/src/rpc/handlers/AccountMPTokenIssuances.cpp
@@ -37,7 +37,7 @@ AccountMPTokenIssuancesHandler::addMPTokenIssuance(
 {
     MPTokenIssuanceResponse issuance;
 
-    issuance.MPTokenIssuanceID = ripple::strHex(sle.key());
+    issuance.mpTokenIssuanceId = ripple::strHex(sle.key());
     issuance.issuer = ripple::to_string(account);
     issuance.sequence = sle.getFieldU32(ripple::sfSequence);
     auto const flags = sle.getFieldU32(ripple::sfFlags);
@@ -225,7 +225,7 @@ tag_invoke(
 )
 {
     auto obj = boost::json::object{
-        {JS(mpt_issuance_id), issuance.MPTokenIssuanceID},
+        {JS(mpt_issuance_id), issuance.mpTokenIssuanceId},
         {JS(issuer), issuance.issuer},
         {JS(sequence), issuance.sequence},
     };

--- a/src/rpc/handlers/AccountMPTokenIssuances.hpp
+++ b/src/rpc/handlers/AccountMPTokenIssuances.hpp
@@ -42,7 +42,7 @@ public:
      * @brief A struct to hold data for one MPTokenIssuance response.
      */
     struct MPTokenIssuanceResponse {
-        std::string MPTokenIssuanceID;
+        std::string mpTokenIssuanceId;
         std::string issuer;
         uint32_t sequence{};
 

--- a/src/rpc/handlers/AccountMPTokens.cpp
+++ b/src/rpc/handlers/AccountMPTokens.cpp
@@ -35,10 +35,10 @@ AccountMPTokensHandler::addMPToken(std::vector<MPTokenResponse>& mpts, ripple::S
     MPTokenResponse token{};
     auto const flags = sle.getFieldU32(ripple::sfFlags);
 
-    token.MPTokenID = ripple::strHex(sle.key());
+    token.mpTokenId = ripple::strHex(sle.key());
     token.account = ripple::to_string(sle.getAccountID(ripple::sfAccount));
-    token.MPTokenIssuanceID = ripple::strHex(sle.getFieldH192(ripple::sfMPTokenIssuanceID));
-    token.MPTAmount = sle.getFieldU64(ripple::sfMPTAmount);
+    token.mpTokenIssuanceId = ripple::strHex(sle.getFieldH192(ripple::sfMPTokenIssuanceID));
+    token.mptAmount = sle.getFieldU64(ripple::sfMPTAmount);
 
     if (sle.isFieldPresent(ripple::sfLockedAmount))
         token.lockedAmount = sle.getFieldU64(ripple::sfLockedAmount);
@@ -177,10 +177,10 @@ tag_invoke(
 )
 {
     auto obj = boost::json::object{
-        {"mpt_id", mptoken.MPTokenID},
+        {"mpt_id", mptoken.mpTokenId},
         {JS(account), mptoken.account},
-        {JS(mpt_issuance_id), mptoken.MPTokenIssuanceID},
-        {JS(mpt_amount), mptoken.MPTAmount},
+        {JS(mpt_issuance_id), mptoken.mpTokenIssuanceId},
+        {JS(mpt_amount), mptoken.mptAmount},
     };
 
     auto const setIfPresent = [&](boost::json::string_view field, auto const& value) {

--- a/src/rpc/handlers/AccountMPTokens.hpp
+++ b/src/rpc/handlers/AccountMPTokens.hpp
@@ -41,10 +41,10 @@ public:
      * @brief A struct to hold data for one MPToken response.
      */
     struct MPTokenResponse {
-        std::string MPTokenID;
+        std::string mpTokenId;
         std::string account;
-        std::string MPTokenIssuanceID;
-        uint64_t MPTAmount{};
+        std::string mpTokenIssuanceId;
+        uint64_t mptAmount{};
         std::optional<uint64_t> lockedAmount;
 
         std::optional<bool> mptLocked;

--- a/src/util/log/Logger.cpp
+++ b/src/util/log/Logger.cpp
@@ -119,7 +119,7 @@ getSeverityLevel(std::string_view logLevel)
 class NonCriticalFormatter : public spdlog::formatter {
 public:
     NonCriticalFormatter(std::unique_ptr<spdlog::formatter> wrappedFormatter)
-        : wrapped_formatter_(std::move(wrappedFormatter))
+        : wrappedFormatter_(std::move(wrappedFormatter))
     {
     }
 
@@ -128,18 +128,18 @@ public:
     {
         // Only format messages with severity less than critical
         if (msg.level != spdlog::level::critical) {
-            wrapped_formatter_->format(msg, dest);
+            wrappedFormatter_->format(msg, dest);
         }
     }
 
     [[nodiscard]] std::unique_ptr<formatter>
     clone() const override
     {
-        return std::make_unique<NonCriticalFormatter>(wrapped_formatter_->clone());
+        return std::make_unique<NonCriticalFormatter>(wrappedFormatter_->clone());
     }
 
 private:
-    std::unique_ptr<spdlog::formatter> wrapped_formatter_;
+    std::unique_ptr<spdlog::formatter> wrappedFormatter_;
 };
 
 /**


### PR DESCRIPTION
In order to keep the configs in tune, this PR mirrors what https://github.com/XRPLF/rippled/pull/7290 did for xrpld.