### PR TITLE
fix: Serialize MPToken UInt64 amounts as base-10 strings

### DIFF
--- a/src/rpc/handlers/AccountMPTokenIssuances.cpp
+++ b/src/rpc/handlers/AccountMPTokenIssuances.cpp
@@ -243,10 +243,10 @@ tag_invoke(
     auto const setUint64IfPresent =
         [&](boost::json::string_view field, xrpl::SField const& sField, auto const& value) {
             if (value.has_value()) {
-                obj[field] =
-                    toBoostJson(xrpl::STUInt64{sField, *value}.getJson(xrpl::JsonOptions::Values::None
-                    ));
-}
+                obj[field] = toBoostJson(
+                    xrpl::STUInt64{sField, *value}.getJson(xrpl::JsonOptions::Values::None)
+                );
+            }
         };
 
     setIfPresent("transfer_fee", issuance.transferFee);

--- a/src/rpc/handlers/AccountMPTokenIssuances.cpp
+++ b/src/rpc/handlers/AccountMPTokenIssuances.cpp
@@ -17,6 +17,7 @@
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/LedgerHeader.h>
 #include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STInteger.h>
 #include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/jss.h>
 
@@ -236,11 +237,22 @@ tag_invoke(
         }
     };
 
+    // UInt64 amount fields must be serialized as base-10 strings (matching rippled's
+    // STUInt64::getJson) so that JSON parsers using IEEE-754 doubles do not silently lose
+    // precision for values greater than 2^53.
+    auto const setUint64IfPresent =
+        [&](boost::json::string_view field, xrpl::SField const& sField, auto const& value) {
+            if (value.has_value())
+                obj[field] =
+                    toBoostJson(xrpl::STUInt64{sField, *value}.getJson(xrpl::JsonOptions::Values::None
+                    ));
+        };
+
     setIfPresent("transfer_fee", issuance.transferFee);
     setIfPresent("asset_scale", issuance.assetScale);
-    setIfPresent("maximum_amount", issuance.maximumAmount);
-    setIfPresent("outstanding_amount", issuance.outstandingAmount);
-    setIfPresent("locked_amount", issuance.lockedAmount);
+    setUint64IfPresent("maximum_amount", xrpl::sfMaximumAmount, issuance.maximumAmount);
+    setUint64IfPresent("outstanding_amount", xrpl::sfOutstandingAmount, issuance.outstandingAmount);
+    setUint64IfPresent("locked_amount", xrpl::sfLockedAmount, issuance.lockedAmount);
     setIfPresent("mptoken_metadata", issuance.mptokenMetadata);
     setIfPresent("domain_id", issuance.domainID);
 

--- a/src/rpc/handlers/AccountMPTokenIssuances.cpp
+++ b/src/rpc/handlers/AccountMPTokenIssuances.cpp
@@ -242,10 +242,11 @@ tag_invoke(
     // precision for values greater than 2^53.
     auto const setUint64IfPresent =
         [&](boost::json::string_view field, xrpl::SField const& sField, auto const& value) {
-            if (value.has_value())
+            if (value.has_value()) {
                 obj[field] =
                     toBoostJson(xrpl::STUInt64{sField, *value}.getJson(xrpl::JsonOptions::Values::None
                     ));
+}
         };
 
     setIfPresent("transfer_fee", issuance.transferFee);

--- a/src/rpc/handlers/AccountMPTokens.cpp
+++ b/src/rpc/handlers/AccountMPTokens.cpp
@@ -18,6 +18,7 @@
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/LedgerHeader.h>
 #include <xrpl/protocol/SField.h>
+#include <xrpl/protocol/STInteger.h>
 #include <xrpl/protocol/STLedgerEntry.h>
 #include <xrpl/protocol/jss.h>
 
@@ -176,12 +177,22 @@ tag_invoke(
     AccountMPTokensHandler::MPTokenResponse const& mptoken
 )
 {
+    // UInt64 amount fields must be serialized as base-10 strings (matching rippled's
+    // STUInt64::getJson) so that JSON parsers using IEEE-754 doubles do not silently lose
+    // precision for values greater than 2^53.
+    auto const uint64ToString = [](xrpl::SField const& field, std::uint64_t value) {
+        return toBoostJson(xrpl::STUInt64{field, value}.getJson(xrpl::JsonOptions::Values::None));
+    };
+
     auto obj = boost::json::object{
         {"mpt_id", mptoken.mpTokenId},
         {JS(account), mptoken.account},
         {JS(mpt_issuance_id), mptoken.mpTokenIssuanceId},
-        {JS(mpt_amount), mptoken.mptAmount},
+        {JS(mpt_amount), uint64ToString(xrpl::sfMPTAmount, mptoken.mptAmount)},
     };
+
+    if (mptoken.lockedAmount.has_value())
+        obj["locked_amount"] = uint64ToString(xrpl::sfLockedAmount, *mptoken.lockedAmount);
 
     auto const setIfPresent = [&](boost::json::string_view field, auto const& value) {
         if (value.has_value()) {
@@ -189,7 +200,6 @@ tag_invoke(
         }
     };
 
-    setIfPresent("locked_amount", mptoken.lockedAmount);
     setIfPresent("mpt_locked", mptoken.mptLocked);
     setIfPresent("mpt_authorized", mptoken.mptAuthorized);
 

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -60,8 +60,8 @@ auto const kIssuanceOuT1 = fmt::format(
         "mpt_issuance_id": "{}",
         "issuer": "{}",
         "sequence": 1,
-        "maximum_amount": {},
-        "outstanding_amount": {},
+        "maximum_amount": "{}",
+        "outstanding_amount": "{}",
         "asset_scale": {},
         "mpt_can_escrow": true,
         "mpt_can_trade": true,
@@ -80,9 +80,9 @@ auto const kIssuanceOuT2 = fmt::format(
         "mpt_issuance_id": "{}",
         "issuer": "{}",
         "sequence": 2,
-        "maximum_amount": {},
-        "outstanding_amount": {},
-        "locked_amount": {},
+        "maximum_amount": "{}",
+        "outstanding_amount": "{}",
+        "locked_amount": "{}",
         "transfer_fee": {},
         "mptoken_metadata": "{}",
         "domain_id": "{}",
@@ -370,7 +370,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, DefaultParameters)
     // return non-empty account
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     ON_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
@@ -378,7 +378,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, DefaultParameters)
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kIssuanceIndeX1}, xrpl::uint256{kIssuanceIndeX2}}, kIssuanceIndeX1
     );
