### PR TITLE
fix: WebServer NG send queue

### DIFF
--- a/src/web/ng/Server.cpp
+++ b/src/web/ng/Server.cpp
@@ -114,6 +114,7 @@ makeConnection(
     std::string ip,
     util::TagDecoratorFactory& tagDecoratorFactory,
     Server::OnConnectCheck onConnectCheck,
+    size_t maxSendingQueueSize,
     boost::asio::yield_context yield
 )
 {
@@ -130,7 +131,8 @@ makeConnection(
             std::move(ip),
             std::move(sslDetectionResult.buffer),
             *sslContext,
-            tagDecoratorFactory
+            tagDecoratorFactory,
+            maxSendingQueueSize
         );
         sslConnection->setTimeout(std::chrono::seconds{10});
         auto const expectedSuccess = sslConnection->sslHandshake(yield);
@@ -146,7 +148,8 @@ makeConnection(
             std::move(sslDetectionResult.socket),
             std::move(ip),
             std::move(sslDetectionResult.buffer),
-            tagDecoratorFactory
+            tagDecoratorFactory,
+            maxSendingQueueSize
         );
     }
 
@@ -163,6 +166,7 @@ std::expected<ConnectionPtr, std::string>
 tryUpgradeConnection(
     impl::UpgradableConnectionPtr connection,
     util::TagDecoratorFactory& tagDecoratorFactory,
+    size_t maxSendingQueueSize,
     boost::asio::yield_context yield
 )
 {
@@ -174,7 +178,8 @@ tryUpgradeConnection(
     }
 
     if (*expectedIsUpgrade) {
-        auto expectedUpgradedConnection = connection->upgrade(tagDecoratorFactory, yield);
+        auto expectedUpgradedConnection =
+            connection->upgrade(tagDecoratorFactory, maxSendingQueueSize, yield);
         if (expectedUpgradedConnection.has_value())
             return std::move(expectedUpgradedConnection).value();
 
@@ -196,13 +201,14 @@ Server::Server(
     std::optional<size_t> parallelRequestLimit,
     util::TagDecoratorFactory tagDecoratorFactory,
     ProxyIpResolver proxyIpResolver,
-    std::optional<size_t> maxSubscriptionSendQueueSize,
+    size_t maxSubscriptionSendQueueSize,
     Hooks hooks
 )
     : ctx_{ctx}
     , sslContext_{std::move(sslContext)}
     , tagDecoratorFactory_{tagDecoratorFactory}
-    , connectionHandler_{processingPolicy, parallelRequestLimit, tagDecoratorFactory_, maxSubscriptionSendQueueSize, std::move(proxyIpResolver), std::move(hooks.onDisconnectHook), std::move(hooks.onIpChangeHook)}
+    , maxSubscriptionSendQueueSize_{maxSubscriptionSendQueueSize}
+    , connectionHandler_{processingPolicy, parallelRequestLimit, tagDecoratorFactory_, std::move(proxyIpResolver), std::move(hooks.onDisconnectHook), std::move(hooks.onIpChangeHook)}
     , endpoint_{std::move(endpoint)}
     , onConnectCheck_{std::move(hooks.onConnectCheck)}
 {
@@ -296,6 +302,7 @@ Server::handleConnection(boost::asio::ip::tcp::socket socket, boost::asio::yield
         std::move(ip).value(),
         tagDecoratorFactory_,
         onConnectCheck_,
+        maxSubscriptionSendQueueSize_,
         yield
     );
     if (not connectionExpected.has_value()) {
@@ -318,8 +325,12 @@ Server::handleConnection(boost::asio::ip::tcp::socket socket, boost::asio::yield
         return;
     }
 
-    auto connection =
-        tryUpgradeConnection(std::move(connectionExpected).value(), tagDecoratorFactory_, yield);
+    auto connection = tryUpgradeConnection(
+        std::move(connectionExpected).value(),
+        tagDecoratorFactory_,
+        maxSubscriptionSendQueueSize_,
+        yield
+    );
     if (not connection.has_value()) {
         LOG(log_.info()) << connection.error();
         return;

--- a/src/web/ng/Server.hpp
+++ b/src/web/ng/Server.hpp
@@ -59,6 +59,7 @@ private:
     std::optional<boost::asio::ssl::context> sslContext_;
 
     util::TagDecoratorFactory tagDecoratorFactory_;
+    size_t maxSubscriptionSendQueueSize_;
 
     impl::ConnectionHandler connectionHandler_;
     boost::asio::ip::tcp::endpoint endpoint_;
@@ -90,7 +91,7 @@ public:
         std::optional<size_t> parallelRequestLimit,
         util::TagDecoratorFactory tagDecoratorFactory,
         ProxyIpResolver proxyIpResolver,
-        std::optional<size_t> maxSubscriptionSendQueueSize,
+        size_t maxSubscriptionSendQueueSize,
         Hooks hooks
     );
 

--- a/src/web/ng/SubscriptionContext.cpp
+++ b/src/web/ng/SubscriptionContext.cpp
@@ -6,10 +6,8 @@
 
 #include <boost/asio/spawn.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 
@@ -18,13 +16,11 @@ namespace web::ng {
 SubscriptionContext::SubscriptionContext(
     util::TagDecoratorFactory const& factory,
     impl::WsConnectionBase& connection,
-    std::optional<size_t> maxSendQueueSize,
     boost::asio::yield_context yield,
     ErrorHandler errorHandler
 )
     : web::SubscriptionContextInterface(factory)
     , connection_(connection)
-    , maxSendQueueSize_(maxSendQueueSize)
     , tasksGroup_(yield)
     , yield_(yield)
     , errorHandler_(std::move(errorHandler))
@@ -41,14 +37,6 @@ SubscriptionContext::send(std::shared_ptr<std::string> message)
 {
     if (disconnected_ or gotError_)
         return;
-
-    if (maxSendQueueSize_.has_value() and tasksGroup_.size() >= *maxSendQueueSize_) {
-        tasksGroup_.spawn(yield_, [this](boost::asio::yield_context innerYield) {
-            connection_.get().close(innerYield);
-        });
-        gotError_ = true;
-        return;
-    }
 
     tasksGroup_.spawn(
         yield_,

--- a/src/web/ng/SubscriptionContext.hpp
+++ b/src/web/ng/SubscriptionContext.hpp
@@ -12,11 +12,9 @@
 #include <boost/signals2/variadic_signal.hpp>
 
 #include <atomic>
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 
 namespace web::ng {
@@ -36,7 +34,6 @@ public:
 
 private:
     std::reference_wrapper<impl::WsConnectionBase> connection_;
-    std::optional<size_t> maxSendQueueSize_;
     util::CoroutineGroup tasksGroup_;
     boost::asio::yield_context yield_;
     ErrorHandler errorHandler_;
@@ -59,15 +56,12 @@ public:
      *
      * @param factory The tag decorator factory to use to init taggable.
      * @param connection The connection for which the context is created.
-     * @param maxSendQueueSize The maximum size of the send queue. If the queue is full, the
-     * connection will be closed.
      * @param yield The yield context to spawn sending coroutines.
      * @param errorHandler The error handler.
      */
     SubscriptionContext(
         util::TagDecoratorFactory const& factory,
         impl::WsConnectionBase& connection,
-        std::optional<size_t> maxSendQueueSize,
         boost::asio::yield_context yield,
         ErrorHandler errorHandler
     );

--- a/src/web/ng/impl/ConnectionHandler.cpp
+++ b/src/web/ng/impl/ConnectionHandler.cpp
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -135,12 +136,9 @@ ConnectionHandler::processConnection(ConnectionPtr connectionPtr, boost::asio::y
     if (connectionRef.wasUpgraded()) {
         auto* ptr = dynamic_cast<impl::WsConnectionBase*>(connectionPtr.get());
         ASSERT(ptr != nullptr, "Casted not websocket connection");
+        ptr->setMaxSendingQueueSize(maxSubscriptionSendQueueSize_);
         subscriptionContext = std::make_shared<SubscriptionContext>(
-            tagFactory_,
-            *ptr,
-            maxSubscriptionSendQueueSize_,
-            yield,
-            [this](Error const& e, Connection const& c) { return handleError(e, c); }
+            tagFactory_, *ptr, yield, std::bind_front(&ConnectionHandler::handleError, this)
         );
         LOG(log_.trace()) << connectionRef.tag()
                           << "Created SubscriptionContext for the connection";

--- a/src/web/ng/impl/ConnectionHandler.cpp
+++ b/src/web/ng/impl/ConnectionHandler.cpp
@@ -76,7 +76,6 @@ ConnectionHandler::ConnectionHandler(
     ProcessingPolicy processingPolicy,
     std::optional<size_t> maxParallelRequests,
     util::TagDecoratorFactory& tagFactory,
-    std::optional<size_t> maxSubscriptionSendQueueSize,
     ProxyIpResolver proxyIpResolver,
     OnDisconnectHook onDisconnectHook,
     OnIpChangeHook onIpChangeHook
@@ -84,7 +83,6 @@ ConnectionHandler::ConnectionHandler(
     : processingPolicy_{processingPolicy}
     , maxParallelRequests_{maxParallelRequests}
     , tagFactory_{tagFactory}
-    , maxSubscriptionSendQueueSize_{maxSubscriptionSendQueueSize}
     , proxyIpResolver_(std::move(proxyIpResolver))
     , onDisconnectHook_{std::move(onDisconnectHook)}
     , onIpChangeHook_(std::move(onIpChangeHook))
@@ -136,7 +134,6 @@ ConnectionHandler::processConnection(ConnectionPtr connectionPtr, boost::asio::y
     if (connectionRef.wasUpgraded()) {
         auto* ptr = dynamic_cast<impl::WsConnectionBase*>(connectionPtr.get());
         ASSERT(ptr != nullptr, "Casted not websocket connection");
-        ptr->setMaxSendingQueueSize(maxSubscriptionSendQueueSize_);
         subscriptionContext = std::make_shared<SubscriptionContext>(
             tagFactory_, *ptr, yield, std::bind_front(&ConnectionHandler::handleError, this)
         );

--- a/src/web/ng/impl/ConnectionHandler.hpp
+++ b/src/web/ng/impl/ConnectionHandler.hpp
@@ -46,7 +46,6 @@ private:
     std::optional<size_t> maxParallelRequests_;
 
     std::reference_wrapper<util::TagDecoratorFactory> tagFactory_;
-    std::optional<size_t> maxSubscriptionSendQueueSize_;
 
     ProxyIpResolver proxyIpResolver_;
 
@@ -73,7 +72,6 @@ public:
         ProcessingPolicy processingPolicy,
         std::optional<size_t> maxParallelRequests,
         util::TagDecoratorFactory& tagFactory,
-        std::optional<size_t> maxSubscriptionSendQueueSize,
         ProxyIpResolver proxyIpResolver,
         OnDisconnectHook onDisconnectHook,
         OnIpChangeHook onIpChangeHook

--- a/src/web/ng/impl/HttpConnection.hpp
+++ b/src/web/ng/impl/HttpConnection.hpp
@@ -26,6 +26,7 @@
 #include <boost/beast/websocket.hpp>
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -43,6 +44,7 @@ public:
     virtual std::expected<ConnectionPtr, Error>
     upgrade(
         util::TagDecoratorFactory const& tagDecoratorFactory,
+        size_t maxSendingQueueSize,
         boost::asio::yield_context yield
     ) = 0;
 
@@ -71,15 +73,19 @@ public:
         boost::asio::ip::tcp::socket socket,
         std::string ip,
         boost::beast::flat_buffer buffer,
-        util::TagDecoratorFactory const& tagDecoratorFactory
+        util::TagDecoratorFactory const& tagDecoratorFactory,
+        size_t maxSendingQueueSize
     )
         requires IsTcpStream<StreamType>
         : UpgradableConnection(std::move(ip), std::move(buffer), tagDecoratorFactory)
         , stream_{std::move(socket)}
-        , sendingQueue_([this](MessageType const& message, auto&& yield) {
-            boost::beast::get_lowest_layer(stream_).expires_after(timeout_);
-            boost::beast::http::async_write(stream_, message, yield);
-        })
+        , sendingQueue_(
+              [this](MessageType const& message, auto&& yield) {
+                  boost::beast::get_lowest_layer(stream_).expires_after(timeout_);
+                  boost::beast::http::async_write(stream_, message, yield);
+              },
+              maxSendingQueueSize
+          )
     {
     }
 
@@ -88,15 +94,19 @@ public:
         std::string ip,
         boost::beast::flat_buffer buffer,
         boost::asio::ssl::context& sslCtx,
-        util::TagDecoratorFactory const& tagDecoratorFactory
+        util::TagDecoratorFactory const& tagDecoratorFactory,
+        size_t maxSendingQueueSize
     )
         requires IsSslTcpStream<StreamType>
         : UpgradableConnection(std::move(ip), std::move(buffer), tagDecoratorFactory)
         , stream_{std::move(socket), sslCtx}
-        , sendingQueue_([this](MessageType const& message, auto&& yield) {
-            boost::beast::get_lowest_layer(stream_).expires_after(timeout_);
-            boost::beast::http::async_write(stream_, message, yield);
-        })
+        , sendingQueue_(
+              [this](MessageType const& message, auto&& yield) {
+                  boost::beast::get_lowest_layer(stream_).expires_after(timeout_);
+                  boost::beast::http::async_write(stream_, message, yield);
+              },
+              maxSendingQueueSize
+          )
     {
     }
 
@@ -202,6 +212,7 @@ public:
     std::expected<ConnectionPtr, Error>
     upgrade(
         util::TagDecoratorFactory const& tagDecoratorFactory,
+        size_t maxSendingQueueSize,
         boost::asio::yield_context yield
     ) override
     {
@@ -213,6 +224,7 @@ public:
             std::move(buffer_),
             std::move(*request_),  // NOLINT(bugprone-unchecked-optional-access)
             tagDecoratorFactory,
+            maxSendingQueueSize,
             yield
         );
     }

--- a/src/web/ng/impl/SendingQueue.hpp
+++ b/src/web/ng/impl/SendingQueue.hpp
@@ -3,12 +3,16 @@
 #include "web/ng/Error.hpp"
 
 #include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/system/detail/error_code.hpp>
 
+#include <cstddef>
+#include <expected>
 #include <functional>
 #include <optional>
 #include <queue>
+#include <utility>
 
 namespace web::ng::impl {
 
@@ -23,10 +27,18 @@ private:
     Sender sender_;
     Error error_;
     bool isSending_{false};
+    std::optional<size_t> maxSize_;
 
 public:
-    SendingQueue(Sender sender) : sender_{std::move(sender)}
+    SendingQueue(Sender sender, std::optional<size_t> maxSize = std::nullopt)
+        : sender_{std::move(sender)}, maxSize_{maxSize}
     {
+    }
+
+    void
+    setMaxSize(std::optional<size_t> maxSize)
+    {
+        maxSize_ = maxSize;
     }
 
     std::expected<void, Error>
@@ -34,6 +46,12 @@ public:
     {
         if (error_)
             return std::unexpected{error_};
+
+        if (maxSize_.has_value() and queue_.size() >= *maxSize_) {
+            error_ = boost::asio::error::timed_out;
+            queue_ = {};
+            return std::unexpected{error_};
+        }
 
         queue_.push(std::move(message));
         if (isSending_)

--- a/src/web/ng/impl/SendingQueue.hpp
+++ b/src/web/ng/impl/SendingQueue.hpp
@@ -10,7 +10,6 @@
 #include <cstddef>
 #include <expected>
 #include <functional>
-#include <optional>
 #include <queue>
 #include <utility>
 
@@ -27,18 +26,11 @@ private:
     Sender sender_;
     Error error_;
     bool isSending_{false};
-    std::optional<size_t> maxSize_;
+    size_t maxSize_;
 
 public:
-    SendingQueue(Sender sender, std::optional<size_t> maxSize = std::nullopt)
-        : sender_{std::move(sender)}, maxSize_{maxSize}
+    SendingQueue(Sender sender, size_t maxSize) : sender_{std::move(sender)}, maxSize_{maxSize}
     {
-    }
-
-    void
-    setMaxSize(std::optional<size_t> maxSize)
-    {
-        maxSize_ = maxSize;
     }
 
     std::expected<void, Error>
@@ -47,9 +39,8 @@ public:
         if (error_)
             return std::unexpected{error_};
 
-        if (maxSize_.has_value() and queue_.size() >= *maxSize_) {
+        if (queue_.size() >= maxSize_) {
             error_ = boost::asio::error::timed_out;
-            queue_ = {};
             return std::unexpected{error_};
         }
 

--- a/src/web/ng/impl/SendingQueue.hpp
+++ b/src/web/ng/impl/SendingQueue.hpp
@@ -52,7 +52,11 @@ public:
         while (not queue_.empty() and not error_) {
             auto const responseToSend = std::move(queue_.front());
             queue_.pop();
-            sender_(responseToSend, yield[error_]);
+
+            Error writeError;
+            sender_(responseToSend, yield[writeError]);
+            if (writeError)
+                error_ = writeError;
         }
         isSending_ = false;
         if (error_)

--- a/src/web/ng/impl/WsConnection.hpp
+++ b/src/web/ng/impl/WsConnection.hpp
@@ -30,7 +30,6 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
-#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -43,9 +42,6 @@ public:
 
     virtual std::expected<void, Error>
     sendShared(std::shared_ptr<std::string> message, boost::asio::yield_context yield) = 0;
-
-    virtual void
-    setMaxSendingQueueSize(std::optional<size_t> maxSize) = 0;
 };
 
 template <typename StreamType>
@@ -64,23 +60,29 @@ public:
         std::string ip,
         boost::beast::flat_buffer buffer,
         boost::beast::http::request<boost::beast::http::string_body> initialRequest,
-        util::TagDecoratorFactory const& tagDecoratorFactory
+        util::TagDecoratorFactory const& tagDecoratorFactory,
+        size_t maxSendingQueueSize
     )
         : WsConnectionBase(std::move(ip), std::move(buffer), tagDecoratorFactory)
         , stream_(std::move(stream))
         , initialRequest_(std::move(initialRequest))
-        , sendingQueue_{[this](MessageType const& message, auto&& yield) {
-            boost::asio::const_buffer const buffer = std::visit(
-                util::OverloadSet{
-                    [](Response const& r) -> boost::asio::const_buffer { return r.asWsResponse(); },
-                    [](std::shared_ptr<std::string> const& m) -> boost::asio::const_buffer {
-                        return boost::asio::buffer(*m);
-                    }
-                },
-                message
-            );
-            stream_.async_write(buffer, yield);
-        }}
+        , sendingQueue_{
+              [this](MessageType const& message, auto&& yield) {
+                  boost::asio::const_buffer const buffer = std::visit(
+                      util::OverloadSet{
+                          [](Response const& r) -> boost::asio::const_buffer {
+                              return r.asWsResponse();
+                          },
+                          [](std::shared_ptr<std::string> const& m) -> boost::asio::const_buffer {
+                              return boost::asio::buffer(*m);
+                          }
+                      },
+                      message
+                  );
+                  stream_.async_write(buffer, yield);
+              },
+              maxSendingQueueSize
+          }
     {
         setupWsStream();
     }
@@ -113,12 +115,6 @@ public:
     sendShared(std::shared_ptr<std::string> message, boost::asio::yield_context yield) override
     {
         return sendingQueue_.send(std::move(message), yield);
-    }
-
-    void
-    setMaxSendingQueueSize(std::optional<size_t> maxSize) override
-    {
-        sendingQueue_.setMaxSize(maxSize);
     }
 
     void
@@ -198,6 +194,7 @@ makeWsConnection(
     boost::beast::flat_buffer buffer,
     boost::beast::http::request<boost::beast::http::string_body> request,
     util::TagDecoratorFactory const& tagDecoratorFactory,
+    size_t maxSendingQueueSize,
     boost::asio::yield_context yield
 )
 {
@@ -206,7 +203,8 @@ makeWsConnection(
         std::move(ip),
         std::move(buffer),
         std::move(request),
-        tagDecoratorFactory
+        tagDecoratorFactory,
+        maxSendingQueueSize
     );
     auto const expectedSuccess = connection->performHandshake(yield);
     if (not expectedSuccess.has_value())

--- a/src/web/ng/impl/WsConnection.hpp
+++ b/src/web/ng/impl/WsConnection.hpp
@@ -28,6 +28,7 @@
 #include <boost/beast/websocket/stream_base.hpp>
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -42,6 +43,9 @@ public:
 
     virtual std::expected<void, Error>
     sendShared(std::shared_ptr<std::string> message, boost::asio::yield_context yield) = 0;
+
+    virtual void
+    setMaxSendingQueueSize(std::optional<size_t> maxSize) = 0;
 };
 
 template <typename StreamType>
@@ -109,6 +113,12 @@ public:
     sendShared(std::shared_ptr<std::string> message, boost::asio::yield_context yield) override
     {
         return sendingQueue_.send(std::move(message), yield);
+    }
+
+    void
+    setMaxSendingQueueSize(std::optional<size_t> maxSize) override
+    {
+        sendingQueue_.setMaxSize(maxSize);
     }
 
     void

--- a/tests/common/web/ng/impl/MockHttpConnection.hpp
+++ b/tests/common/web/ng/impl/MockHttpConnection.hpp
@@ -14,6 +14,7 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <optional>
 
@@ -52,7 +53,9 @@ struct MockHttpConnectionImpl : web::ng::impl::UpgradableConnection {
     MOCK_METHOD(
         UpgradeReturnType,
         upgrade,
-        (util::TagDecoratorFactory const& tagDecoratorFactory, boost::asio::yield_context yield),
+        (util::TagDecoratorFactory const& tagDecoratorFactory,
+         size_t maxSendingQueueSize,
+         boost::asio::yield_context yield),
         (override)
     );
 };

--- a/tests/common/web/ng/impl/MockWsConnection.hpp
+++ b/tests/common/web/ng/impl/MockWsConnection.hpp
@@ -12,6 +12,7 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -37,6 +38,8 @@ struct MockWsConnectionImpl : web::ng::impl::WsConnectionBase {
         (std::shared_ptr<std::string>, boost::asio::yield_context),
         (override)
     );
+
+    MOCK_METHOD(void, setMaxSendingQueueSize, (std::optional<size_t>), (override));
 };
 
 using MockWsConnection = testing::NiceMock<MockWsConnectionImpl>;

--- a/tests/common/web/ng/impl/MockWsConnection.hpp
+++ b/tests/common/web/ng/impl/MockWsConnection.hpp
@@ -12,7 +12,6 @@
 #include <gmock/gmock.h>
 
 #include <chrono>
-#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
@@ -38,8 +37,6 @@ struct MockWsConnectionImpl : web::ng::impl::WsConnectionBase {
         (std::shared_ptr<std::string>, boost::asio::yield_context),
         (override)
     );
-
-    MOCK_METHOD(void, setMaxSendingQueueSize, (std::optional<size_t>), (override));
 };
 
 using MockWsConnection = testing::NiceMock<MockWsConnectionImpl>;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -212,6 +212,7 @@ target_sources(
         web/ng/impl/ConnectionHandlerTests.cpp
         web/ng/impl/ErrorHandlingTests.cpp
         web/ng/impl/HttpConnectionTests.cpp
+        web/ng/impl/SendingQueueTests.cpp
         web/ng/impl/ServerSslContextTests.cpp
         web/ng/impl/WsConnectionTests.cpp
         web/ProxyIpResolverTests.cpp

--- a/tests/unit/web/ng/ServerTests.cpp
+++ b/tests/unit/web/ng/ServerTests.cpp
@@ -35,11 +35,16 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <unordered_set>
+
+namespace {
+constexpr size_t kMaxSendingQueueSize = 1500;
+}  // namespace
 
 using namespace web::ng;
 using namespace util::config;
@@ -218,7 +223,7 @@ TEST_F(ServerTest, BadEndpoint)
         std::nullopt,
         tagDecoratorFactory,
         web::ProxyIpResolver{{}, {}},
-        std::nullopt,
+        kMaxSendingQueueSize,
         Server::Hooks{
             .onConnectCheck = emptyOnConnectCheck_,
             .onIpChangeHook = [](auto&&, auto&&) {},
@@ -291,7 +296,7 @@ TEST_F(ServerHttpTest, OnConnectCheck)
         std::nullopt,
         tagDecoratorFactory,
         web::ProxyIpResolver{{}, {}},
-        std::nullopt,
+        kMaxSendingQueueSize,
         Server::Hooks{
             .onConnectCheck = onConnectCheck.AsStdFunction(),
             .onIpChangeHook = [](auto&&, auto&&) {},
@@ -361,7 +366,7 @@ TEST_F(ServerHttpTest, OnConnectCheckFailed)
         std::nullopt,
         tagDecoratorFactory,
         web::ProxyIpResolver{{}, {}},
-        std::nullopt,
+        kMaxSendingQueueSize,
         Server::Hooks{
             .onConnectCheck = onConnectCheck.AsStdFunction(),
             .onIpChangeHook = [](auto&&, auto&&) {},
@@ -431,7 +436,7 @@ TEST_F(ServerHttpTest, OnDisconnectHook)
         std::nullopt,
         tagDecoratorFactory,
         web::ProxyIpResolver{{}, {}},
-        std::nullopt,
+        kMaxSendingQueueSize,
         Server::Hooks{
             .onConnectCheck = emptyOnConnectCheck_,
             .onIpChangeHook = [](auto&&, auto&&) {},

--- a/tests/unit/web/ng/SubscriptionContextTests.cpp
+++ b/tests/unit/web/ng/SubscriptionContextTests.cpp
@@ -11,16 +11,13 @@
 #include "web/ng/impl/MockWsConnection.hpp"
 
 #include <boost/asio/error.hpp>
-#include <boost/asio/post.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/system/errc.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <memory>
-#include <optional>
 #include <string>
 
 using namespace web::ng;

--- a/tests/unit/web/ng/SubscriptionContextTests.cpp
+++ b/tests/unit/web/ng/SubscriptionContextTests.cpp
@@ -10,6 +10,7 @@
 #include "web/ng/SubscriptionContext.hpp"
 #include "web/ng/impl/MockWsConnection.hpp"
 
+#include <boost/asio/error.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
@@ -27,14 +28,9 @@ using namespace util::config;
 
 struct NgSubscriptionContextTests : SyncAsioContextTest {
     SubscriptionContext
-    makeSubscriptionContext(
-        boost::asio::yield_context yield,
-        std::optional<size_t> maxSendQueueSize = std::nullopt
-    )
+    makeSubscriptionContext(boost::asio::yield_context yield)
     {
-        return SubscriptionContext{
-            tagFactory_, connection_, maxSendQueueSize, yield, errorHandler_.AsStdFunction()
-        };
+        return SubscriptionContext{tagFactory_, connection_, yield, errorHandler_.AsStdFunction()};
     }
 
 protected:
@@ -124,26 +120,15 @@ TEST_F(NgSubscriptionContextTests, SendFailed)
 TEST_F(NgSubscriptionContextTests, SendTooManySubscriptions)
 {
     runSpawn([this](boost::asio::yield_context yield) {
-        auto subscriptionContext = makeSubscriptionContext(yield, 1);
+        auto subscriptionContext = makeSubscriptionContext(yield);
         auto const message = std::make_shared<std::string>("message1");
 
-        EXPECT_CALL(connection_, sendShared)
-            .WillOnce(
-                [&message](
-                    std::shared_ptr<std::string> sendingMessage,
-                    boost::asio::yield_context innerYield
-                ) -> std::expected<void, web::ng::Error> {
-                    boost::asio::post(
-                        innerYield
-                    );  // simulate send is slow by switching to another coroutine
-                    EXPECT_EQ(sendingMessage, message);
-                    return {};
-                }
-            );
+        EXPECT_CALL(connection_, sendShared).WillOnce([](auto&&, auto&&) {
+            return std::unexpected{boost::system::error_code{boost::asio::error::timed_out}};
+        });
+        EXPECT_CALL(errorHandler_, Call).WillOnce(testing::Return(true));
         EXPECT_CALL(connection_, close);
 
-        subscriptionContext.send(message);
-        subscriptionContext.send(message);
         subscriptionContext.send(message);
         subscriptionContext.disconnect(yield);
     });

--- a/tests/unit/web/ng/impl/ConnectionHandlerTests.cpp
+++ b/tests/unit/web/ng/impl/ConnectionHandlerTests.cpp
@@ -47,7 +47,11 @@ namespace http = boost::beast::http;
 namespace websocket = boost::beast::websocket;
 
 struct ConnectionHandlerTest : prometheus::WithPrometheus, SyncAsioContextTest {
-    ConnectionHandlerTest(ProcessingPolicy policy, std::optional<size_t> maxParallelConnections)
+    ConnectionHandlerTest(
+        ProcessingPolicy policy,
+        std::optional<size_t> maxParallelConnections,
+        std::optional<size_t> maxSubscriptionSendQueueSize = std::nullopt
+    )
         : tagFactory{util::config::ClioConfigDefinition{
               {"log.tag_style",
                config::ConfigValue{config::ConfigType::String}.defaultValue("uint")}
@@ -56,12 +60,13 @@ struct ConnectionHandlerTest : prometheus::WithPrometheus, SyncAsioContextTest {
               policy,
               maxParallelConnections,
               tagFactory,
-              std::nullopt,
+              maxSubscriptionSendQueueSize,
               proxyIpResolver,
               onDisconnectMock.AsStdFunction(),
               onIpChangeMock.AsStdFunction()
           }
     {
+        EXPECT_CALL(*mockWsConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     }
 
     template <typename BoostErrorType>
@@ -804,6 +809,38 @@ TEST_F(ConnectionHandlerSequentialProcessingTest, ProcessCalledAfterStop)
     });
 }
 
+struct ConnectionHandlerSendQueueLimitTest : ConnectionHandlerTest {
+    static constexpr size_t kMaxSendQueueSize = 42;
+
+    ConnectionHandlerSendQueueLimitTest()
+        : ConnectionHandlerTest(ProcessingPolicy::Sequential, std::nullopt, kMaxSendQueueSize)
+    {
+    }
+};
+
+TEST_F(ConnectionHandlerSendQueueLimitTest, ConfiguredLimitIsAppliedToUpgradedConnection)
+{
+    testing::StrictMock<testing::MockFunction<Response(
+        Request const&,
+        ConnectionMetadata const&,
+        web::SubscriptionContextPtr,
+        boost::asio::yield_context
+    )>>
+        wsHandlerMock;
+    connectionHandler.onWs(wsHandlerMock.AsStdFunction());
+
+    EXPECT_CALL(*mockWsConnection, wasUpgraded).WillOnce(Return(true));
+    EXPECT_CALL(
+        *mockWsConnection, setMaxSendingQueueSize(std::optional<size_t>{kMaxSendQueueSize})
+    );
+    EXPECT_CALL(*mockWsConnection, receive).WillOnce(Return(makeError(websocket::error::closed)));
+    EXPECT_CALL(onDisconnectMock, Call);
+
+    runSpawn([this](boost::asio::yield_context yield) {
+        connectionHandler.processConnection(std::move(mockWsConnection), yield);
+    });
+}
+
 struct ConnectionHandlerParallelProcessingTest : ConnectionHandlerTest {
     static constexpr size_t kMaxParallelRequests = 3;
 
@@ -902,6 +939,7 @@ TEST_F(ConnectionHandlerParallelProcessingTest, OnIpChangeHookCalledWhenSentFrom
     std::string const responseMessage = "some response";
 
     EXPECT_CALL(*mockWsConnectionFromProxy, wasUpgraded).WillOnce(Return(true));
+    EXPECT_CALL(*mockWsConnectionFromProxy, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockWsConnectionFromProxy, receive)
         .WillOnce(Return(makeRequest(requestMessage, headers)))
         .WillOnce(Return(makeError(websocket::error::closed)));
@@ -946,6 +984,7 @@ TEST_F(ConnectionHandlerParallelProcessingTest, ProxyConnection_SameClientReuses
     headers.set(http::field::forwarded, fmt::format("for={}", clientIp));
 
     EXPECT_CALL(*mockProxyConnection, wasUpgraded).WillOnce(Return(true));
+    EXPECT_CALL(*mockProxyConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockProxyConnection, receive)
         .WillOnce(Return(makeRequest("msg", headers)))
         .WillOnce(Return(makeRequest("msg", headers)))
@@ -989,6 +1028,7 @@ TEST_F(
     headers2.set(http::field::forwarded, fmt::format("for={}", anotherClientIp));
 
     EXPECT_CALL(*mockProxyConnection, wasUpgraded).WillOnce(Return(true));
+    EXPECT_CALL(*mockProxyConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockProxyConnection, receive)
         .WillOnce(Return(makeRequest("msg", headers1)))
         .WillOnce(Return(makeRequest("msg", headers2)))

--- a/tests/unit/web/ng/impl/ConnectionHandlerTests.cpp
+++ b/tests/unit/web/ng/impl/ConnectionHandlerTests.cpp
@@ -47,11 +47,7 @@ namespace http = boost::beast::http;
 namespace websocket = boost::beast::websocket;
 
 struct ConnectionHandlerTest : prometheus::WithPrometheus, SyncAsioContextTest {
-    ConnectionHandlerTest(
-        ProcessingPolicy policy,
-        std::optional<size_t> maxParallelConnections,
-        std::optional<size_t> maxSubscriptionSendQueueSize = std::nullopt
-    )
+    ConnectionHandlerTest(ProcessingPolicy policy, std::optional<size_t> maxParallelConnections)
         : tagFactory{util::config::ClioConfigDefinition{
               {"log.tag_style",
                config::ConfigValue{config::ConfigType::String}.defaultValue("uint")}
@@ -60,13 +56,11 @@ struct ConnectionHandlerTest : prometheus::WithPrometheus, SyncAsioContextTest {
               policy,
               maxParallelConnections,
               tagFactory,
-              maxSubscriptionSendQueueSize,
               proxyIpResolver,
               onDisconnectMock.AsStdFunction(),
               onIpChangeMock.AsStdFunction()
           }
     {
-        EXPECT_CALL(*mockWsConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     }
 
     template <typename BoostErrorType>
@@ -809,38 +803,6 @@ TEST_F(ConnectionHandlerSequentialProcessingTest, ProcessCalledAfterStop)
     });
 }
 
-struct ConnectionHandlerSendQueueLimitTest : ConnectionHandlerTest {
-    static constexpr size_t kMaxSendQueueSize = 42;
-
-    ConnectionHandlerSendQueueLimitTest()
-        : ConnectionHandlerTest(ProcessingPolicy::Sequential, std::nullopt, kMaxSendQueueSize)
-    {
-    }
-};
-
-TEST_F(ConnectionHandlerSendQueueLimitTest, ConfiguredLimitIsAppliedToUpgradedConnection)
-{
-    testing::StrictMock<testing::MockFunction<Response(
-        Request const&,
-        ConnectionMetadata const&,
-        web::SubscriptionContextPtr,
-        boost::asio::yield_context
-    )>>
-        wsHandlerMock;
-    connectionHandler.onWs(wsHandlerMock.AsStdFunction());
-
-    EXPECT_CALL(*mockWsConnection, wasUpgraded).WillOnce(Return(true));
-    EXPECT_CALL(
-        *mockWsConnection, setMaxSendingQueueSize(std::optional<size_t>{kMaxSendQueueSize})
-    );
-    EXPECT_CALL(*mockWsConnection, receive).WillOnce(Return(makeError(websocket::error::closed)));
-    EXPECT_CALL(onDisconnectMock, Call);
-
-    runSpawn([this](boost::asio::yield_context yield) {
-        connectionHandler.processConnection(std::move(mockWsConnection), yield);
-    });
-}
-
 struct ConnectionHandlerParallelProcessingTest : ConnectionHandlerTest {
     static constexpr size_t kMaxParallelRequests = 3;
 
@@ -939,7 +901,6 @@ TEST_F(ConnectionHandlerParallelProcessingTest, OnIpChangeHookCalledWhenSentFrom
     std::string const responseMessage = "some response";
 
     EXPECT_CALL(*mockWsConnectionFromProxy, wasUpgraded).WillOnce(Return(true));
-    EXPECT_CALL(*mockWsConnectionFromProxy, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockWsConnectionFromProxy, receive)
         .WillOnce(Return(makeRequest(requestMessage, headers)))
         .WillOnce(Return(makeError(websocket::error::closed)));
@@ -984,7 +945,6 @@ TEST_F(ConnectionHandlerParallelProcessingTest, ProxyConnection_SameClientReuses
     headers.set(http::field::forwarded, fmt::format("for={}", clientIp));
 
     EXPECT_CALL(*mockProxyConnection, wasUpgraded).WillOnce(Return(true));
-    EXPECT_CALL(*mockProxyConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockProxyConnection, receive)
         .WillOnce(Return(makeRequest("msg", headers)))
         .WillOnce(Return(makeRequest("msg", headers)))
@@ -1028,7 +988,6 @@ TEST_F(
     headers2.set(http::field::forwarded, fmt::format("for={}", anotherClientIp));
 
     EXPECT_CALL(*mockProxyConnection, wasUpgraded).WillOnce(Return(true));
-    EXPECT_CALL(*mockProxyConnection, setMaxSendingQueueSize).Times(testing::AnyNumber());
     EXPECT_CALL(*mockProxyConnection, receive)
         .WillOnce(Return(makeRequest("msg", headers1)))
         .WillOnce(Return(makeRequest("msg", headers2)))

--- a/tests/unit/web/ng/impl/HttpConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/HttpConnectionTests.cpp
@@ -29,6 +29,10 @@
 #include <string>
 #include <utility>
 
+namespace {
+constexpr size_t kMaxSendingQueueSize = 1500;
+}  // namespace
+
 using namespace web::ng::impl;
 using namespace web::ng;
 using namespace util::config;
@@ -45,7 +49,8 @@ struct HttpConnectionTests : SyncAsioContextTest {
             std::move(expectedSocket).value(),
             std::move(ip),
             boost::beast::flat_buffer{},
-            tagDecoratorFactory_
+            tagDecoratorFactory_,
+            kMaxSendingQueueSize
         );
         connection->setTimeout(std::chrono::milliseconds{100});
         return connection;
@@ -388,7 +393,8 @@ TEST_F(HttpConnectionTests, Upgrade)
         [&]() { ASSERT_TRUE(expectedResult.has_value()) << expectedResult.error().message(); }();
         [&]() { ASSERT_TRUE(expectedResult.value()); }();
 
-        auto expectedWsConnection = connection->upgrade(tagDecoratorFactory_, yield);
+        auto expectedWsConnection =
+            connection->upgrade(tagDecoratorFactory_, kMaxSendingQueueSize, yield);
         [&]() {
             ASSERT_TRUE(expectedWsConnection.has_value()) << expectedWsConnection.error().message();
         }();

--- a/tests/unit/web/ng/impl/SendingQueueTests.cpp
+++ b/tests/unit/web/ng/impl/SendingQueueTests.cpp
@@ -5,8 +5,10 @@
 #include <boost/asio/error.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/spawn.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -116,6 +118,35 @@ TEST_F(SendingQueueTests, StaysFailedAfterRejection)
 
         auto const result = queue.send("after", yield);
         ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), boost::asio::error::timed_out);
+    });
+}
+
+// Regression: the overflow state must survive the completion of a write that was already in
+// flight. Real senders complete with void(error_code), so asio writes success into whatever error
+// slot the drain loop bound for that write - which must not be the slot holding the overflow.
+TEST_F(SendingQueueTests, OverflowSurvivesSuccessfulInFlightWrite)
+{
+    boost::asio::steady_timer timer{ctx_};
+    SendingQueue<std::string> queue{
+        [&timer](std::string const&, auto&& yield) {
+            timer.expires_after(std::chrono::milliseconds{1});
+            timer.async_wait(yield);  // void(error_code), and it succeeds
+        },
+        1
+    };
+
+    runSpawn([&queue](boost::asio::yield_context yield) {
+        util::CoroutineGroup group{yield};
+        for (size_t i = 0; i < 4; ++i) {
+            group.spawn(yield, [&queue](boost::asio::yield_context innerYield) {
+                queue.send("message", innerYield);
+            });
+        }
+        group.asyncWait(yield);
+
+        auto const result = queue.send("after", yield);
+        ASSERT_FALSE(result.has_value()) << "queue must stay failed once it has overflowed";
         EXPECT_EQ(result.error(), boost::asio::error::timed_out);
     });
 }

--- a/tests/unit/web/ng/impl/SendingQueueTests.cpp
+++ b/tests/unit/web/ng/impl/SendingQueueTests.cpp
@@ -1,0 +1,135 @@
+#include "util/AsioContextTestFixture.hpp"
+#include "util/CoroutineGroup.hpp"
+#include "web/ng/impl/SendingQueue.hpp"
+
+#include <boost/asio/error.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/spawn.hpp>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+using namespace web::ng::impl;
+
+struct SendingQueueTests : SyncAsioContextTest {};
+
+TEST_F(SendingQueueTests, SendsInOrder)
+{
+    std::vector<std::string> sent;
+    SendingQueue<std::string> queue{[&sent](std::string const& message, auto&&) {
+        sent.push_back(message);
+    }};
+
+    runSpawn([&queue](boost::asio::yield_context yield) {
+        EXPECT_TRUE(queue.send("one", yield).has_value());
+        EXPECT_TRUE(queue.send("two", yield).has_value());
+    });
+
+    EXPECT_EQ(sent, (std::vector<std::string>{"one", "two"}));
+}
+
+// While one coroutine is draining the queue, other senders only push and return. Without a limit on
+// queue_ itself nothing bounds how many of them may pile up.
+TEST_F(SendingQueueTests, UnboundedByDefault)
+{
+    constexpr size_t kSendersWhileBlocked = 100;
+    size_t sentCount = 0;
+
+    SendingQueue<std::string> queue{[&sentCount](std::string const&, auto&& yield) {
+        boost::asio::post(yield);  // the peer is slow: suspend inside the drain loop
+        ++sentCount;
+    }};
+
+    runSpawn([&queue](boost::asio::yield_context yield) {
+        util::CoroutineGroup group{yield};
+        for (size_t i = 0; i <= kSendersWhileBlocked; ++i) {
+            group.spawn(yield, [&queue](boost::asio::yield_context innerYield) {
+                EXPECT_TRUE(queue.send("message", innerYield).has_value());
+            });
+        }
+        group.asyncWait(yield);
+    });
+
+    EXPECT_EQ(sentCount, kSendersWhileBlocked + 1);
+}
+
+// The regression test: with a limit set, the sender that would push past it is rejected with
+// timed_out instead of growing the queue. Before the fix SendingQueue had no limit at all and every
+// one of these senders succeeded.
+TEST_F(SendingQueueTests, RejectsWhenFull)
+{
+    constexpr size_t kMaxSize = 4;
+    size_t sentCount = 0;
+    size_t rejectedCount = 0;
+
+    SendingQueue<std::string> queue{
+        [&sentCount](std::string const&, auto&& yield) {
+            boost::asio::post(yield);  // the peer is slow: suspend inside the drain loop
+            ++sentCount;
+        },
+        kMaxSize
+    };
+
+    runSpawn([&queue, &rejectedCount](boost::asio::yield_context yield) {
+        util::CoroutineGroup group{yield};
+        for (size_t i = 0; i < kMaxSize * 4; ++i) {
+            group.spawn(yield, [&queue, &rejectedCount](boost::asio::yield_context innerYield) {
+                auto const result = queue.send("message", innerYield);
+                if (not result.has_value()) {
+                    EXPECT_EQ(result.error(), boost::asio::error::timed_out);
+                    ++rejectedCount;
+                }
+            });
+        }
+        group.asyncWait(yield);
+    });
+
+    EXPECT_GT(rejectedCount, 0u) << "the limit must reject senders once the queue is full";
+    EXPECT_LE(sentCount, kMaxSize + 1) << "no more than the limit may ever be pending";
+}
+
+// Once the limit has been hit the connection is doomed, so every later send fails too rather than
+// silently resuming.
+TEST_F(SendingQueueTests, StaysFailedAfterRejection)
+{
+    SendingQueue<std::string> queue{
+        [](std::string const&, auto&& yield) { boost::asio::post(yield); }, 1
+    };
+
+    runSpawn([&queue](boost::asio::yield_context yield) {
+        util::CoroutineGroup group{yield};
+        for (size_t i = 0; i < 4; ++i) {
+            group.spawn(yield, [&queue](boost::asio::yield_context innerYield) {
+                queue.send("message", innerYield);
+            });
+        }
+        group.asyncWait(yield);
+
+        auto const result = queue.send("after", yield);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), boost::asio::error::timed_out);
+    });
+}
+
+TEST_F(SendingQueueTests, SetMaxSizeAppliesLater)
+{
+    SendingQueue<std::string> queue{[](std::string const&, auto&& yield) {
+        boost::asio::post(yield);
+    }};
+    queue.setMaxSize(1);
+
+    runSpawn([&queue](boost::asio::yield_context yield) {
+        util::CoroutineGroup group{yield};
+        bool rejected = false;
+        for (size_t i = 0; i < 4; ++i) {
+            group.spawn(yield, [&queue, &rejected](boost::asio::yield_context innerYield) {
+                if (not queue.send("message", innerYield).has_value())
+                    rejected = true;
+            });
+        }
+        group.asyncWait(yield);
+        EXPECT_TRUE(rejected);
+    });
+}

--- a/tests/unit/web/ng/impl/SendingQueueTests.cpp
+++ b/tests/unit/web/ng/impl/SendingQueueTests.cpp
@@ -11,6 +11,10 @@
 #include <string>
 #include <vector>
 
+namespace {
+constexpr size_t kLargeLimit = 10000;
+}  // namespace
+
 using namespace web::ng::impl;
 
 struct SendingQueueTests : SyncAsioContextTest {};
@@ -18,9 +22,9 @@ struct SendingQueueTests : SyncAsioContextTest {};
 TEST_F(SendingQueueTests, SendsInOrder)
 {
     std::vector<std::string> sent;
-    SendingQueue<std::string> queue{[&sent](std::string const& message, auto&&) {
-        sent.push_back(message);
-    }};
+    SendingQueue<std::string> queue{
+        [&sent](std::string const& message, auto&&) { sent.push_back(message); }, kLargeLimit
+    };
 
     runSpawn([&queue](boost::asio::yield_context yield) {
         EXPECT_TRUE(queue.send("one", yield).has_value());
@@ -30,17 +34,20 @@ TEST_F(SendingQueueTests, SendsInOrder)
     EXPECT_EQ(sent, (std::vector<std::string>{"one", "two"}));
 }
 
-// While one coroutine is draining the queue, other senders only push and return. Without a limit on
-// queue_ itself nothing bounds how many of them may pile up.
-TEST_F(SendingQueueTests, UnboundedByDefault)
+// While one coroutine drains the queue, every other sender only pushes and returns - so the number
+// of live coroutines says nothing about how many messages are pending.
+TEST_F(SendingQueueTests, NonDrainingSendersOnlyPushAndReturn)
 {
     constexpr size_t kSendersWhileBlocked = 100;
     size_t sentCount = 0;
 
-    SendingQueue<std::string> queue{[&sentCount](std::string const&, auto&& yield) {
-        boost::asio::post(yield);  // the peer is slow: suspend inside the drain loop
-        ++sentCount;
-    }};
+    SendingQueue<std::string> queue{
+        [&sentCount](std::string const&, auto&& yield) {
+            boost::asio::post(yield);  // the peer is slow: suspend inside the drain loop
+            ++sentCount;
+        },
+        kLargeLimit
+    };
 
     runSpawn([&queue](boost::asio::yield_context yield) {
         util::CoroutineGroup group{yield};
@@ -110,26 +117,5 @@ TEST_F(SendingQueueTests, StaysFailedAfterRejection)
         auto const result = queue.send("after", yield);
         ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), boost::asio::error::timed_out);
-    });
-}
-
-TEST_F(SendingQueueTests, SetMaxSizeAppliesLater)
-{
-    SendingQueue<std::string> queue{[](std::string const&, auto&& yield) {
-        boost::asio::post(yield);
-    }};
-    queue.setMaxSize(1);
-
-    runSpawn([&queue](boost::asio::yield_context yield) {
-        util::CoroutineGroup group{yield};
-        bool rejected = false;
-        for (size_t i = 0; i < 4; ++i) {
-            group.spawn(yield, [&queue, &rejected](boost::asio::yield_context innerYield) {
-                if (not queue.send("message", innerYield).has_value())
-                    rejected = true;
-            });
-        }
-        group.asyncWait(yield);
-        EXPECT_TRUE(rejected);
     });
 }

--- a/tests/unit/web/ng/impl/WsConnectionTests.cpp
+++ b/tests/unit/web/ng/impl/WsConnectionTests.cpp
@@ -33,6 +33,10 @@
 #include <thread>
 #include <utility>
 
+namespace {
+constexpr size_t kMaxSendingQueueSize = 1500;
+}  // namespace
+
 using namespace web::ng::impl;
 using namespace web::ng;
 using namespace util;
@@ -50,6 +54,7 @@ struct WebWsConnectionTests : SyncAsioContextTest {
             std::move(ip),
             boost::beast::flat_buffer{},
             tagDecoratorFactory_,
+            kMaxSendingQueueSize,
         };
 
         auto expectedTrue = httpConnection.isUpgradeRequested(yield);
@@ -58,7 +63,8 @@ struct WebWsConnectionTests : SyncAsioContextTest {
             ASSERT_TRUE(expectedTrue.value()) << "Expected upgrade request";
         }();
 
-        auto expectedWsConnection = httpConnection.upgrade(tagDecoratorFactory_, yield);
+        auto expectedWsConnection =
+            httpConnection.upgrade(tagDecoratorFactory_, kMaxSendingQueueSize, yield);
         [&]() {
             ASSERT_TRUE(expectedWsConnection.has_value()) << expectedWsConnection.error().message();
         }();


### PR DESCRIPTION
`ws_max_sending_queue_size` was not being applied correctly on the ng web server path.
The check counted in-flight coroutines rather than queued messages, which does
not track queue depth because non-draining senders return immediately.

Moves the limit into `SendingQueue`, which owns the queue and can enforce it
directly, and wires the configured value through on connection upgrade. Matches
the existing `WsBase` behaviour of failing the connection with `timed_out`.

Adds unit tests for the queue bound and for the config value reaching the
connection.