### PR TITLE
fix: Internal error in `account_info` with pseudo account

### DIFF
--- a/src/rpc/handlers/AccountInfo.cpp
+++ b/src/rpc/handlers/AccountInfo.cpp
@@ -182,7 +182,7 @@ tag_invoke(
                 ASSERT(!name.empty(), "Field name is empty after stripping 'ID'");
             }
             // ValidPseudoAccounts invariant guarantees that only one field can be set
-            jv.as_object()[JS(pseudo_account)].as_object()[JS(type)] = name;
+            jv.as_object()[JS(pseudo_account)] = boost::json::object{{JS(type), name}};
             break;
         }
     }

--- a/tests/unit/rpc/handlers/AccountInfoTests.cpp
+++ b/tests/unit/rpc/handlers/AccountInfoTests.cpp
@@ -437,6 +437,80 @@ TEST_F(RPCAccountInfoHandlerTest, SignerListsTrueV2)
     });
 }
 
+TEST_F(RPCAccountInfoHandlerTest, PseudoAccountReportsType)
+{
+    auto const expectedOutput = fmt::format(
+        R"JSON({{
+            "account_data": {{
+                "Account": "{}",
+                "AMMID": "{}",
+                "Balance": "200",
+                "Flags": 0,
+                "LedgerEntryType": "AccountRoot",
+                "OwnerCount": 2,
+                "PreviousTxnID": "{}",
+                "PreviousTxnLgrSeq": 2,
+                "Sequence": 2,
+                "TransferRate": 0,
+                "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+            }},
+            "account_flags": {{
+                "defaultRipple": false,
+                "depositAuth": false,
+                "disableMasterKey": false,
+                "disallowIncomingXRP": false,
+                "globalFreeze": false,
+                "noFreeze": false,
+                "passwordSpent": false,
+                "requireAuthorization": false,
+                "requireDestinationTag": false
+            }},
+            "pseudo_account": {{
+                "type": "AMM"
+            }},
+            "ledger_hash": "{}",
+            "ledger_index": 30,
+            "validated": true
+        }})JSON",
+        kAccount,
+        kIndex1,
+        kIndex1,
+        kLedgerHash
+    );
+
+    auto const ledgerHeader = createLedgerHeader(kLedgerHash, 30);
+    EXPECT_CALL(*backend_, fetchLedgerBySequence).WillOnce(Return(ledgerHeader));
+
+    auto const account = getAccountIdWithString(kAccount);
+    auto const accountKk = xrpl::keylet::account(account).key;
+    auto const accountRoot =
+        createAccountRootObject(kAccount, 0, 2, 200, 2, kIndex1, 2, 0, xrpl::uint256{kIndex1});
+    ON_CALL(*backend_, doFetchLedgerObject(accountKk, 30, _))
+        .WillByDefault(Return(accountRoot.getSerializer().peekData()));
+    EXPECT_CALL(*mockAmendmentCenterPtr_, isEnabled(_, Amendments::DisallowIncoming, _))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*mockAmendmentCenterPtr_, isEnabled(_, Amendments::Clawback, _))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*mockAmendmentCenterPtr_, isEnabled(_, Amendments::TokenEscrow, _))
+        .WillOnce(Return(false));
+    EXPECT_CALL(*backend_, doFetchLedgerObject).Times(1);
+
+    static auto const kInput = boost::json::parse(
+        fmt::format(
+            R"JSON({{
+                "account": "{}"
+            }})JSON",
+            kAccount
+        )
+    );
+    auto const handler = AnyHandler{AccountInfoHandler{backend_, mockAmendmentCenterPtr_}};
+    runSpawn([&](auto yield) {
+        auto const output = handler.process(kInput, Context{.yield = yield, .apiVersion = 2});
+        ASSERT_TRUE(output);
+        EXPECT_EQ(*output.result, boost::json::parse(expectedOutput));
+    });
+}
+
 TEST_F(RPCAccountInfoHandlerTest, SignerListsTrueV1)
 {
     auto const expectedOutput = fmt::format(


### PR DESCRIPTION
This recent addition was throwing at `as_object()` because `jv` did not contain a `pseudo_account` object. This PR fixes the issue and adds a regression test for it.