### PR TITLE
chore: Add CODEOWNERS for CI-related changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,6 @@ updates:
       day: monday
       time: "04:00"
       timezone: Etc/GMT
-    reviewers:
-      - XRPLF/clio-dev-team
     commit-message:
       prefix: "ci: [DEPENDABOT] "
     target-branch: develop

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# By default, anyone can review changes.
+
+# The CI tooling team should review changes to the CI configuration.
+/.github/ @XRPLF/ci-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # By default, anyone can review changes.
 
 # The CI tooling team should review changes to the CI configuration.
-/.github/ @xrplf/ci-tooling
+/.github/ @XRPLF/ci-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # By default, anyone can review changes.
 
 # The CI tooling team should review changes to the CI configuration.
-/.github/ @XRPLF/ci-tooling
+/.github/ @xrplf/ci-tooling


### PR DESCRIPTION
This change allows anyone to review any change by default, but requires the `XRPLF/ci-tooling` team to review CI-related changes. It also removes the reviewers from the `dependabot.yml` file, since that functionality is [deprecated](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).