-    ON_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    ON_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
 
     // mocking mptoken issuance ledger objects
@@ -452,7 +452,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, UseLimit)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     ON_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
@@ -468,7 +468,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, UseLimit)
 
     xrpl::STObject ownerDir = createOwnerDirLedgerObject(indexes, kIssuanceIndeX1);
     ownerDir.setFieldU64(xrpl::sfIndexNext, 99);
-    ON_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    ON_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
     EXPECT_CALL(*backend_, doFetchLedgerObject).Times(7);
 
@@ -662,14 +662,14 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LimitLessThanMin)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kIssuanceIndeX1}, xrpl::uint256{kIssuanceIndeX2}}, kIssuanceIndeX1
     );
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -750,14 +750,14 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LimitMoreThanMax)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kIssuanceIndeX1}, xrpl::uint256{kIssuanceIndeX2}}, kIssuanceIndeX1
     );
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -838,12 +838,12 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, EmptyResult)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject({}, kIssuanceIndeX1);
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     runSpawn([this](auto yield) {
@@ -862,6 +862,66 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, EmptyResult)
     });
 }
 
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON
+// strings (as rippled does) so that values greater than 2^53 are not silently rounded by
+// JSON parsers backed by IEEE-754 doubles.
+TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
+{
+    constexpr uint64_t kLargeMaxAmount = 9223372036854775807ULL;    // 2^63 - 1 (max MPT amount)
+    constexpr uint64_t kLargeOutstandingAmount = 9007199254740993ULL;  // 2^53 + 1
+    constexpr uint64_t kLargeLockedAmount = 12345678901234567ULL;   // > 2^53, odd
+
+    auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
+    EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
+
+    auto const account = getAccountIdWithString(kAccount);
+    auto const accountKk = xrpl::keylet::account(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
+    EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
+        .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+
+    xrpl::STObject const ownerDir =
+        createOwnerDirLedgerObject({xrpl::uint256{kIssuanceIndeX1}}, kIssuanceIndeX1);
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
+        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+
+    auto const bbs = std::vector<Blob>{
+        createMptIssuanceObject(
+            kAccount,
+            1,
+            std::nullopt,
+            xrpl::lsfMPTCanLock,
+            kLargeOutstandingAmount,
+            std::nullopt,
+            std::nullopt,
+            kLargeMaxAmount,
+            kLargeLockedAmount
+        )
+            .getSerializer()
+            .peekData()
+    };
+    EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
+
+    runSpawn([this](auto yield) {
+        auto const input =
+            boost::json::parse(fmt::format(R"JSON({{"account": "{}"}})JSON", kAccount));
+        auto const handler = AnyHandler{AccountMPTokenIssuancesHandler{this->backend_}};
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_TRUE(output);
+
+        auto const& issuances = output.result->as_object().at("mpt_issuances").as_array();
+        ASSERT_EQ(issuances.size(), 1);
+        auto const& issuance = issuances[0].as_object();
+
+        ASSERT_TRUE(issuance.at("maximum_amount").is_string());
+        EXPECT_EQ(issuance.at("maximum_amount").as_string(), "9223372036854775807");
+        ASSERT_TRUE(issuance.at("outstanding_amount").is_string());
+        EXPECT_EQ(issuance.at("outstanding_amount").as_string(), "9007199254740993");
+        ASSERT_TRUE(issuance.at("locked_amount").is_string());
+        EXPECT_EQ(issuance.at("locked_amount").as_string(), "12345678901234567");
+    });
+}
+
 TEST_F(RPCAccountMPTokenIssuancesHandlerTest, MutableFlags)
 {
     uint32_t const mutableFlags1 = xrpl::lsmfMPTCanMutateCanLock |
@@ -877,14 +937,14 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, MutableFlags)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kIssuanceIndeX1}, xrpl::uint256{kIssuanceIndeX2}}, kIssuanceIndeX1
     );
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -945,7 +1005,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, MutableFlags)
                         "mpt_issuance_id": "{}",
                         "issuer": "{}",
                         "sequence": 3,
-                        "outstanding_amount": {},
+                        "outstanding_amount": "{}",
                         "transfer_fee": {},
                         "mpt_can_transfer": true,
                         "mpt_can_mutate_can_lock": true,
@@ -957,7 +1017,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, MutableFlags)
                         "mpt_issuance_id": "{}",
                         "issuer": "{}",
                         "sequence": 5,
-                        "outstanding_amount": {},
+                        "outstanding_amount": "{}",
                         "transfer_fee": {},
                         "mptoken_metadata": "{}",
                         "mpt_can_transfer": true,
