### PR TITLE
fix: Internal error on warning injection

### DIFF
--- a/src/web/LoadWarning.hpp
+++ b/src/web/LoadWarning.hpp
@@ -13,7 +13,11 @@
 namespace web {
 
 /**
- * @brief Attach the DOSGuard "load" warning to a serialized response body.
+ * @brief Parse a serialized response body and attach the DOSGuard "load" warning to it.
+ *
+ * Sets `warning` to "load" and appends a rpc::WarningCode::WarnRpcRateLimit entry to the `warnings`
+ * array, creating that array if the body has none - or replacing it if `warnings` is present but is
+ * not an array.
  *
  * @note Not every response body is JSON. Over plain HTTP the error paths return text/html bodies
  * (e.g. "Null method" or "Unable to parse JSON from the request"), which cannot carry the warning.
@@ -21,7 +25,8 @@ namespace web {
  * JSON would throw.
  *
  * @param message The serialized response body
- * @return The body with the warning attached, or std::nullopt if it is not a JSON object
+ * @return The response as a JSON object with the warning attached; callers that need a string body
+ * must serialize it again. std::nullopt if @p message does not parse as a JSON object.
  */
 inline std::optional<boost::json::object>
 withLoadWarning(std::string_view message)

--- a/src/web/LoadWarning.hpp
+++ b/src/web/LoadWarning.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "rpc/Errors.hpp"
+
+#include <boost/json/array.hpp>
+#include <boost/json/object.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <optional>
+#include <string_view>
+
+namespace web {
+
+/**
+ * @brief Attach the DOSGuard "load" warning to a serialized response body.
+ *
+ * @note Not every response body is JSON. Over plain HTTP the error paths return text/html bodies
+ * (e.g. "Null method" or "Unable to parse JSON from the request"), which cannot carry the warning.
+ * For those this returns std::nullopt and the caller must send the body unchanged - parsing them as
+ * JSON would throw.
+ *
+ * @param message The serialized response body
+ * @return The body with the warning attached, or std::nullopt if it is not a JSON object
+ */
+inline std::optional<boost::json::object>
+withLoadWarning(std::string_view message)
+{
+    boost::system::error_code ec;
+    auto const parsed = boost::json::parse(message, ec);
+    if (ec.failed() or not parsed.is_object())
+        return std::nullopt;
+
+    auto jsonResponse = parsed.as_object();
+    jsonResponse["warning"] = "load";
+
+    if (jsonResponse.contains("warnings") and jsonResponse["warnings"].is_array()) {
+        jsonResponse["warnings"].as_array().push_back(
+            rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)
+        );
+    } else {
+        jsonResponse["warnings"] =
+            boost::json::array{rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)};
+    }
+
+    return jsonResponse;
+}
+
+}  // namespace web

--- a/src/web/impl/HttpBase.hpp
+++ b/src/web/impl/HttpBase.hpp
@@ -311,8 +311,13 @@ public:
 
     /**
      * @brief Send a response to the client
-     * The message length will be added to the DOSGuard, if the limit is reached, a warning will be
-     * added to the response
+     *
+     * The message length is added to the DOSGuard. If that puts the client over its limit and the
+     * body parses as a JSON object, a "load" warning is attached to it; bodies that are not JSON
+     * objects - the text/html error paths - are sent unchanged.
+     *
+     * @param msg The serialized response body
+     * @param status The HTTP status to respond with
      */
     void
     send(std::string&& msg, http::status status = http::status::ok) override

--- a/src/web/impl/HttpBase.hpp
+++ b/src/web/impl/HttpBase.hpp
@@ -8,6 +8,7 @@
 #include "util/log/Logger.hpp"
 #include "util/prometheus/Http.hpp"
 #include "web/AdminVerificationStrategy.hpp"
+#include "web/LoadWarning.hpp"
 #include "web/ProxyIpResolver.hpp"
 #include "web/SubscriptionContextInterface.hpp"
 #include "web/dosguard/DOSGuardInterface.hpp"
@@ -317,19 +318,10 @@ public:
     send(std::string&& msg, http::status status = http::status::ok) override
     {
         if (!dosGuard_.get().add(clientIp_, msg.size())) {
-            auto jsonResponse = boost::json::parse(msg).as_object();
-            jsonResponse["warning"] = "load";
-            if (jsonResponse.contains("warnings") && jsonResponse["warnings"].is_array()) {
-                jsonResponse["warnings"].as_array().push_back(
-                    rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)
-                );
-            } else {
-                jsonResponse["warnings"] =
-                    boost::json::array{rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)};
+            if (auto const warned = withLoadWarning(msg); warned.has_value()) {
+                // Reserialize when we need to include this warning
+                msg = boost::json::serialize(*warned);
             }
-
-            // Reserialize when we need to include this warning
-            msg = boost::json::serialize(jsonResponse);
         }
         sender_(httpResponse(status, "application/json", std::move(msg)));
     }

