### PR TITLE
build: Don't reuse binaries between different C++ versions

### DIFF
--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -20,6 +20,8 @@ compiler.libcxx={{ detect_api.detect_libcxx(compiler, version, compiler_exe) }}
 {% endif %}
 
 [conf]
-{# By default, conan tries compatibility mode to reuse binaries built with different cppstd versions #}
+{# By default, Conan tries to reuse binaries built with different cppstd versions. #}
+{# We want to avoid that to improve reproduceability, so we add the cppstd version to the package ID. #}
+{# More info: https://docs.conan.io/2/reference/extensions/binary_compatibility.html #}
 user.package:cppstd_version=23
 tools.info.package_id:confs+=["user.package:cppstd_version"]

--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -10,11 +10,16 @@
 os={{ os }}
 arch={{ arch }}
 build_type=Debug
-compiler={{compiler}}
+compiler={{ compiler }}
 compiler.version={{ compiler_version }}
 compiler.cppstd=23
 {% if os == "Windows" %}
 compiler.runtime=static
 {% else %}
-compiler.libcxx={{detect_api.detect_libcxx(compiler, version, compiler_exe)}}
+compiler.libcxx={{ detect_api.detect_libcxx(compiler, version, compiler_exe) }}
 {% endif %}
+
+[conf]
+{# By default, conan tries compatibility mode to reuse binaries built with different cppstd versions #}
+user.package:cppstd_version=23
+tools.info.package_id:confs+=["user.package:cppstd_version"]

--- a/conan/profiles/sanitizers
+++ b/conan/profiles/sanitizers
@@ -87,15 +87,15 @@ include(default)
 {% endif %}
 
 [conf]
-tools.build:defines+={{defines}}
-tools.build:cxxflags+={{sanitizer_compiler_flags}}
-tools.build:sharedlinkflags+={{sanitizer_linker_flags}}
-tools.build:exelinkflags+={{sanitizer_linker_flags}}
+tools.build:defines+={{ defines }}
+tools.build:cxxflags+={{ sanitizer_compiler_flags }}
+tools.build:sharedlinkflags+={{ sanitizer_linker_flags }}
+tools.build:exelinkflags+={{ sanitizer_linker_flags }}
 
 tools.info.package_id:confs+=["tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags", "tools.build:defines"]
 
 # &: means "apply only to the consumer/root package"
-&:tools.cmake.cmaketoolchain:extra_variables={"SANITIZERS": "{{sanitizers}}", "SANITIZERS_COMPILER_FLAGS": "{{sanitizer_compiler_flags | join(' ')}}", "SANITIZERS_LINKER_FLAGS": "{{sanitizer_linker_flags | join(' ')}}"}
+&:tools.cmake.cmaketoolchain:extra_variables={"SANITIZERS": "{{ sanitizers }}", "SANITIZERS_COMPILER_FLAGS": "{{ sanitizer_compiler_flags | join(' ') }}", "SANITIZERS_LINKER_FLAGS": "{{ sanitizer_linker_flags | join(' ') }}"}
 
 [options]
 {% if enable_asan %}


### PR DESCRIPTION
By default, Conan tries to use binaries built with other cppstd version.
It makes code less reproducible.
Let's force all binaries to have an exact C++ version.

Small tweaks:
- Style in templates is unified
- Everything was pre-built here: https://github.com/XRPLF/clio/actions/runs/28514120255?pr=3131