@@ -1035,13 +1095,13 @@ TEST_P(AccountMPTokenIssuancesImmutableFlagsTest, SingleFlag)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir =
         createOwnerDirLedgerObject({xrpl::uint256{kIssuanceIndeX1}}, kIssuanceIndeX1);
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs =
@@ -1130,13 +1190,13 @@ TEST_P(AccountMPTokenIssuancesMutableFlagsTest, SingleMutableFlag)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir =
         createOwnerDirLedgerObject({xrpl::uint256{kIssuanceIndeX1}}, kIssuanceIndeX1);
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{createMptIssuanceObject(

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -21,6 +21,7 @@
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STObject.h>
 
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -883,13 +884,14 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .maxAmount = std::pow(2, 63) - 1,  // max MPT amount
-             .outstandingAmount = std::pow(2, 53) + 1,
-             .lockedAmount = std::pow(2, 53) + 12345},  // arbitrary odd value above 2^53
+             .maxAmount = static_cast<uint64_t>(std::pow(2, 63)) - 1,  // max MPT amount
+             .outstandingAmount = static_cast<uint64_t>(std::pow(2, 53)) + 1,
+             .lockedAmount = static_cast<uint64_t>(std::pow(2, 53)) +
+                 12345},  // odd value above 2^53
             {.testName = "ExactDoubleBoundary",
-             .maxAmount = std::pow(2, 53),
-             .outstandingAmount = std::pow(2, 53),
-             .lockedAmount = std::pow(2, 53)}
+             .maxAmount = static_cast<uint64_t>(std::pow(2, 53)),
+             .outstandingAmount = static_cast<uint64_t>(std::pow(2, 53)),
+             .lockedAmount = static_cast<uint64_t>(std::pow(2, 53))}
         }
     ),
     tests::util::kNameGenerator

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -862,14 +862,49 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, EmptyResult)
     });
 }
 
-// Regression test: UInt64 amount fields must be serialized as base-10 JSON
-// strings (as rippled does) so that values greater than 2^53 are not silently rounded by
-// JSON parsers backed by IEEE-754 doubles.
-TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as rippled
+// does) so that values greater than 2^53 are not silently rounded by JSON parsers backed by
+// IEEE-754 doubles. 2^53 itself is still exactly representable as a double, but it must be emitted
+// as a string like every other amount so the wire format stays consistent regardless of magnitude.
+struct AccountMPTokenIssuancesAmountSerializationTestCaseBundle {
+    std::string testName;
+    uint64_t maxAmount;
+    uint64_t outstandingAmount;
+    uint64_t lockedAmount;
+    std::string expectedMaxAmount;
+    std::string expectedOutstandingAmount;
+    std::string expectedLockedAmount;
+};
+
+struct AccountMPTokenIssuancesAmountSerializationTest
+    : RPCAccountMPTokenIssuancesHandlerTest,
+      WithParamInterface<AccountMPTokenIssuancesAmountSerializationTestCaseBundle> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    RPCAccountMPTokenIssuancesAmountSerializationGroup,
+    AccountMPTokenIssuancesAmountSerializationTest,
+    ValuesIn(std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
+        {.testName = "LargeAmounts",
+         .maxAmount = 9223372036854775807ULL,       // 2^63 - 1 (max MPT amount)
+         .outstandingAmount = 9007199254740993ULL,  // 2^53 + 1
+         .lockedAmount = 12345678901234567ULL,      // > 2^53, odd
+         .expectedMaxAmount = "9223372036854775807",
+         .expectedOutstandingAmount = "9007199254740993",
+         .expectedLockedAmount = "12345678901234567"},
+        {.testName = "ExactDoubleBoundary",
+         .maxAmount = 9007199254740992ULL,  // 2^53
+         .outstandingAmount = 9007199254740992ULL,
+         .lockedAmount = 9007199254740992ULL,
+         .expectedMaxAmount = "9007199254740992",
+         .expectedOutstandingAmount = "9007199254740992",
+         .expectedLockedAmount = "9007199254740992"}
+    }),
+    tests::util::kNameGenerator
+);
+
+TEST_P(AccountMPTokenIssuancesAmountSerializationTest, SerializedAsStrings)
 {
-    constexpr uint64_t kLargeMaxAmount = 9223372036854775807ULL;       // 2^63 - 1 (max MPT amount)
-    constexpr uint64_t kLargeOutstandingAmount = 9007199254740993ULL;  // 2^53 + 1
-    constexpr uint64_t kLargeLockedAmount = 12345678901234567ULL;      // > 2^53, odd
+    auto const testBundle = GetParam();
 
     auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
     EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
@@ -890,17 +925,17 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
                                            1,
                                            std::nullopt,
                                            xrpl::lsfMPTCanLock,
-                                           kLargeOutstandingAmount,
+                                           testBundle.outstandingAmount,
                                            std::nullopt,
                                            std::nullopt,
-                                           kLargeMaxAmount,
-                                           kLargeLockedAmount
+                                           testBundle.maxAmount,
+                                           testBundle.lockedAmount
     )
                                            .getSerializer()
                                            .peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
-    runSpawn([this](auto yield) {
+    runSpawn([&, this](auto yield) {
         auto const input =
             boost::json::parse(fmt::format(R"JSON({{"account": "{}"}})JSON", kAccount));
         auto const handler = AnyHandler{AccountMPTokenIssuancesHandler{this->backend_}};
@@ -912,11 +947,13 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
         auto const& issuance = issuances[0].as_object();
 
         ASSERT_TRUE(issuance.at("maximum_amount").is_string());
-        EXPECT_EQ(issuance.at("maximum_amount").as_string(), "9223372036854775807");
+        EXPECT_EQ(issuance.at("maximum_amount").as_string(), testBundle.expectedMaxAmount);
         ASSERT_TRUE(issuance.at("outstanding_amount").is_string());
-        EXPECT_EQ(issuance.at("outstanding_amount").as_string(), "9007199254740993");
+        EXPECT_EQ(
+            issuance.at("outstanding_amount").as_string(), testBundle.expectedOutstandingAmount
+        );
         ASSERT_TRUE(issuance.at("locked_amount").is_string());
-        EXPECT_EQ(issuance.at("locked_amount").as_string(), "12345678901234567");
+        EXPECT_EQ(issuance.at("locked_amount").as_string(), testBundle.expectedLockedAmount);
     });
 }
 

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -867,9 +867,9 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, EmptyResult)
 // JSON parsers backed by IEEE-754 doubles.
 TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
 {
-    constexpr uint64_t kLargeMaxAmount = 9223372036854775807ULL;    // 2^63 - 1 (max MPT amount)
+    constexpr uint64_t kLargeMaxAmount = 9223372036854775807ULL;       // 2^63 - 1 (max MPT amount)
     constexpr uint64_t kLargeOutstandingAmount = 9007199254740993ULL;  // 2^53 + 1
-    constexpr uint64_t kLargeLockedAmount = 12345678901234567ULL;   // > 2^53, odd
+    constexpr uint64_t kLargeLockedAmount = 12345678901234567ULL;      // > 2^53, odd
 
     auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
     EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
@@ -885,21 +885,19 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, LargeAmountsSerializedAsStrings)
     EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