--- a/src/web/impl/HttpBase.hpp
+++ b/src/web/impl/HttpBase.hpp
@@ -310,14 +310,11 @@ public:
     }
 
     /**
-     * @brief Send a response to the client
+     * @copydoc ConnectionBase::send
      *
-     * The message length is added to the DOSGuard. If that puts the client over its limit and the
-     * body parses as a JSON object, a "load" warning is attached to it; bodies that are not JSON
-     * objects - the text/html error paths - are sent unchanged.
-     *
-     * @param msg The serialized response body
-     * @param status The HTTP status to respond with
+     * @note The message length is added to the DOSGuard. If that puts the client over its limit
+     * and the body parses as a JSON object, a "load" warning is attached to it; bodies that are
+     * not JSON objects - the text/html error paths - are sent unchanged.
      */
     void
     send(std::string&& msg, http::status status = http::status::ok) override

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -4,6 +4,7 @@
 #include "rpc/common/Types.hpp"
 #include "util/Taggable.hpp"
 #include "util/log/Logger.hpp"
+#include "web/LoadWarning.hpp"
 #include "web/SubscriptionContext.hpp"
 #include "web/SubscriptionContextInterface.hpp"
 #include "web/dosguard/DOSGuardInterface.hpp"
@@ -205,20 +206,10 @@ public:
     send(std::string&& msg, http::status) override
     {
         if (!dosGuard_.get().add(clientIp_, msg.size())) {
-            auto jsonResponse = boost::json::parse(msg).as_object();
-            jsonResponse["warning"] = "load";
-
-            if (jsonResponse.contains("warnings") && jsonResponse["warnings"].is_array()) {
-                jsonResponse["warnings"].as_array().push_back(
-                    rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)
-                );
-            } else {
-                jsonResponse["warnings"] =
-                    boost::json::array{rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)};
+            if (auto const warned = withLoadWarning(msg); warned.has_value()) {
+                // Reserialize when we need to include this warning
+                msg = boost::json::serialize(*warned);
             }
-
-            // Reserialize when we need to include this warning
-            msg = boost::json::serialize(jsonResponse);
         }
         auto sharedMsg = std::make_shared<std::string>(std::move(msg));
         send(std::move(sharedMsg));

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -197,13 +197,11 @@ public:
     }
 
     /**
-     * @brief Send a message to the client
+     * @copydoc ConnectionBase::send
      *
-     * The message length is added to the DOSGuard. If that puts the client over its limit and the
-     * message parses as a JSON object, a "load" warning is attached to it; messages that are not
-     * JSON objects are sent unchanged.
-     *
-     * @param msg The message to send
+     * @note The message length is added to the DOSGuard. If that puts the client over its limit
+     * and the message parses as a JSON object, a "load" warning is attached to it; messages that
+     * are not JSON objects are sent unchanged.
      */
     void
     send(std::string&& msg, http::status) override

--- a/src/web/impl/WsBase.hpp
+++ b/src/web/impl/WsBase.hpp
@@ -198,9 +198,12 @@ public:
 
     /**
      * @brief Send a message to the client
+     *
+     * The message length is added to the DOSGuard. If that puts the client over its limit and the
+     * message parses as a JSON object, a "load" warning is attached to it; messages that are not
+     * JSON objects are sent unchanged.
+     *
      * @param msg The message to send
-     * Send this message to the client. The message length will be added to the DOSGuard
-     * If the DOSGuard is triggered, the message will be modified to include a warning
      */
     void
     send(std::string&& msg, http::status) override

--- a/src/web/ng/RPCServerHandler.hpp
+++ b/src/web/ng/RPCServerHandler.hpp
@@ -13,6 +13,7 @@
 #include "util/Profiler.hpp"
 #include "util/Taggable.hpp"
 #include "util/log/Logger.hpp"
+#include "web/LoadWarning.hpp"
 #include "web/SubscriptionContextInterface.hpp"
 #include "web/dosguard/DOSGuardInterface.hpp"
 #include "web/ng/Connection.hpp"
