### PR TITLE
fix: Fiber suspension during exception

### DIFF
--- a/src/data/BackendInterface.hpp
+++ b/src/data/BackendInterface.hpp
@@ -103,16 +103,21 @@ retryOnTimeout(
     auto retry = util::makeRetryExponentialBackoff(delays, yield.get_executor());
 
     while (true) {
+        // Suspending a coroutine from inside a catch block is not safe so we copy out the failure.
+        std::string failure;
+
         try {
             return func();
         } catch (DatabaseError const& e) {
-            auto const delayMs =
-                std::chrono::duration_cast<std::chrono::milliseconds>(retry.delayValue()).count();
-            LOG(log.error()) << e.what() << " (attempt " << retry.attemptNumber() + 1
-                             << "). Retrying in " << delayMs << "ms ...";
-
-            retry.wait(yield);
+            failure = e.what();
         }
+
+        auto const delayMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(retry.delayValue()).count();
+        LOG(log.error()) << failure << " (attempt " << retry.attemptNumber() + 1
+                         << "). Retrying in " << delayMs << "ms ...";
+
+        retry.wait(yield);
     }
 }
 

--- a/src/util/Retry.cpp
+++ b/src/util/Retry.cpp
@@ -1,5 +1,7 @@
 #include "util/Retry.hpp"
 
+#include "util/Assert.hpp"
+
 #include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
@@ -8,6 +10,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <exception>
 #include <memory>
 #include <utility>
 
@@ -95,6 +98,14 @@ ExponentialBackoffStrategy::nextDelay() const
 void
 Retry::wait(boost::asio::yield_context yield)
 {
+    // Suspending a coroutine while an exception is being handled corrupts the caught-exception
+    // state, which is per-thread rather than per-coroutine. Copy whatever is needed out of the
+    // handler and let it exit before waiting.
+    ASSERT(
+        std::current_exception() == nullptr,
+        "Retry::wait must not be called while an exception is being handled"
+    );
+
     *canceled_ = false;
     timer_.expires_after(strategy_->getDelay());
     strategy_->increaseDelay();

--- a/tests/unit/data/BackendInterfaceTests.cpp
+++ b/tests/unit/data/BackendInterfaceTests.cpp
@@ -293,6 +293,7 @@ TEST_F(BackendInterfaceRetryCoroTest, RetryOnTimeoutCoroDoesNotWaitInsideCatchHa
 
     ASSERT_TRUE(exceptionInFlightDuringWait.has_value())
         << "the posted handler was expected to run while the retry was waiting";
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_FALSE(*exceptionInFlightDuringWait)
         << "retry.wait() must not be reached from inside a catch handler";
 }

--- a/tests/unit/data/BackendInterfaceTests.cpp
+++ b/tests/unit/data/BackendInterfaceTests.cpp
@@ -264,6 +264,39 @@ TEST_F(BackendInterfaceRetryCoroTest, RetryOnTimeoutCoroDoesNotSwallowOtherExcep
     });
 }
 
+// An exception left in flight across a suspension point is visible to whatever else runs on that
+// thread meanwhile, and is corrupted when the handlers unwind out of order or on a different thread
+// of the pool. We prevent this.
+TEST_F(BackendInterfaceRetryCoroTest, RetryOnTimeoutCoroDoesNotWaitInsideCatchHandler)
+{
+    std::optional<bool> exceptionInFlightDuringWait;
+
+    runSpawn([&exceptionInFlightDuringWait, this](auto yield) {
+        // Runs on this thread while the retry below is suspended on its timer.
+        boost::asio::post(ctx_, [&exceptionInFlightDuringWait]() {
+            exceptionInFlightDuringWait = std::current_exception() != nullptr;
+        });
+
+        std::size_t calls = 0;
+        retryOnTimeout(
+            [&calls]() -> int {
+                if (++calls < 2)
+                    throw DatabaseError{};
+                return 0;
+            },
+            yield,
+            util::Retry::Delays{
+                .initial = std::chrono::milliseconds{1}, .max = std::chrono::milliseconds{1}
+            }
+        );
+    });
+
+    ASSERT_TRUE(exceptionInFlightDuringWait.has_value())
+        << "the posted handler was expected to run while the retry was waiting";
+    EXPECT_FALSE(*exceptionInFlightDuringWait)
+        << "retry.wait() must not be reached from inside a catch handler";
+}
+
 TEST_F(BackendInterfaceRetryCoroTest, RetryOnTimeoutCoroDoesNotBlockItsThread)
 {
     bool ran = false;
@@ -280,7 +313,7 @@ TEST_F(BackendInterfaceRetryCoroTest, RetryOnTimeoutCoroDoesNotBlockItsThread)
             },
             yield,
             util::Retry::Delays{
-                .initial = std::chrono::milliseconds{20}, .max = std::chrono::milliseconds{20}
+                .initial = std::chrono::milliseconds{1}, .max = std::chrono::milliseconds{1}
             }
         );
 


### PR DESCRIPTION
This PR fixes a segfault that can be caused by Retry logic when used via coroutines during cache load. 
The regression was introduced in #3167.