-    auto const bbs = std::vector<Blob>{
-        createMptIssuanceObject(
-            kAccount,
-            1,
-            std::nullopt,
-            xrpl::lsfMPTCanLock,
-            kLargeOutstandingAmount,
-            std::nullopt,
-            std::nullopt,
-            kLargeMaxAmount,
-            kLargeLockedAmount
-        )
-            .getSerializer()
-            .peekData()
-    };
+    auto const bbs = std::vector<Blob>{createMptIssuanceObject(
+                                           kAccount,
+                                           1,
+                                           std::nullopt,
+                                           xrpl::lsfMPTCanLock,
+                                           kLargeOutstandingAmount,
+                                           std::nullopt,
+                                           std::nullopt,
+                                           kLargeMaxAmount,
+                                           kLargeLockedAmount
+    )
+                                           .getSerializer()
+                                           .peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([this](auto yield) {

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -883,13 +883,13 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .maxAmount = (1ULL << 63) - 1,  // max MPT amount
-             .outstandingAmount = (1ULL << 53) + 1,
-             .lockedAmount = (1ULL << 53) + 12345},  // arbitrary odd value above 2^53
+             .maxAmount = std::pow(2, 63) - 1,  // max MPT amount
+             .outstandingAmount = std::pow(2, 53) + 1,
+             .lockedAmount = std::pow(2, 53) + 12345},  // arbitrary odd value above 2^53
             {.testName = "ExactDoubleBoundary",
-             .maxAmount = 1ULL << 53,
-             .outstandingAmount = 1ULL << 53,
-             .lockedAmount = 1ULL << 53}
+             .maxAmount = std::pow(2, 53),
+             .outstandingAmount = std::pow(2, 53),
+             .lockedAmount = std::pow(2, 53)}
         }
     ),
     tests::util::kNameGenerator

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -862,7 +862,7 @@ TEST_F(RPCAccountMPTokenIssuancesHandlerTest, EmptyResult)
     });
 }
 
-// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as rippled
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as xrpld
 // does) so that values greater than 2^53 are not silently rounded by JSON parsers backed by
 // IEEE-754 doubles. 2^53 itself is still exactly representable as a double, but it must be emitted
 // as a string like every other amount so the wire format stays consistent regardless of magnitude.
@@ -871,9 +871,6 @@ struct AccountMPTokenIssuancesAmountSerializationTestCaseBundle {
     uint64_t maxAmount;
     uint64_t outstandingAmount;
     uint64_t lockedAmount;
-    std::string expectedMaxAmount;
-    std::string expectedOutstandingAmount;
-    std::string expectedLockedAmount;
 };
 
 struct AccountMPTokenIssuancesAmountSerializationTest
@@ -886,19 +883,13 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .maxAmount = 9223372036854775807ULL,       // 2^63 - 1 (max MPT amount)
-             .outstandingAmount = 9007199254740993ULL,  // 2^53 + 1
-             .lockedAmount = 12345678901234567ULL,      // > 2^53, odd
-             .expectedMaxAmount = "9223372036854775807",
-             .expectedOutstandingAmount = "9007199254740993",
-             .expectedLockedAmount = "12345678901234567"},
+             .maxAmount = (1ULL << 63) - 1,  // max MPT amount
+             .outstandingAmount = (1ULL << 53) + 1,
+             .lockedAmount = (1ULL << 53) + 12345},  // arbitrary odd value above 2^53
             {.testName = "ExactDoubleBoundary",
-             .maxAmount = 9007199254740992ULL,  // 2^53
-             .outstandingAmount = 9007199254740992ULL,
-             .lockedAmount = 9007199254740992ULL,
-             .expectedMaxAmount = "9007199254740992",
-             .expectedOutstandingAmount = "9007199254740992",
-             .expectedLockedAmount = "9007199254740992"}
+             .maxAmount = 1ULL << 53,
+             .outstandingAmount = 1ULL << 53,
+             .lockedAmount = 1ULL << 53}
         }
     ),
     tests::util::kNameGenerator
@@ -922,19 +913,18 @@ TEST_P(AccountMPTokenIssuancesAmountSerializationTest, SerializedAsStrings)
     EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