@@ -182,7 +183,13 @@ public:
 
         // NOLINTBEGIN(bugprone-unchecked-optional-access)
         if (not dosguard_.get().add(connectionMetadata.ip(), response->message().size())) {
-            response->setMessage(makeLoadWarning(*response));
+            if (auto const warned = withLoadWarning(response->message()); warned.has_value()) {
+                response->setMessage(*warned);
+            } else {
+                LOG(log_.debug()) << connectionMetadata.tag()
+                                  << "Rate limit reached but the response body is not a JSON "
+                                     "object; sending it without a load warning";
+            }
         }
 
         return *std::move(response);
@@ -355,22 +362,6 @@ private:
             }
         }
         return web::ng::Response{boost::beast::http::status::service_unavailable, error, request};
-    }
-
-    static boost::json::object
-    makeLoadWarning(Response const& response)
-    {
-        auto jsonResponse = boost::json::parse(response.message()).as_object();
-        jsonResponse["warning"] = "load";
-        if (jsonResponse.contains("warnings") && jsonResponse["warnings"].is_array()) {
-            jsonResponse["warnings"].as_array().push_back(
-                rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)
-            );
-        } else {
-            jsonResponse["warnings"] =
-                boost::json::array{rpc::makeWarning(rpc::WarningCode::WarnRpcRateLimit)};
-        }
-        return jsonResponse;
     }
 
     [[nodiscard]] bool

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -204,6 +204,7 @@ target_sources(
         web/dosguard/WeightsTests.cpp
         web/dosguard/WhitelistHandlerTests.cpp
         web/impl/ErrorHandlingTests.cpp
+        web/LoadWarningTests.cpp
         web/ng/ResponseTests.cpp
         web/ng/RequestTests.cpp
         web/ng/RPCServerHandlerTests.cpp

--- a/tests/unit/web/LoadWarningTests.cpp
+++ b/tests/unit/web/LoadWarningTests.cpp
@@ -1,0 +1,81 @@
+#include "rpc/Errors.hpp"
+#include "web/LoadWarning.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+using namespace web;
+
+namespace {
+
+struct LoadWarningNonJsonTest : testing::TestWithParam<std::string> {};
+
+}  // namespace
+
+INSTANTIATE_TEST_SUITE_P(
+    NonJsonBodies,
+    LoadWarningNonJsonTest,
+    testing::Values(
+        "Unable to parse JSON from the request",
+        "Null method",
+        "method is empty",
+        "method is not string",
+        "params unparsable",
+        "Bad target",
+        "Too many requests for one connection",
+        "",
+        "[1, 2, 3]",  // valid JSON, but not an object
+        "42",
+        "null",
+        R"("a string")"
+    )
+);
+
+TEST_P(LoadWarningNonJsonTest, ReturnsNulloptInsteadOfThrowing)
+{
+    EXPECT_NO_THROW({ EXPECT_FALSE(withLoadWarning(GetParam()).has_value()); });
+}
+
+TEST(LoadWarningTest, AddsWarningToJsonObjectWithoutExistingWarnings)
+{
+    auto const result = withLoadWarning(R"({"result": {"status": "success"}})");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->at("warning").as_string(), "load");
+    ASSERT_EQ(result->at("warnings").as_array().size(), 1);
+    EXPECT_EQ(
+        result->at("warnings").as_array().at(0).as_object().at("id").as_int64(),
+        static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
+    );
+    EXPECT_EQ(result->at("result").as_object().at("status").as_string(), "success");
+}
+
+TEST(LoadWarningTest, AppendsToExistingWarningsArray)
+{
+    auto const result =
+        withLoadWarning(R"({"warnings": [{"id": 2001, "message": "already here"}]})");
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->at("warning").as_string(), "load");
+    ASSERT_EQ(result->at("warnings").as_array().size(), 2);
+    EXPECT_EQ(result->at("warnings").as_array().at(0).as_object().at("id").as_int64(), 2001);
+    EXPECT_EQ(
+        result->at("warnings").as_array().at(1).as_object().at("id").as_int64(),
+        static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
+    );
+}
+
+TEST(LoadWarningTest, ReplacesNonArrayWarningsField)
+{
+    auto const result = withLoadWarning(R"({"warnings": "not an array"})");
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->at("warnings").is_array());
+    ASSERT_EQ(result->at("warnings").as_array().size(), 1);
+    EXPECT_EQ(
+        result->at("warnings").as_array().at(0).as_object().at("id").as_int64(),
+        static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
+    );
+}

