### PR TITLE
fix: Rare race in cluster tests

### DIFF
--- a/tests/unit/cluster/BackendTests.cpp
+++ b/tests/unit/cluster/BackendTests.cpp
@@ -40,13 +40,13 @@ struct ClusterBackendTest : util::prometheus::WithPrometheus, MockBackendTestStr
     testing::StrictMock<
         testing::MockFunction<void(ClioNode::CUuid, std::shared_ptr<Backend::ClusterData const>)>>
         callbackMock;
-    std::binary_semaphore semaphore{0};
+    std::counting_semaphore<> semaphore{0};
 
     class SemaphoreReleaseGuard {
-        std::binary_semaphore& semaphore_;
+        std::counting_semaphore<>& semaphore_;
 
     public:
-        SemaphoreReleaseGuard(std::binary_semaphore& s) : semaphore_(s)
+        SemaphoreReleaseGuard(std::counting_semaphore<>& s) : semaphore_(s)
         {
         }
         ~SemaphoreReleaseGuard()
@@ -72,7 +72,7 @@ TEST_F(ClusterBackendTest, SubscribeToNewState)
     EXPECT_CALL(*backend_, fetchClioNodesData)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(BackendInterface::ClioNodesDataFetchResult{}));
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));
@@ -151,7 +151,7 @@ TEST_F(ClusterBackendTest, FetchClioNodesDataThrowsException)
     EXPECT_CALL(*backend_, fetchClioNodesData)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Throw(std::runtime_error("Database connection failed")));
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));
@@ -208,7 +208,7 @@ TEST_F(ClusterBackendTest, FetchClioNodesDataReturnsDataWithOtherNodes)
                 }
             )
         );
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(false));
@@ -286,7 +286,7 @@ TEST_F(ClusterBackendTest, FetchClioNodesDataReturnsOnlySelfData)
             }
         };
     });
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));
@@ -342,7 +342,7 @@ TEST_F(ClusterBackendTest, FetchClioNodesDataReturnsInvalidJson)
                 }
             )
         );
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));
@@ -398,7 +398,7 @@ TEST_F(ClusterBackendTest, FetchClioNodesDataReturnsValidJsonButCannotConvertToC
                 }
             )
         );
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));
@@ -536,7 +536,7 @@ TEST_F(ClusterBackendTest, SubscribeToNewStateReflectsCacheIsCurrentlyLoading)
     EXPECT_CALL(*backend_, fetchClioNodesData)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(BackendInterface::ClioNodesDataFetchResult{}));
-    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AtLeast(1));
+    EXPECT_CALL(*backend_, writeNodeMessage).Times(testing::AnyNumber());
     EXPECT_CALL(writerStateRef, isReadOnly)
         .Times(testing::AtLeast(1))
         .WillRepeatedly(testing::Return(true));


### PR DESCRIPTION
While working on #3174 we had a failure in https://github.com/XRPLF/clio/actions/runs/33074493704/job/98527800974?pr=3174 which appears to be an actual race. This PR fixes the small and rare race that the run exposed.

`Backend::run()` starts two independent `RepeatedTask`s on separate strands: a reader
(`doRead` → `onNewState_`) and a writer (`doWrite` → `writeNodeMessage`). Seven tests
asserted `EXPECT_CALL(writeNodeMessage).Times(AtLeast(1))` but only ever waited on the
read path (`semaphore.acquire()` is released from the state callback). When the test body
returns, `~Backend` → `stop()` sets `state_ = Stopped`, and `RepeatedTask`'s loop checks
`state_` *after* the timer wait — so a writer whose first tick hasn't landed yet breaks
out without ever calling `doWrite()`. CI hit exactly that: `writeNodeMessage`
"never called - unsatisfied and active".

Both intervals are 1 ms, so the writer almost always wins the race — hence the rarity.

- Relaxed those seven expectations to `Times(AnyNumber())`. None of them inspects the
  written message; the expectation only existed because the fixture is a `StrictMock`.
  The write path stays properly covered by the two `WriteNodeMessage*` tests, which
  release the semaphore from inside the write action and so actually wait for it.
  `Stop` keeps `AtLeast(1)` (it sleeps 20 ms and asserting both tasks ran is its point).
- `std::binary_semaphore` → `std::counting_semaphore<>` in the fixture: both callbacks
  are `WillRepeatedly` on a 1 ms timer, so a second `release()` before the main thread's
  `acquire()` was UB.