### PR TITLE
fix: Rare deadlock in subscriptions

### DIFF
--- a/src/feed/impl/TrackableSignalMap.hpp
+++ b/src/feed/impl/TrackableSignalMap.hpp
@@ -30,8 +30,10 @@ template <Hashable Key, typename Session, typename... Args>
 class TrackableSignalMap {
     using ConnectionPtr = Session*;
     using ConnectionSharedPtr = std::shared_ptr<Session>;
+    using SignalType = TrackableSignal<Session, Args...>;
+    using SignalPtr = std::shared_ptr<SignalType>;
+    using SignalsMap = std::unordered_map<Key, SignalPtr>;
 
-    using SignalsMap = std::unordered_map<Key, TrackableSignal<Session, Args...>>;
     util::Mutex<SignalsMap> signalsMap_;
 
 public:
@@ -55,7 +57,11 @@ public:
     )
     {
         auto map = signalsMap_.template lock<std::scoped_lock>();
-        return map->operator[](key).connectTrackableSlot(trackable, slot);
+        auto& signal = map->operator[](key);
+        if (signal == nullptr)
+            signal = std::make_shared<SignalType>();
+
+        return signal->connectTrackableSlot(trackable, slot);
     }
 
     /**
@@ -70,13 +76,14 @@ public:
     disconnect(ConnectionPtr trackablePtr, Key const& key)
     {
         auto map = signalsMap_.template lock<std::scoped_lock>();
-        if (!map->contains(key))
+        auto const it = map->find(key);
+        if (it == map->end())
             return false;
 
-        auto const disconnected = map->operator[](key).disconnect(trackablePtr);
+        auto const disconnected = it->second->disconnect(trackablePtr);
         // clean the map if there is no connection left.
-        if (disconnected && map->operator[](key).count() == 0)
-            map->erase(key);
+        if (disconnected && it->second->count() == 0)
+            map->erase(it);
 
         return disconnected;
     }
@@ -90,9 +97,14 @@ public:
     void
     emit(Key const& key, Args const&... args)
     {
-        auto map = signalsMap_.template lock<std::scoped_lock>();
-        if (map->contains(key))
-            map->operator[](key).emit(args...);
+        auto const signal = [this, &key]() -> SignalPtr {
+            auto map = signalsMap_.template lock<std::scoped_lock>();
+            auto const it = map->find(key);
+            return it == map->end() ? nullptr : it->second;
+        }();
+
+        if (signal != nullptr)
+            signal->emit(args...);
     }
 };
 }  // namespace feed::impl

--- a/src/feed/impl/TrackableSignalMap.hpp
+++ b/src/feed/impl/TrackableSignalMap.hpp
@@ -57,11 +57,13 @@ public:
     )
     {
         auto map = signalsMap_.template lock<std::scoped_lock>();
-        auto& signal = map->operator[](key);
-        if (signal == nullptr)
-            signal = std::make_shared<SignalType>();
+        auto it = map->find(key);
+        if (it == map->end()) {
+            auto signal = std::make_shared<SignalType>();
+            it = map->emplace(key, std::move(signal)).first;
+        }
 
-        return signal->connectTrackableSlot(trackable, slot);
+        return it->second->connectTrackableSlot(trackable, slot);
     }
 
     /**

--- a/tests/unit/feed/TrackableSignalTests.cpp
+++ b/tests/unit/feed/TrackableSignalTests.cpp
@@ -14,6 +14,25 @@ struct FeedTrackableSignalTests : Test {
     web::SubscriptionContextPtr sessionPtr = std::make_shared<MockSession>();
 };
 
+namespace {
+
+struct DestructorDisconnectingSubscriber;
+using ReentrantSignalMap =
+    feed::impl::TrackableSignalMap<std::string, DestructorDisconnectingSubscriber, int>;
+
+struct DestructorDisconnectingSubscriber {
+    ReentrantSignalMap* signalMap = nullptr;
+    bool* disconnectFinished = nullptr;
+
+    ~DestructorDisconnectingSubscriber()
+    {
+        signalMap->disconnect(this, "key");
+        *disconnectFinished = true;
+    }
+};
+
+}  // namespace
+
 TEST_F(FeedTrackableSignalTests, Connect)
 {
     feed::impl::TrackableSignal<web::SubscriptionContextInterface, std::string> signal;
@@ -106,4 +125,31 @@ TEST_F(FeedTrackableSignalTests, MapAutoDisconnect)
 
     signalMap.emit("test1", "test1");
     EXPECT_TRUE(testString.empty());
+}
+
+TEST_F(FeedTrackableSignalTests, MapDisconnectFromTrackableDestructorWhileEmitting)
+{
+    ReentrantSignalMap signalMap;
+    bool disconnectFinished = false;
+
+    auto subscriber = std::make_shared<DestructorDisconnectingSubscriber>();
+    subscriber->signalMap = &signalMap;
+    subscriber->disconnectFinished = &disconnectFinished;
+
+    bool slotCalled = false;
+    ASSERT_TRUE(signalMap.connectTrackableSlot(subscriber, "key", [&](int) {
+        slotCalled = true;
+        // The session died while the slot is running; the signal now holds the last reference.
+        subscriber.reset();
+    }));
+
+    signalMap.emit("key", 42);
+
+    EXPECT_TRUE(slotCalled);
+    EXPECT_TRUE(disconnectFinished);
+
+    // The entry was removed by the destructor's disconnect, so nothing is left to notify.
+    slotCalled = false;
+    signalMap.emit("key", 42);
+    EXPECT_FALSE(slotCalled);
 }


### PR DESCRIPTION
Clio would silently stop delivering all subscription messages while HTTP RPC kept working. The feed's strand thread was permanently deadlocked on a mutex it already held.

`TrackableSignalMap::emit` held the map mutex while running slots. If the last reference to a subscriber dropped during delivery, the session was destroyed *inside* `emit` → its destructor fired `onDisconnect` → `disconnect()` → tried to lock the same non-recursive mutex on the same thread. The narrow race window (session dying exactly during delivery) is why it was rare.

Fix: `emit` copies the signal out under the lock, releases it, then emits. The map value became `shared_ptr<TrackableSignal>` because once the lock is dropped, the re-entrant `disconnect` can erase and destroy the signal mid-emit — an owning pointer keeps it alive.

Scope: legacy web stack only (ng calls `disconnect()` explicitly instead of from the destructor), which is the deployed default. `TrackableSignal` itself was never affected — it takes no lock during emit.

Test `MapDisconnectFromTrackableDestructorWhileEmitting` hangs forever on the old code.