-    auto const bbs = std::vector<Blob>{createMptIssuanceObject(
-                                           kAccount,
-                                           1,
-                                           std::nullopt,
-                                           xrpl::lsfMPTCanLock,
-                                           testBundle.outstandingAmount,
-                                           std::nullopt,
-                                           std::nullopt,
-                                           testBundle.maxAmount,
-                                           testBundle.lockedAmount
-    )
-                                           .getSerializer()
-                                           .peekData()};
+    xrpl::STObject const mptIssuance = createMptIssuanceObject(
+        kAccount,
+        1,
+        std::nullopt,
+        xrpl::lsfMPTCanLock,
+        testBundle.outstandingAmount,
+        std::nullopt,
+        std::nullopt,
+        testBundle.maxAmount,
+        testBundle.lockedAmount
+    );
+    auto const bbs = std::vector<Blob>{mptIssuance.getSerializer().peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([&, this](auto yield) {
@@ -949,13 +939,16 @@ TEST_P(AccountMPTokenIssuancesAmountSerializationTest, SerializedAsStrings)
         auto const& issuance = issuances[0].as_object();
 
         ASSERT_TRUE(issuance.at("maximum_amount").is_string());
-        EXPECT_EQ(issuance.at("maximum_amount").as_string(), testBundle.expectedMaxAmount);
+        EXPECT_EQ(issuance.at("maximum_amount").as_string(), std::to_string(testBundle.maxAmount));
         ASSERT_TRUE(issuance.at("outstanding_amount").is_string());
         EXPECT_EQ(
-            issuance.at("outstanding_amount").as_string(), testBundle.expectedOutstandingAmount
+            issuance.at("outstanding_amount").as_string(),
+            std::to_string(testBundle.outstandingAmount)
         );
         ASSERT_TRUE(issuance.at("locked_amount").is_string());
-        EXPECT_EQ(issuance.at("locked_amount").as_string(), testBundle.expectedLockedAmount);
+        EXPECT_EQ(
+            issuance.at("locked_amount").as_string(), std::to_string(testBundle.lockedAmount)
+        );
     });
 }
 

--- a/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokenIssuancesTests.cpp
@@ -883,22 +883,24 @@ struct AccountMPTokenIssuancesAmountSerializationTest
 INSTANTIATE_TEST_SUITE_P(
     RPCAccountMPTokenIssuancesAmountSerializationGroup,
     AccountMPTokenIssuancesAmountSerializationTest,
-    ValuesIn(std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
-        {.testName = "LargeAmounts",
-         .maxAmount = 9223372036854775807ULL,       // 2^63 - 1 (max MPT amount)
-         .outstandingAmount = 9007199254740993ULL,  // 2^53 + 1
-         .lockedAmount = 12345678901234567ULL,      // > 2^53, odd
-         .expectedMaxAmount = "9223372036854775807",
-         .expectedOutstandingAmount = "9007199254740993",
-         .expectedLockedAmount = "12345678901234567"},
-        {.testName = "ExactDoubleBoundary",
-         .maxAmount = 9007199254740992ULL,  // 2^53
-         .outstandingAmount = 9007199254740992ULL,
-         .lockedAmount = 9007199254740992ULL,
-         .expectedMaxAmount = "9007199254740992",
-         .expectedOutstandingAmount = "9007199254740992",
-         .expectedLockedAmount = "9007199254740992"}
-    }),
+    ValuesIn(
+        std::vector<AccountMPTokenIssuancesAmountSerializationTestCaseBundle>{
+            {.testName = "LargeAmounts",
+             .maxAmount = 9223372036854775807ULL,       // 2^63 - 1 (max MPT amount)
+             .outstandingAmount = 9007199254740993ULL,  // 2^53 + 1
+             .lockedAmount = 12345678901234567ULL,      // > 2^53, odd
+             .expectedMaxAmount = "9223372036854775807",
+             .expectedOutstandingAmount = "9007199254740993",
+             .expectedLockedAmount = "12345678901234567"},
+            {.testName = "ExactDoubleBoundary",
+             .maxAmount = 9007199254740992ULL,  // 2^53
+             .outstandingAmount = 9007199254740992ULL,
+             .lockedAmount = 9007199254740992ULL,
+             .expectedMaxAmount = "9007199254740992",
+             .expectedOutstandingAmount = "9007199254740992",
+             .expectedLockedAmount = "9007199254740992"}
+        }
+    ),
     tests::util::kNameGenerator
 );
 

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -832,9 +832,11 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .mptAmount = (1ULL << 63) - 1,  // max MPT amount
-             .lockedAmount = (1ULL << 53) + 1},
-            {.testName = "ExactDoubleBoundary", .mptAmount = 1ULL << 53, .lockedAmount = 1ULL << 53}
+             .mptAmount = std::pow(2, 63) - 1,  // max MPT amount
+             .lockedAmount = std::pow(2, 53) + 1},
+            {.testName = "ExactDoubleBoundary",
+             .mptAmount = std::pow(2, 53),
+             .lockedAmount = std::pow(2, 53)}
         }
     ),
     tests::util::kNameGenerator

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -812,13 +812,43 @@ TEST_F(RPCAccountMPTokensHandlerTest, EmptyResult)
     });
 }
 