--- a/tests/unit/web/LoadWarningTests.cpp
+++ b/tests/unit/web/LoadWarningTests.cpp
@@ -43,6 +43,7 @@ TEST(LoadWarningTest, AddsWarningToJsonObjectWithoutExistingWarnings)
     auto const result = withLoadWarning(R"({"result": {"status": "success"}})");
 
     ASSERT_TRUE(result.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(result->at("warning").as_string(), "load");
     ASSERT_EQ(result->at("warnings").as_array().size(), 1);
     EXPECT_EQ(
@@ -50,6 +51,7 @@ TEST(LoadWarningTest, AddsWarningToJsonObjectWithoutExistingWarnings)
         static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
     );
     EXPECT_EQ(result->at("result").as_object().at("status").as_string(), "success");
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(LoadWarningTest, AppendsToExistingWarningsArray)
@@ -58,6 +60,7 @@ TEST(LoadWarningTest, AppendsToExistingWarningsArray)
         withLoadWarning(R"({"warnings": [{"id": 2001, "message": "already here"}]})");
 
     ASSERT_TRUE(result.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(result->at("warning").as_string(), "load");
     ASSERT_EQ(result->at("warnings").as_array().size(), 2);
     EXPECT_EQ(result->at("warnings").as_array().at(0).as_object().at("id").as_int64(), 2001);
@@ -65,6 +68,7 @@ TEST(LoadWarningTest, AppendsToExistingWarningsArray)
         result->at("warnings").as_array().at(1).as_object().at("id").as_int64(),
         static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
     );
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(LoadWarningTest, ReplacesNonArrayWarningsField)
@@ -72,10 +76,12 @@ TEST(LoadWarningTest, ReplacesNonArrayWarningsField)
     auto const result = withLoadWarning(R"({"warnings": "not an array"})");
 
     ASSERT_TRUE(result.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     ASSERT_TRUE(result->at("warnings").is_array());
     ASSERT_EQ(result->at("warnings").as_array().size(), 1);
     EXPECT_EQ(
         result->at("warnings").as_array().at(0).as_object().at("id").as_int64(),
         static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
     );
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }

--- a/tests/unit/web/ng/RPCServerHandlerTests.cpp
+++ b/tests/unit/web/ng/RPCServerHandlerTests.cpp
@@ -197,6 +197,52 @@ TEST_F(NgRpcServerHandlerTest, JsonParseFailed)
     });
 }
 
+TEST_F(NgRpcServerHandlerTest, JsonParseFailedAndDosguardLimitReached)
+{
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const request = makeHttpRequest("not a json");
+
+        EXPECT_CALL(dosguard_, isOk(ip_)).WillOnce(Return(true));
+        EXPECT_CALL(*rpcEngine_, post).WillOnce([&](auto&& fn, auto&&) {
+            EXPECT_CALL(*rpcEngine_, notifyBadSyntax);
+            fn(yield);
+            return true;
+        });
+        EXPECT_CALL(dosguard_, add(ip_, testing::_)).WillOnce(Return(false));
+
+        auto response = rpcServerHandler_(request, connectionMetadata_, nullptr, yield);
+        auto const responseHttp = std::move(response).intoHttpResponse();
+
+        EXPECT_EQ(responseHttp.result(), http::status::bad_request);
+        EXPECT_EQ(responseHttp.body(), "Unable to parse JSON from the request");
+    });
+}
+
+TEST_F(NgRpcServerHandlerTest, WsJsonParseFailedAndDosguardLimitReached)
+{
+    runSpawn([&](boost::asio::yield_context yield) {
+        auto const request = makeWsRequest("not a json");
+
+        EXPECT_CALL(dosguard_, isOk(ip_)).WillOnce(Return(true));
+        EXPECT_CALL(*rpcEngine_, post).WillOnce([&](auto&& fn, auto&&) {
+            EXPECT_CALL(*rpcEngine_, notifyBadSyntax);
+            fn(yield);
+            return true;
+        });
+        EXPECT_CALL(dosguard_, add(ip_, testing::_)).WillOnce(Return(false));
+
+        auto const response = rpcServerHandler_(request, connectionMetadata_, nullptr, yield);
+        auto const responseJson = boost::json::parse(response.message()).as_object();
+
+        EXPECT_EQ(responseJson.at("error").as_string(), "badSyntax");
+        EXPECT_EQ(responseJson.at("warning").as_string(), "load");
+        EXPECT_EQ(
+            responseJson.at("warnings").as_array().at(0).as_object().at("id").as_int64(),
+            static_cast<int64_t>(rpc::WarningCode::WarnRpcRateLimit)
+        );
+    });
+}
+
 TEST_F(NgRpcServerHandlerTest, DosguardRejectedParsedRequest)
 {
     runSpawn([&](boost::asio::yield_context yield) {


### PR DESCRIPTION
This PR fixes a bug which produced internal error output instead of the correct plain-text error output in cases where it overlapped with maxing out the DOSGuard session allowance.