### PR TITLE
fix: Better validator for issuer

### DIFF
--- a/src/rpc/common/Validators.cpp
+++ b/src/rpc/common/Validators.cpp
@@ -363,7 +363,7 @@ CustomValidator CustomValidators::authorizeCredentialValidator =
             }
 
             // don't want to change issuer error message to be about credentials
-            if (!issuerValidator.verify(credObj, "issuer")) {
+            if (!accountBase58Validator.verify(credObj, "issuer")) {
                 return Error{
                     Status{ClioError::RpcMalformedAuthorizedCredentials, "issuer NotString"}
                 };

--- a/tests/unit/rpc/handlers/LedgerEntryTests.cpp
+++ b/tests/unit/rpc/handlers/LedgerEntryTests.cpp
@@ -348,6 +348,27 @@ generateTestValuesForParametersTest()
         },
 
         ParamTestCaseBundle{
+            .testName = "DepositPreauthAuthorizeCredentialsHexIssuer",
+            .testJson = fmt::format(
+                R"JSON({{
+                    "deposit_preauth": {{
+                        "owner": "{}",
+                        "authorized_credentials": [
+                        {{
+                            "issuer": "0000000000000000000000000000000000000002",
+                            "credential_type": "{}"
+                        }}
+                        ]
+                    }}
+                }})JSON",
+                kAccount,
+                kCredentialType
+            ),
+            .expectedError = "malformedAuthorizedCredentials",
+            .expectedErrorMessage = "issuer NotString"
+        },
+
+        ParamTestCaseBundle{
             .testName = "DepositPreauthAuthorizeCredentialsIncorrectCredentialType",
             .testJson = fmt::format(
                 R"JSON({{


### PR DESCRIPTION
The validation for `issuer` was using the incorrect validator, `accountBase58Validator` is the better option.