-// Regression test: UInt64 amount fields must be serialized as base-10 JSON
-// strings (as rippled does) so that values greater than 2^53 are not silently rounded by
-// JSON parsers backed by IEEE-754 doubles.
-TEST_F(RPCAccountMPTokensHandlerTest, LargeAmountsSerializedAsStrings)
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as rippled
+// does) so that values greater than 2^53 are not silently rounded by JSON parsers backed by
+// IEEE-754 doubles. 2^53 itself is still exactly representable as a double, but it must be emitted
+// as a string like every other amount so the wire format stays consistent regardless of magnitude.
+struct AccountMPTokensAmountSerializationTestCaseBundle {
+    std::string testName;
+    uint64_t mptAmount;
+    uint64_t lockedAmount;
+    std::string expectedMptAmount;
+    std::string expectedLockedAmount;
+};
+
+struct AccountMPTokensAmountSerializationTest
+    : RPCAccountMPTokensHandlerTest,
+      WithParamInterface<AccountMPTokensAmountSerializationTestCaseBundle> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    RPCAccountMPTokensAmountSerializationGroup,
+    AccountMPTokensAmountSerializationTest,
+    ValuesIn(std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
+        {.testName = "LargeAmounts",
+         .mptAmount = 9223372036854775807ULL,  // 2^63 - 1 (max MPT amount)
+         .lockedAmount = 9007199254740993ULL,  // 2^53 + 1
+         .expectedMptAmount = "9223372036854775807",
+         .expectedLockedAmount = "9007199254740993"},
+        {.testName = "ExactDoubleBoundary",
+         .mptAmount = 9007199254740992ULL,  // 2^53
+         .lockedAmount = 9007199254740992ULL,
+         .expectedMptAmount = "9007199254740992",
+         .expectedLockedAmount = "9007199254740992"}
+    }),
+    tests::util::kNameGenerator
+);
+
+TEST_P(AccountMPTokensAmountSerializationTest, SerializedAsStrings)
 {
-    constexpr uint64_t kLargeMptAmount = 9223372036854775807ULL;  // 2^63 - 1 (max MPT amount)
-    constexpr uint64_t kLargeLockedAmount = 9007199254740993ULL;  // 2^53 + 1
+    auto const testBundle = GetParam();
 
     auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
     EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
@@ -837,15 +867,15 @@ TEST_F(RPCAccountMPTokensHandlerTest, LargeAmountsSerializedAsStrings)
     auto const bbs = std::vector<Blob>{createMpTokenObject(
                                            kAccount,
                                            xrpl::uint192(kIssuanceIdHex),
-                                           kLargeMptAmount,
+                                           testBundle.mptAmount,
                                            xrpl::lsfMPTLocked,
-                                           kLargeLockedAmount
+                                           testBundle.lockedAmount
     )
                                            .getSerializer()
                                            .peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
-    runSpawn([this](auto yield) {
+    runSpawn([&, this](auto yield) {
         auto const input =
             boost::json::parse(fmt::format(R"JSON({{"account": "{}"}})JSON", kAccount));
         auto const handler = AnyHandler{AccountMPTokensHandler{this->backend_}};
@@ -857,8 +887,8 @@ TEST_F(RPCAccountMPTokensHandlerTest, LargeAmountsSerializedAsStrings)
         auto const& token = mptokens[0].as_object();
 
         ASSERT_TRUE(token.at("mpt_amount").is_string());
-        EXPECT_EQ(token.at("mpt_amount").as_string(), "9223372036854775807");
+        EXPECT_EQ(token.at("mpt_amount").as_string(), testBundle.expectedMptAmount);
         ASSERT_TRUE(token.at("locked_amount").is_string());
-        EXPECT_EQ(token.at("locked_amount").as_string(), "9007199254740993");
+        EXPECT_EQ(token.at("locked_amount").as_string(), testBundle.expectedLockedAmount);
     });
 }

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -834,17 +834,15 @@ TEST_F(RPCAccountMPTokensHandlerTest, LargeAmountsSerializedAsStrings)
     EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
-    auto const bbs = std::vector<Blob>{
-        createMpTokenObject(
-            kAccount,
-            xrpl::uint192(kIssuanceIdHex),
-            kLargeMptAmount,
-            xrpl::lsfMPTLocked,
-            kLargeLockedAmount
-        )
-            .getSerializer()
-            .peekData()
-    };
+    auto const bbs = std::vector<Blob>{createMpTokenObject(
+                                           kAccount,
+                                           xrpl::uint192(kIssuanceIdHex),
+                                           kLargeMptAmount,
+                                           xrpl::lsfMPTLocked,
+                                           kLargeLockedAmount
+    )
+                                           .getSerializer()
+                                           .peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([this](auto yield) {

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -831,18 +831,20 @@ struct AccountMPTokensAmountSerializationTest
 INSTANTIATE_TEST_SUITE_P(
     RPCAccountMPTokensAmountSerializationGroup,
     AccountMPTokensAmountSerializationTest,
-    ValuesIn(std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
-        {.testName = "LargeAmounts",
-         .mptAmount = 9223372036854775807ULL,  // 2^63 - 1 (max MPT amount)
-         .lockedAmount = 9007199254740993ULL,  // 2^53 + 1
-         .expectedMptAmount = "9223372036854775807",
-         .expectedLockedAmount = "9007199254740993"},
-        {.testName = "ExactDoubleBoundary",
-         .mptAmount = 9007199254740992ULL,  // 2^53
-         .lockedAmount = 9007199254740992ULL,
-         .expectedMptAmount = "9007199254740992",
-         .expectedLockedAmount = "9007199254740992"}
-    }),
+    ValuesIn(
+        std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
+            {.testName = "LargeAmounts",
+             .mptAmount = 9223372036854775807ULL,  // 2^63 - 1 (max MPT amount)
+             .lockedAmount = 9007199254740993ULL,  // 2^53 + 1
+             .expectedMptAmount = "9223372036854775807",
+             .expectedLockedAmount = "9007199254740993"},
+            {.testName = "ExactDoubleBoundary",
+             .mptAmount = 9007199254740992ULL,  // 2^53
+             .lockedAmount = 9007199254740992ULL,
+             .expectedMptAmount = "9007199254740992",
+             .expectedLockedAmount = "9007199254740992"}
+        }
+    ),
     tests::util::kNameGenerator
 );
 

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -20,6 +20,7 @@
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STObject.h>
 
+#include <cmath>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -832,11 +833,11 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .mptAmount = std::pow(2, 63) - 1,  // max MPT amount
-             .lockedAmount = std::pow(2, 53) + 1},
+             .mptAmount = static_cast<uint64_t>(std::pow(2, 63)) - 1,  // max MPT amount
+             .lockedAmount = static_cast<uint64_t>(std::pow(2, 53)) + 1},
             {.testName = "ExactDoubleBoundary",
-             .mptAmount = std::pow(2, 53),
-             .lockedAmount = std::pow(2, 53)}
+             .mptAmount = static_cast<uint64_t>(std::pow(2, 53)),
+             .lockedAmount = static_cast<uint64_t>(std::pow(2, 53))}
         }
     ),
     tests::util::kNameGenerator

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -812,7 +812,7 @@ TEST_F(RPCAccountMPTokensHandlerTest, EmptyResult)
     });
 }
 
-// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as rippled
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON strings (as xrpld
 // does) so that values greater than 2^53 are not silently rounded by JSON parsers backed by
 // IEEE-754 doubles. 2^53 itself is still exactly representable as a double, but it must be emitted
 // as a string like every other amount so the wire format stays consistent regardless of magnitude.
@@ -820,8 +820,6 @@ struct AccountMPTokensAmountSerializationTestCaseBundle {
     std::string testName;
     uint64_t mptAmount;
     uint64_t lockedAmount;
-    std::string expectedMptAmount;
-    std::string expectedLockedAmount;
 };
 
 struct AccountMPTokensAmountSerializationTest
@@ -834,15 +832,9 @@ INSTANTIATE_TEST_SUITE_P(
     ValuesIn(
         std::vector<AccountMPTokensAmountSerializationTestCaseBundle>{
             {.testName = "LargeAmounts",
-             .mptAmount = 9223372036854775807ULL,  // 2^63 - 1 (max MPT amount)
-             .lockedAmount = 9007199254740993ULL,  // 2^53 + 1
-             .expectedMptAmount = "9223372036854775807",
-             .expectedLockedAmount = "9007199254740993"},
-            {.testName = "ExactDoubleBoundary",
-             .mptAmount = 9007199254740992ULL,  // 2^53
-             .lockedAmount = 9007199254740992ULL,
-             .expectedMptAmount = "9007199254740992",
-             .expectedLockedAmount = "9007199254740992"}
+             .mptAmount = (1ULL << 63) - 1,  // max MPT amount
+             .lockedAmount = (1ULL << 53) + 1},
+            {.testName = "ExactDoubleBoundary", .mptAmount = 1ULL << 53, .lockedAmount = 1ULL << 53}
         }
     ),
     tests::util::kNameGenerator
@@ -866,15 +858,14 @@ TEST_P(AccountMPTokensAmountSerializationTest, SerializedAsStrings)
     EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
-    auto const bbs = std::vector<Blob>{createMpTokenObject(
-                                           kAccount,
-                                           xrpl::uint192(kIssuanceIdHex),
-                                           testBundle.mptAmount,
-                                           xrpl::lsfMPTLocked,
-                                           testBundle.lockedAmount
-    )
-                                           .getSerializer()
-                                           .peekData()};
+    xrpl::STObject const mptoken = createMpTokenObject(
+        kAccount,
+        xrpl::uint192(kIssuanceIdHex),
+        testBundle.mptAmount,
+        xrpl::lsfMPTLocked,
+        testBundle.lockedAmount
+    );
+    auto const bbs = std::vector<Blob>{mptoken.getSerializer().peekData()};
     EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
 
     runSpawn([&, this](auto yield) {
@@ -889,8 +880,8 @@ TEST_P(AccountMPTokensAmountSerializationTest, SerializedAsStrings)
         auto const& token = mptokens[0].as_object();
 
         ASSERT_TRUE(token.at("mpt_amount").is_string());
-        EXPECT_EQ(token.at("mpt_amount").as_string(), testBundle.expectedMptAmount);
+        EXPECT_EQ(token.at("mpt_amount").as_string(), std::to_string(testBundle.mptAmount));
         ASSERT_TRUE(token.at("locked_amount").is_string());
-        EXPECT_EQ(token.at("locked_amount").as_string(), testBundle.expectedLockedAmount);
+        EXPECT_EQ(token.at("locked_amount").as_string(), std::to_string(testBundle.lockedAmount));
     });
 }

--- a/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
+++ b/tests/unit/rpc/handlers/AccountMPTokensTests.cpp
@@ -47,8 +47,8 @@ auto const kTokenOuT1 = fmt::format(
         "mpt_id": "{}",
         "account": "{}",
         "mpt_issuance_id": "{}",
-        "mpt_amount": {},
-        "locked_amount": {},
+        "mpt_amount": "{}",
+        "locked_amount": "{}",
         "mpt_locked": true
     }})JSON",
     kTokenIndeX1,
@@ -63,7 +63,7 @@ auto const kTokenOuT2 = fmt::format(
         "mpt_id": "{}",
         "account": "{}",
         "mpt_issuance_id": "{}",
-        "mpt_amount": {},
+        "mpt_amount": "{}",
         "mpt_authorized": true
     }})JSON",
     kTokenIndeX2,
@@ -337,14 +337,14 @@ TEST_F(RPCAccountMPTokensHandlerTest, DefaultParameters)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     ON_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kTokenIndeX1}, xrpl::uint256{kTokenIndeX2}}, kTokenIndeX1
     );
-    ON_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    ON_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -407,7 +407,7 @@ TEST_F(RPCAccountMPTokensHandlerTest, UseLimit)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     ON_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillByDefault(Return(Blob{'f', 'a', 'k', 'e'}));
 
@@ -427,7 +427,7 @@ TEST_F(RPCAccountMPTokensHandlerTest, UseLimit)
 
     xrpl::STObject ownerDir = createOwnerDirLedgerObject(indexes, kTokenIndeX1);
     ownerDir.setFieldU64(xrpl::sfIndexNext, 99);
-    ON_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    ON_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillByDefault(Return(ownerDir.getSerializer().peekData()));
     EXPECT_CALL(*backend_, doFetchLedgerObject).Times(7);
 
