### PR TITLE
ci: Pin scylladb docker to fix integration tests

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -104,7 +104,7 @@ jobs:
 
     services:
       scylladb:
-        image: ${{ inputs.container != '' && 'scylladb/scylla' || '' }}
+        image: ${{ inputs.container != '' && 'scylladb/scylla:2026.1' || '' }}
         options: >-
           --health-cmd "cqlsh -e 'describe cluster'"
           --health-interval 10s
@@ -156,7 +156,7 @@ jobs:
               --health-retries 5 \
               --publish 9042:9042 \
               --memory 16G \
-              scylladb/scylla
+              scylladb/scylla:2026.1
 
       - name: Wait for scylladb container to be healthy (macOS)
         if: ${{ runner.os == 'macOS' }}

--- a/docs/trouble_shooting.md
+++ b/docs/trouble_shooting.md
@@ -13,7 +13,7 @@ If you see the error log message `Could not connect to Cassandra: No hosts avail
 If you would like to run a local ScyllaDB, you can call:
 
 ```sh
-docker run --rm -p 9042:9042 --name clio-scylla -d scylladb/scylla
+docker run --rm -p 9042:9042 --name clio-scylla -d scylladb/scylla:2026.1
 ```
 
 ## Check the server status of Clio


### PR DESCRIPTION
It seems that new scylladb versions have changed `SimpleStrategy` that we use and now code fails with:
```
C++ exception with description "Could not create keyspace: future::get(): SimpleStrategy doesn't support tablet replication" thrown in the test fixture's constructor.
```

This should fix it for now in integration tests, but we should take a closer look if we need to migrate the database