### PR TITLE
chore: Add clang-tidy rules for lower_case namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -165,6 +165,8 @@ CheckOptions:
 
   readability-braces-around-statements.ShortStatementLines: 2
   readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.NamespaceCase: lower_case
+  readability-identifier-naming.InlineNamespaceCase: lower_case
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.StructCase: CamelCase
   readability-identifier-naming.UnionCase: CamelCase

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,7 +17,7 @@ on:
       - "tests/**"
       - "benchmarks/**"
 
-      - .clang_tidy
+      - .clang-tidy
 
 concurrency:
   # Only cancel in-progress jobs or runs for the current workflow - matches against branch & tags


### PR DESCRIPTION
To keep the style the same across projects, this mimics what we did in https://github.com/XRPLF/rippled/pull/7933