@@ -630,14 +630,14 @@ TEST_F(RPCAccountMPTokensHandlerTest, LimitLessThanMin)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kTokenIndeX1}, xrpl::uint256{kTokenIndeX2}}, kTokenIndeX1
     );
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -709,14 +709,14 @@ TEST_F(RPCAccountMPTokensHandlerTest, LimitMoreThanMax)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject(
         {xrpl::uint256{kTokenIndeX1}, xrpl::uint256{kTokenIndeX2}}, kTokenIndeX1
     );
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     auto const bbs = std::vector<Blob>{
@@ -788,12 +788,12 @@ TEST_F(RPCAccountMPTokensHandlerTest, EmptyResult)
 
     auto const account = getAccountIdWithString(kAccount);
     auto const accountKk = xrpl::keylet::account(account).key;
-    auto const owneDirKk = xrpl::keylet::ownerDir(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
     EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
         .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
 
     xrpl::STObject const ownerDir = createOwnerDirLedgerObject({}, kTokenIndeX1);
-    EXPECT_CALL(*backend_, doFetchLedgerObject(owneDirKk, _, _))
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
         .WillOnce(Return(ownerDir.getSerializer().peekData()));
 
     runSpawn([this](auto yield) {
@@ -809,5 +809,58 @@ TEST_F(RPCAccountMPTokensHandlerTest, EmptyResult)
         auto const output = handler.process(input, Context{yield});
         ASSERT_TRUE(output);
         EXPECT_EQ(output.result->as_object().at("mptokens").as_array().size(), 0);
+    });
+}
+
+// Regression test: UInt64 amount fields must be serialized as base-10 JSON
+// strings (as rippled does) so that values greater than 2^53 are not silently rounded by
+// JSON parsers backed by IEEE-754 doubles.
+TEST_F(RPCAccountMPTokensHandlerTest, LargeAmountsSerializedAsStrings)
+{
+    constexpr uint64_t kLargeMptAmount = 9223372036854775807ULL;  // 2^63 - 1 (max MPT amount)
+    constexpr uint64_t kLargeLockedAmount = 9007199254740993ULL;  // 2^53 + 1
+
+    auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
+    EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
+
+    auto const account = getAccountIdWithString(kAccount);
+    auto const accountKk = xrpl::keylet::account(account).key;
+    auto const ownerDirKk = xrpl::keylet::ownerDir(account).key;
+    EXPECT_CALL(*backend_, doFetchLedgerObject(accountKk, _, _))
+        .WillOnce(Return(Blob{'f', 'a', 'k', 'e'}));
+
+    xrpl::STObject const ownerDir =
+        createOwnerDirLedgerObject({xrpl::uint256{kTokenIndeX1}}, kTokenIndeX1);
+    EXPECT_CALL(*backend_, doFetchLedgerObject(ownerDirKk, _, _))
+        .WillOnce(Return(ownerDir.getSerializer().peekData()));
+
+    auto const bbs = std::vector<Blob>{
+        createMpTokenObject(
+            kAccount,
+            xrpl::uint192(kIssuanceIdHex),
+            kLargeMptAmount,
+            xrpl::lsfMPTLocked,
+            kLargeLockedAmount
+        )
+            .getSerializer()
+            .peekData()
+    };
+    EXPECT_CALL(*backend_, doFetchLedgerObjects).WillOnce(Return(bbs));
+
+    runSpawn([this](auto yield) {
+        auto const input =
+            boost::json::parse(fmt::format(R"JSON({{"account": "{}"}})JSON", kAccount));
+        auto const handler = AnyHandler{AccountMPTokensHandler{this->backend_}};
+        auto const output = handler.process(input, Context{yield});
+        ASSERT_TRUE(output);
+
+        auto const& mptokens = output.result->as_object().at("mptokens").as_array();
+        ASSERT_EQ(mptokens.size(), 1);
+        auto const& token = mptokens[0].as_object();
+
+        ASSERT_TRUE(token.at("mpt_amount").is_string());
+        EXPECT_EQ(token.at("mpt_amount").as_string(), "9223372036854775807");
+        ASSERT_TRUE(token.at("locked_amount").is_string());
+        EXPECT_EQ(token.at("locked_amount").as_string(), "9007199254740993");
     });
 }


### PR DESCRIPTION
## Summary

The `account_mptokens` and `account_mpt_issuances` RPCs emitted MPToken amount fields as JSON **numbers**. Because many JSON parsers back numbers with IEEE-754 doubles, any value greater than 2^53 was silently rounded, so clients could not recover the exact on-ledger amount.

This change serializes the affected `UInt64` amount fields as base-10 JSON **strings**, matching rippled's `STUInt64::getJson` behavior so Clio's output is consistent with the reference implementation:

- `account_mptokens`: `mpt_amount`, `locked_amount`
- `account_mpt_issuances`: `maximum_amount`, `outstanding_amount`, `locked_amount`

## Changes

- Serialize the `UInt64` amount fields via `xrpl::STUInt64{field, value}.getJson(...)` instead of inserting the raw integer into the JSON object, so the encoding matches rippled's string representation exactly.
- Add regression tests in both handlers asserting that large amounts (`2^63 - 1`, `2^53 + 1`, and an odd value `> 2^53`) round-trip as exact strings.

## Test plan

- New unit tests: `RPCAccountMPTokensHandlerTest.LargeAmountsSerializedAsStrings` and `RPCAccountMPTokenIssuancesHandlerTest.LargeAmountsSerializedAsStrings`.
- Existing MPToken handler tests updated to expect string-typed amount fields.

## Notes

`mpt_holders` already serializes `mpt_amount` correctly via `STUInt64::getJson`; all other handlers that expose ledger `UInt64` fields (e.g. `vault_info`, `get_aggregate_price`, `gateway_balances`) route through rippled's own serialization or `STAmount`, so they were already emitting strings and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
