### PR TITLE
ci: Fix docs workflow && build on PRs

### DIFF
--- a/.github/scripts/conan/generate_matrix.py
+++ b/.github/scripts/conan/generate_matrix.py
@@ -3,7 +3,7 @@ import itertools
 import json
 
 LINUX_OS = ["heavy", "heavy-arm64"]
-LINUX_CONTAINERS = ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }']
+LINUX_CONTAINERS = ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }']
 LINUX_COMPILERS = ["gcc", "clang"]
 
 MACOS_OS = ["macos15"]

--- a/.github/scripts/conan/generate_matrix.py
+++ b/.github/scripts/conan/generate_matrix.py
@@ -3,7 +3,7 @@ import itertools
 import json
 
 LINUX_OS = ["heavy", "heavy-arm64"]
-LINUX_CONTAINERS = ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }']
+LINUX_CONTAINERS = ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }']
 LINUX_COMPILERS = ["gcc", "clang"]
 
 MACOS_OS = ["macos15"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         os: [heavy]
         compiler: [gcc, clang]
         build_type: [Release, Debug]
-        container: ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }']
+        container: ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }']
 
         include:
           - os: macos15
@@ -73,7 +73,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
       compiler: gcc
       build_type: Debug
       download_ccache: true
@@ -90,7 +90,7 @@ jobs:
     needs: build-and-test
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         os: [heavy]
         compiler: [gcc, clang]
         build_type: [Release, Debug]
-        container: ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }']
+        container: ['{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }']
 
         include:
           - os: macos15
@@ -73,7 +73,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
       compiler: gcc
       build_type: Debug
       download_ccache: true
@@ -90,7 +90,7 @@ jobs:
     needs: build-and-test
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/check-libxrpl.yml
+++ b/.github/workflows/check-libxrpl.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build Clio / `libXRPL ${{ github.event.client_payload.version }}`
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -76,7 +76,7 @@ jobs:
     needs: build
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/check-libxrpl.yml
+++ b/.github/workflows/check-libxrpl.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build Clio / `libXRPL ${{ github.event.client_payload.version }}`
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -76,7 +76,7 @@ jobs:
     needs: build
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || needs.determine-files.outputs.cpp_changed_files != '' || needs.determine-files.outputs.clang_tidy_config_changed == 'true') }}
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 
     permissions:
       contents: write

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || needs.determine-files.outputs.cpp_changed_files != '' || needs.determine-files.outputs.clang_tidy_config_changed == 'true') }}
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches: [develop]
   workflow_dispatch:
+  pull_request:
+    branches: [release/*, develop]
+    paths:
+      - .github/workflows/docs.yml
+
+      - CMakeLists.txt
+      - conanfile.py
+      - conan.lock
+      - "cmake/**"
+      - "docs/**"
+      - "src/**"
+      - "tests/**"
 
 concurrency:
   # Only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
@@ -18,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,16 +53,16 @@ jobs:
           - os: heavy
             compiler: gcc
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
           - os: heavy
             compiler: gcc
             build_type: Debug
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
           - os: heavy
             compiler: gcc
             sanitizers: undefinedbehavior
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
 
     uses: ./.github/workflows/reusable-build-test.yml
     with:
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
       compiler: gcc
       build_type: Release
       download_ccache: false
@@ -107,7 +107,7 @@ jobs:
         include:
           - os: heavy
             compiler: clang
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
           - os: macos15
             compiler: apple-clang
             container: ""

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,16 +53,16 @@ jobs:
           - os: heavy
             compiler: gcc
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
           - os: heavy
             compiler: gcc
             build_type: Debug
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
           - os: heavy
             compiler: gcc
             sanitizers: undefinedbehavior
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
 
     uses: ./.github/workflows/reusable-build-test.yml
     with:
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
       compiler: gcc
       build_type: Release
       download_ccache: false
@@ -107,7 +107,7 @@ jobs:
         include:
           - os: heavy
             compiler: clang
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
           - os: macos15
             compiler: apple-clang
             container: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           - os: heavy
             compiler: gcc
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
 
     uses: ./.github/workflows/reusable-build-test.yml
     with:
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
       compiler: gcc
       build_type: Release
       download_ccache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           - os: heavy
             compiler: gcc
             build_type: Release
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
 
     uses: ./.github/workflows/reusable-build-test.yml
     with:
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
       compiler: gcc
       build_type: Release
       download_ccache: false

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -46,7 +46,7 @@ jobs:
   release:
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -46,7 +46,7 @@ jobs:
   release:
     runs-on: heavy
     container:
-      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b" }'
       download_ccache: false
       upload_ccache: false
       compiler: ${{ matrix.compiler }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-test.yml
     with:
       runs_on: heavy
-      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553" }'
+      container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d" }'
       download_ccache: false
       upload_ccache: false
       compiler: ${{ matrix.compiler }}

--- a/docker/develop/compose.yaml
+++ b/docker/develop/compose.yaml
@@ -1,6 +1,6 @@
 services:
   clio_develop:
-    image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+    image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
     volumes:
       - clio_develop_conan_data:/root/.conan2/p
       - clio_develop_ccache:/root/.ccache

--- a/docker/develop/compose.yaml
+++ b/docker/develop/compose.yaml
@@ -1,6 +1,6 @@
 services:
   clio_develop:
-    image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+    image: ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
     volumes:
       - clio_develop_conan_data:/root/.conan2/p
       - clio_develop_ccache:/root/.ccache

--- a/docs/build-clio.md
+++ b/docs/build-clio.md
@@ -175,7 +175,7 @@ Open the `index.html` file in your browser to see the documentation pages.
 It is also possible to build Clio using [Docker](https://www.docker.com/) if you don't want to install all the dependencies on your machine.
 
 ```sh
-docker run -it ghcr.io/xrplf/xrpld/nix-ubuntu:sha-7b9d553
+docker run -it ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
 git clone https://github.com/XRPLF/clio
 cd clio
 ```

--- a/docs/build-clio.md
+++ b/docs/build-clio.md
@@ -175,7 +175,7 @@ Open the `index.html` file in your browser to see the documentation pages.
 It is also possible to build Clio using [Docker](https://www.docker.com/) if you don't want to install all the dependencies on your machine.
 
 ```sh
-docker run -it ghcr.io/xrplf/xrpld/nix-ubuntu:sha-45ddc1d
+docker run -it ghcr.io/xrplf/xrpld/nix-ubuntu:sha-cb2642b
 git clone https://github.com/XRPLF/clio
 cd clio
 ```


### PR DESCRIPTION
I update all workflows to use new image (which now has git-lfs)
Also, to check it, we should build docs in PRs - it's fast, so shouldn't affect anyone.